### PR TITLE
Stop auto-switching sidebar tab on feature select

### DIFF
--- a/src/modules/globeview/maplibreScenarioFeatures.test.ts
+++ b/src/modules/globeview/maplibreScenarioFeatures.test.ts
@@ -177,8 +177,12 @@ describe("buildScenarioFeatureRenderPlan", () => {
       },
     );
 
-    const startArrow = plan.arrowData.features.find((feature) => feature.id === "line-2-arrow-start");
-    const endArrow = plan.arrowData.features.find((feature) => feature.id === "line-2-arrow-end");
+    const startArrow = plan.arrowData.features.find(
+      (feature) => feature.id === "line-2-arrow-start",
+    );
+    const endArrow = plan.arrowData.features.find(
+      (feature) => feature.id === "line-2-arrow-end",
+    );
 
     expect(startArrow?.properties?.rotation).toBeCloseTo(-180, 5);
     expect(endArrow?.properties?.rotation).toBeCloseTo(-90, 5);

--- a/src/modules/globeview/maplibreScenarioFeatures.ts
+++ b/src/modules/globeview/maplibreScenarioFeatures.ts
@@ -253,9 +253,7 @@ function getLabelGeometry(geometry: Geometry): Point | undefined {
   }
 }
 
-function getLineArrowAnchors(
-  geometry: Geometry,
-):
+function getLineArrowAnchors(geometry: Geometry):
   | {
       start: Position;
       startAdjacent: Position;

--- a/src/modules/scenarioeditor/useScenarioFeatureSelection.ts
+++ b/src/modules/scenarioeditor/useScenarioFeatureSelection.ts
@@ -1,8 +1,6 @@
 import { nextTick } from "vue";
-import { TAB_LAYERS } from "@/types/constants";
 import { injectStrict } from "@/utils";
 import { activeScenarioKey, activeScenarioMapEngineKey } from "@/components/injects";
-import { useUiStore } from "@/stores/uiStore";
 import { useSelectedItems } from "@/stores/selectedStore";
 import type { FeatureId } from "@/types/scenarioGeoModels";
 
@@ -16,7 +14,6 @@ interface ApplyScenarioFeatureSelectionOptions {
 export function useScenarioFeatureSelection() {
   const engineRef = injectStrict(activeScenarioMapEngineKey);
   const activeScenario = injectStrict(activeScenarioKey);
-  const ui = useUiStore();
   const { selectedUnitIds, selectedFeatureIds } = useSelectedItems();
 
   function applyScenarioFeatureSelection({
@@ -27,10 +24,6 @@ export function useScenarioFeatureSelection() {
   }: ApplyScenarioFeatureSelectionOptions) {
     const resolvedPrimaryFeatureId =
       primaryFeatureId !== undefined ? primaryFeatureId : featureIds[0];
-
-    if (resolvedPrimaryFeatureId) {
-      ui.activeTabIndex = TAB_LAYERS;
-    }
 
     const resolvedLayerId =
       layerId ??


### PR DESCRIPTION
## Summary
- Selecting a scenario feature on the map no longer forces the sidebar to the Layers tab, matching the existing unit-click behavior.
- Applies to both OpenLayers and globe (MapLibre) renderers since both feature-select paths funnel through `applyScenarioFeatureSelection`.