### PR TITLE
Refactor arrow tips onto a shared attach point

### DIFF
--- a/src/components/DrawArrow.vue
+++ b/src/components/DrawArrow.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, watchEffect } from "vue";
-import { getArrowSvgDataUri } from "@/geo/arrowStyles";
+import { getArrowSvgDataUri } from "@/geo/arrowSymbols";
 import type { ArrowType } from "@/geo/simplestyle";
 
 interface Props {

--- a/src/components/DrawArrow.vue
+++ b/src/components/DrawArrow.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
 import { ref, watchEffect } from "vue";
-import Point from "ol/geom/Point";
-import { toContext } from "ol/render";
-import Style from "ol/style/Style";
-import { createArrowMarkerImage, getArrowSvgDataUri } from "@/geo/arrowStyles";
+import { getArrowSvgDataUri } from "@/geo/arrowStyles";
 import type { ArrowType } from "@/geo/simplestyle";
 
 interface Props {
@@ -52,36 +49,19 @@ function drawSymbol(el: HTMLCanvasElement, color: string) {
   el.style.width = `${props.size}px`;
   el.style.height = `${props.size}px`;
 
-  // Check if this arrow type uses SVG (returns a data URI)
   const svgDataUri = getArrowSvgDataUri(props.arrowType, color);
+  if (!svgDataUri) return;
 
-  if (svgDataUri) {
-    // For SVG-based arrows, use direct Image API (simpler and more reliable)
-    const img = new Image();
-    img.onload = () => {
-      ctx.clearRect(0, 0, el.width, el.height);
-      // Apply rotation around center
-      ctx.save();
-      ctx.translate(el.width / 2, el.height / 2);
-      ctx.rotate(-props.rotation);
-      ctx.drawImage(img, -el.width / 2, -el.height / 2, el.width, el.height);
-      ctx.restore();
-    };
-    img.src = svgDataUri;
-  } else if (props.arrowType !== "none") {
-    // For shape-based arrows (RegularShape, CircleStyle), use OpenLayers
-    const image = createArrowMarkerImage(props.arrowType, color, props.rotation, 1);
-    if (image) {
-      const style = new Style({ image });
-      const vectorContext = toContext(ctx, {
-        size: [props.size, props.size],
-        pixelRatio: ratio,
-      });
-      ctx.clearRect(0, 0, el.width, el.height);
-      vectorContext.setStyle(style);
-      vectorContext.drawGeometry(new Point([props.size / 2, props.size / 2]));
-    }
-  }
+  const img = new Image();
+  img.onload = () => {
+    ctx.clearRect(0, 0, el.width, el.height);
+    ctx.save();
+    ctx.translate(el.width / 2, el.height / 2);
+    ctx.rotate(-props.rotation);
+    ctx.drawImage(img, -el.width / 2, -el.height / 2, el.width, el.height);
+    ctx.restore();
+  };
+  img.src = svgDataUri;
 }
 </script>
 

--- a/src/geo/arrowStyles.test.ts
+++ b/src/geo/arrowStyles.test.ts
@@ -1,10 +1,6 @@
 import { describe, it, expect } from "vitest";
-import {
-  getLineAngle,
-  createArrowMarkerImage,
-  createArrowStyles,
-  getArrowSvgDataUri,
-} from "./arrowStyles";
+import { getLineAngle, createArrowMarkerImage, createArrowStyles } from "./arrowStyles";
+import { getArrowSvgDataUri } from "./arrowSymbols";
 import LineString from "ol/geom/LineString";
 import Point from "ol/geom/Point";
 import Polygon from "ol/geom/Polygon";
@@ -12,8 +8,9 @@ import Style from "ol/style/Style";
 import Icon from "ol/style/Icon";
 
 function decodeDataUri(uri: string) {
-  const encoded = uri.split(",", 2)[1] ?? "";
-  return Buffer.from(encoded, "base64").toString("utf8");
+  const headerEnd = uri.indexOf(",");
+  const encoded = headerEnd >= 0 ? uri.slice(headerEnd + 1) : "";
+  return decodeURIComponent(encoded);
 }
 
 describe("getLineAngle", () => {
@@ -105,18 +102,18 @@ describe("createArrowMarkerImage", () => {
     expect(decodeDataUri(src!)).toContain("rgba(255,0,0,0.5)");
   });
 
-  it("extends directional arrow tips to the symbol edge", () => {
+  it("insets stroked arrow tips to keep round joins inside the viewBox", () => {
     const image = createArrowMarkerImage("arrow", "#000", 0) as Icon;
-    expect(decodeDataUri(image.getSrc()!)).toContain("L24 12");
+    expect(decodeDataUri(image.getSrc()!)).toContain("L23 12");
   });
 });
 
 describe("getArrowSvgDataUri", () => {
   it("returns a data URI for all supported arrow types", () => {
     expect(getArrowSvgDataUri("none", "#000")).toBeNull();
-    expect(getArrowSvgDataUri("arrow", "#000")).toMatch(/^data:image\/svg\+xml;base64,/);
+    expect(getArrowSvgDataUri("arrow", "#000")).toMatch(/^data:image\/svg\+xml;utf8,/);
     expect(getArrowSvgDataUri("arrow-hand-drawn", "#000")).toMatch(
-      /^data:image\/svg\+xml;base64,/,
+      /^data:image\/svg\+xml;utf8,/,
     );
   });
 });
@@ -226,7 +223,7 @@ describe("createArrowStyles", () => {
     const image2 = stylesWidth2[0].getImage() as Icon;
     const image4 = stylesWidth4[0].getImage() as Icon;
 
-    expect(image4.getScale()).toBeGreaterThan(image2.getScale());
+    expect(image4.getScale() as number).toBeGreaterThan(image2.getScale() as number);
   });
 
   it("returns empty for lines with too few coordinates", () => {

--- a/src/geo/arrowStyles.test.ts
+++ b/src/geo/arrowStyles.test.ts
@@ -104,6 +104,11 @@ describe("createArrowMarkerImage", () => {
     expect(src).toBeTruthy();
     expect(decodeDataUri(src!)).toContain("rgba(255,0,0,0.5)");
   });
+
+  it("extends directional arrow tips to the symbol edge", () => {
+    const image = createArrowMarkerImage("arrow", "#000", 0) as Icon;
+    expect(decodeDataUri(image.getSrc()!)).toContain("L24 12");
+  });
 });
 
 describe("getArrowSvgDataUri", () => {

--- a/src/geo/arrowStyles.test.ts
+++ b/src/geo/arrowStyles.test.ts
@@ -1,12 +1,20 @@
 import { describe, it, expect } from "vitest";
-import { getLineAngle, createArrowMarkerImage, createArrowStyles } from "./arrowStyles";
+import {
+  getLineAngle,
+  createArrowMarkerImage,
+  createArrowStyles,
+  getArrowSvgDataUri,
+} from "./arrowStyles";
 import LineString from "ol/geom/LineString";
 import Point from "ol/geom/Point";
 import Polygon from "ol/geom/Polygon";
 import Style from "ol/style/Style";
-import RegularShape from "ol/style/RegularShape";
-import CircleStyle from "ol/style/Circle";
 import Icon from "ol/style/Icon";
+
+function decodeDataUri(uri: string) {
+  const encoded = uri.split(",", 2)[1] ?? "";
+  return Buffer.from(encoded, "base64").toString("utf8");
+}
 
 describe("getLineAngle", () => {
   it("returns 0 for a horizontal line pointing right", () => {
@@ -67,65 +75,44 @@ describe("createArrowMarkerImage", () => {
     expect(createArrowMarkerImage("none", "#000", 0)).toBeNull();
   });
 
-  it("creates a RegularShape for 'arrow' type", () => {
-    const image = createArrowMarkerImage("arrow", "#ff0000", 0);
-    expect(image).toBeInstanceOf(RegularShape);
-  });
-
-  it("creates a RegularShape for 'arrow-open' type", () => {
-    const image = createArrowMarkerImage("arrow-open", "#ff0000", 0);
-    expect(image).toBeInstanceOf(RegularShape);
-  });
-
-  it("creates a CircleStyle for 'dot' type", () => {
-    const image = createArrowMarkerImage("dot", "#ff0000", 0);
-    expect(image).toBeInstanceOf(CircleStyle);
-  });
-
-  it("creates a RegularShape for 'square' type", () => {
-    const image = createArrowMarkerImage("square", "#ff0000", 0);
-    expect(image).toBeInstanceOf(RegularShape);
-  });
-
-  it("creates a RegularShape for 'diamond' type", () => {
-    const image = createArrowMarkerImage("diamond", "#ff0000", 0);
-    expect(image).toBeInstanceOf(RegularShape);
-  });
-
-  it("creates a RegularShape for 'bar' type", () => {
-    const image = createArrowMarkerImage("bar", "#ff0000", 0);
-    expect(image).toBeInstanceOf(RegularShape);
-  });
-
-  it("creates an Icon for 'arrow-curved' type", () => {
-    const image = createArrowMarkerImage("arrow-curved", "#ff0000", 0);
-    expect(image).toBeInstanceOf(Icon);
-  });
-
-  it("creates an Icon for 'arrow-stealth' type", () => {
-    const image = createArrowMarkerImage("arrow-stealth", "#ff0000", 0);
-    expect(image).toBeInstanceOf(Icon);
-  });
-
-  it("creates an Icon for 'arrow-double' type", () => {
-    const image = createArrowMarkerImage("arrow-double", "#ff0000", 0);
-    expect(image).toBeInstanceOf(Icon);
-  });
-
-  it("creates an Icon for 'arrow-hand-drawn' type", () => {
-    const image = createArrowMarkerImage("arrow-hand-drawn", "#ff0000", 0);
-    expect(image).toBeInstanceOf(Icon);
-  });
-
-  it("creates an Icon for 'arrow-double-hand-drawn' type", () => {
-    const image = createArrowMarkerImage("arrow-double-hand-drawn", "#ff0000", 0);
+  it.each([
+    "arrow",
+    "arrow-open",
+    "dot",
+    "square",
+    "diamond",
+    "bar",
+    "arrow-curved",
+    "arrow-stealth",
+    "arrow-double",
+    "arrow-hand-drawn",
+    "arrow-double-hand-drawn",
+  ] as const)("creates a shared Icon for '%s'", (arrowType) => {
+    const image = createArrowMarkerImage(arrowType, "#ff0000", 0);
     expect(image).toBeInstanceOf(Icon);
   });
 
   it("respects scale parameter", () => {
-    const scale1 = createArrowMarkerImage("arrow", "#000", 0, 1) as RegularShape;
-    const scale2 = createArrowMarkerImage("arrow", "#000", 0, 2) as RegularShape;
-    expect(scale2.getRadius()).toBe(scale1.getRadius() * 2);
+    const scale1 = createArrowMarkerImage("arrow", "#000", 0, 1) as Icon;
+    const scale2 = createArrowMarkerImage("arrow", "#000", 0, 2) as Icon;
+    expect(scale2.getScale()).toBe((scale1.getScale() as number) * 2);
+  });
+
+  it("encodes the requested color in the shared SVG", () => {
+    const image = createArrowMarkerImage("arrow", "rgba(255,0,0,0.5)", 0) as Icon;
+    const src = image.getSrc();
+    expect(src).toBeTruthy();
+    expect(decodeDataUri(src!)).toContain("rgba(255,0,0,0.5)");
+  });
+});
+
+describe("getArrowSvgDataUri", () => {
+  it("returns a data URI for all supported arrow types", () => {
+    expect(getArrowSvgDataUri("none", "#000")).toBeNull();
+    expect(getArrowSvgDataUri("arrow", "#000")).toMatch(/^data:image\/svg\+xml;base64,/);
+    expect(getArrowSvgDataUri("arrow-hand-drawn", "#000")).toMatch(
+      /^data:image\/svg\+xml;base64,/,
+    );
   });
 });
 
@@ -211,8 +198,8 @@ describe("createArrowStyles", () => {
       "stroke-opacity": strokeOpacity,
     });
     expect(styles).toHaveLength(1);
-    const image = styles[0].getImage() as RegularShape;
-    expect(image.getFill()?.getColor()).toBe("rgba(255,0,0,0.5)");
+    const image = styles[0].getImage() as Icon;
+    expect(decodeDataUri(image.getSrc()!)).toContain("rgba(255,0,0,0.5)");
   });
 
   it("scales arrow markers with strokeWidth", () => {
@@ -231,11 +218,10 @@ describe("createArrowStyles", () => {
       "stroke-width": 4,
     });
 
-    const image2 = stylesWidth2[0].getImage() as RegularShape;
-    const image4 = stylesWidth4[0].getImage() as RegularShape;
+    const image2 = stylesWidth2[0].getImage() as Icon;
+    const image4 = stylesWidth4[0].getImage() as Icon;
 
-    // Radius should be larger for larger strokeWidth
-    expect(image4.getRadius()).toBeGreaterThan(image2.getRadius());
+    expect(image4.getScale()).toBeGreaterThan(image2.getScale());
   });
 
   it("returns empty for lines with too few coordinates", () => {

--- a/src/geo/arrowStyles.ts
+++ b/src/geo/arrowStyles.ts
@@ -9,13 +9,13 @@ import type Geometry from "ol/geom/Geometry";
 import LineString from "ol/geom/LineString";
 import Point from "ol/geom/Point";
 import Style from "ol/style/Style";
-import RegularShape from "ol/style/RegularShape";
-import Fill from "ol/style/Fill";
-import Stroke from "ol/style/Stroke";
-import CircleStyle from "ol/style/Circle";
 import Icon from "ol/style/Icon";
 import * as olColor from "ol/color";
 import type { ArrowType, SimpleStyleSpec } from "./simplestyle";
+import {
+  getArrowSvgDataUri as getSharedArrowSvgDataUri,
+  getArrowSymbolDefinition,
+} from "./arrowSymbols";
 import {
   defaultStrokeColor,
   defaultStrokeOpacity,
@@ -46,58 +46,18 @@ export function getLineAngle(coordinates: number[][], position: "start" | "end")
 }
 
 /**
- * Get the SVG data URI for an arrow type, for use in direct canvas rendering.
- * Returns null for shape-based arrow types (which use RegularShape/CircleStyle).
+ * Get the SVG data URI for an arrow type.
  *
  * @param arrowType - The type of arrow marker
  * @param color - Fill/stroke color for the marker
- * @returns Base64-encoded SVG data URI, or null for non-SVG types
+ * @returns Base64-encoded SVG data URI, or null for "none"
  */
 export function getArrowSvgDataUri(arrowType: ArrowType, color: string): string | null {
-  switch (arrowType) {
-    case "arrow-curved": {
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="${color}" d="M2,12 Q6,12 10,4 L22,12 L10,20 Q6,12 2,12 Z" /></svg>`;
-      return "data:image/svg+xml;base64," + btoa(svg);
-    }
-    case "arrow-stealth": {
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="${color}" d="M2,2 L22,12 L2,22 L6,12 Z" /></svg>`;
-      return "data:image/svg+xml;base64," + btoa(svg);
-    }
-    case "arrow-double": {
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="${color}" d="M2,2 L12,12 L2,22 Z M10,2 L20,12 L10,22 Z" /></svg>`;
-      return "data:image/svg+xml;base64," + btoa(svg);
-    }
-    case "arrow-hand-drawn": {
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
-        <path stroke="${color}" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
-          d="M 12 10 C 18 16 34 22 44 24 C 34 26 18 32 12 38" />
-        <path stroke="${color}" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-          d="M 14 14 C 20 18 30 22 40 24 C 30 26 20 30 14 34" />
-      </svg>`;
-      return "data:image/svg+xml;base64," + btoa(svg);
-    }
-    case "arrow-double-hand-drawn": {
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
-        <!-- First arrow -->
-        <path stroke="${color}" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
-          d="M 4 10 C 10 16 26 22 36 24 C 26 26 10 32 4 38" />
-        <path stroke="${color}" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-          d="M 6 14 C 12 18 22 22 32 24 C 22 26 12 30 6 34" />
-        <!-- Second arrow -->
-        <path stroke="${color}" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
-          d="M 12 10 C 18 16 34 22 44 24 C 34 26 18 32 12 38" />
-        <path stroke="${color}" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-          d="M 14 14 C 20 18 30 22 40 24 C 30 26 20 30 14 34" />
-      </svg>`;
-      return "data:image/svg+xml;base64," + btoa(svg);
-    }
-    default:
-      return null;
-  }
+  return getSharedArrowSvgDataUri(arrowType, color);
 }
 
 /**
- * Create an arrow marker image (RegularShape or CircleStyle) for a specific arrow type.
+ * Create an arrow marker image for a specific arrow type.
  *
  * @param arrowType - The type of arrow marker to create
  * @param color - Fill/stroke color for the marker
@@ -110,136 +70,17 @@ export function createArrowMarkerImage(
   color: string,
   rotation: number,
   scale: number = 1,
-): RegularShape | CircleStyle | Icon | null {
-  if (arrowType === "none") return null;
-  const size = 10 * scale;
+): Icon | null {
+  const definition = getArrowSymbolDefinition(arrowType);
+  const src = getArrowSvgDataUri(arrowType, color);
+  if (!(definition && src)) return null;
 
-  // Helper functions to create fill/stroke on demand
-  const createFill = () => new Fill({ color });
-  const createStroke = () => new Stroke({ color, width: 2 });
-
-  switch (arrowType) {
-    case "arrow":
-      return new RegularShape({
-        fill: createFill(),
-        stroke: createStroke(),
-        points: 3,
-        radius: size,
-        rotation: -rotation + Math.PI / 2,
-        angle: 0,
-      });
-
-    case "arrow-open":
-      return new RegularShape({
-        stroke: createStroke(),
-        points: 3,
-        radius: size,
-        rotation: -rotation + Math.PI / 2,
-        angle: 0,
-      });
-
-    case "arrow-curved": {
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="${color}" d="M2,12 Q6,12 10,4 L22,12 L10,20 Q6,12 2,12 Z" /></svg>`;
-      return new Icon({
-        src: "data:image/svg+xml;base64," + btoa(svg),
-        rotation: -rotation,
-        scale: scale * 0.8,
-        anchor: [0.5, 0.5],
-      });
-    }
-
-    case "arrow-stealth": {
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="${color}" d="M2,2 L22,12 L2,22 L6,12 Z" /></svg>`;
-      return new Icon({
-        src: "data:image/svg+xml;base64," + btoa(svg),
-        rotation: -rotation,
-        scale: scale * 0.8,
-        anchor: [0.5, 0.5],
-      });
-    }
-
-    case "arrow-double": {
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="${color}" d="M2,2 L12,12 L2,22 Z M10,2 L20,12 L10,22 Z" /></svg>`;
-      return new Icon({
-        src: "data:image/svg+xml;base64," + btoa(svg),
-        rotation: -rotation,
-        scale: scale * 0.8,
-        anchor: [0.5, 0.5],
-      });
-    }
-
-    case "arrow-hand-drawn": {
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
-        <path stroke="${color}" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
-          d="M 12 10 C 18 16 34 22 44 24 C 34 26 18 32 12 38" />
-        <path stroke="${color}" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-          d="M 14 14 C 20 18 30 22 40 24 C 30 26 20 30 14 34" />
-      </svg>`;
-      return new Icon({
-        src: "data:image/svg+xml;base64," + btoa(svg),
-        rotation: -rotation,
-        scale: scale * 0.4,
-        anchor: [0.5, 0.5],
-      });
-    }
-
-    case "arrow-double-hand-drawn": {
-      const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
-        <!-- First arrow -->
-        <path stroke="${color}" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
-          d="M 4 10 C 10 16 26 22 36 24 C 26 26 10 32 4 38" />
-        <path stroke="${color}" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-          d="M 6 14 C 12 18 22 22 32 24 C 22 26 12 30 6 34" />
-        <!-- Second arrow -->
-        <path stroke="${color}" fill="none" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
-          d="M 12 10 C 18 16 34 22 44 24 C 34 26 18 32 12 38" />
-        <path stroke="${color}" fill="none" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"
-          d="M 14 14 C 20 18 30 22 40 24 C 30 26 20 30 14 34" />
-      </svg>`;
-      return new Icon({
-        src: "data:image/svg+xml;base64," + btoa(svg),
-        rotation: -rotation,
-        scale: scale * 0.4,
-        anchor: [0.5, 0.5],
-      });
-    }
-
-    case "dot":
-      return new CircleStyle({
-        fill: createFill(),
-        radius: size / 2,
-      });
-
-    case "square":
-      return new RegularShape({
-        fill: createFill(),
-        points: 4,
-        radius: size * 0.7,
-        rotation: -rotation + Math.PI / 4,
-        angle: 0,
-      });
-
-    case "diamond":
-      return new RegularShape({
-        fill: createFill(),
-        points: 4,
-        radius: size * 0.7,
-        rotation: -rotation,
-        angle: 0,
-      });
-
-    case "bar":
-      return new RegularShape({
-        stroke: new Stroke({ color, width: 2 + 4 * scale }),
-        points: 2,
-        radius: size,
-        rotation: -rotation,
-        angle: 0,
-      });
-
-    default:
-      return null;
-  }
+  return new Icon({
+    src,
+    rotation: -rotation,
+    scale: scale * definition.olScale,
+    anchor: definition.olAnchor,
+  });
 }
 
 /**

--- a/src/geo/arrowStyles.ts
+++ b/src/geo/arrowStyles.ts
@@ -13,7 +13,9 @@ import Icon from "ol/style/Icon";
 import * as olColor from "ol/color";
 import type { ArrowType, SimpleStyleSpec } from "./simplestyle";
 import {
-  getArrowSvgDataUri as getSharedArrowSvgDataUri,
+  getArrowOlAnchor,
+  getArrowRenderScale,
+  getArrowSvgDataUri,
   getArrowSymbolDefinition,
 } from "./arrowSymbols";
 import {
@@ -46,17 +48,6 @@ export function getLineAngle(coordinates: number[][], position: "start" | "end")
 }
 
 /**
- * Get the SVG data URI for an arrow type.
- *
- * @param arrowType - The type of arrow marker
- * @param color - Fill/stroke color for the marker
- * @returns Base64-encoded SVG data URI, or null for "none"
- */
-export function getArrowSvgDataUri(arrowType: ArrowType, color: string): string | null {
-  return getSharedArrowSvgDataUri(arrowType, color);
-}
-
-/**
  * Create an arrow marker image for a specific arrow type.
  *
  * @param arrowType - The type of arrow marker to create
@@ -79,7 +70,7 @@ export function createArrowMarkerImage(
     src,
     rotation: -rotation,
     scale: scale * definition.olScale,
-    anchor: definition.olAnchor,
+    anchor: getArrowOlAnchor(definition),
   });
 }
 
@@ -110,7 +101,7 @@ export function createArrowStyles(
   const color = [...olColor.fromString(strokeColor)];
   color[3] = strokeOpacity;
   const rgbaColor = olColor.asString(color);
-  const scale = Math.max(0.4, strokeWidth / 2.5);
+  const scale = getArrowRenderScale(strokeWidth);
 
   // Start arrow
   if (opts["arrow-start"] && opts["arrow-start"] !== "none") {

--- a/src/geo/arrowSymbols.ts
+++ b/src/geo/arrowSymbols.ts
@@ -13,220 +13,267 @@ type ArrowSvgElement = {
 export type ArrowSymbolDefinition = {
   width: number;
   height: number;
+  // Attach point in viewBox coordinates: the point that lands on the feature
+  // endpoint and around which the arrow rotates. For directional arrows this
+  // is intentionally set a few units *behind* the visual tip, so the arrow
+  // overshoots the line endpoint and covers the line's round-cap overshoot.
+  tip: [number, number];
+  // Which MapLibre icon-anchor preset to use on the globe. `icon-offset` is
+  // derived automatically to bring the anchor onto `tip`.
   anchorKind: "center" | "right";
-  globeOffset: [number, number];
-  olAnchor: [number, number];
   olScale: number;
   elements: ArrowSvgElement[];
 };
 
+// Base native pixel size used when rasterizing arrow sprites on the globe.
+// Actual canvas size grows with sprite scale; see `getArrowSpriteCanvasSize`.
+export const GLOBE_SPRITE_BASE_SIZE = 28;
+
 const sharedLineJoin = "round" as const;
 const sharedLineCap = "round" as const;
 
-const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinition> = {
-  arrow: {
-    width: 24,
-    height: 24,
-    anchorKind: "right",
-    globeOffset: [0, 0],
-    olAnchor: [1, 0.5],
-    olScale: 0.85,
-    elements: [
-      {
-        d: "M3.84 4.32 L24 12 L3.84 19.68 Z",
-        fill: true,
-        stroke: true,
-        strokeWidth: 2,
-        lineJoin: sharedLineJoin,
-      },
-    ],
-  },
-  "arrow-open": {
-    width: 24,
-    height: 24,
-    anchorKind: "right",
-    globeOffset: [0.35, 0],
-    olAnchor: [1, 0.5],
-    olScale: 0.85,
-    elements: [
-      {
-        d: "M5.28 4.32 L24 12 L5.28 19.68",
-        stroke: true,
-        strokeWidth: 2,
-        lineCap: sharedLineCap,
-        lineJoin: sharedLineJoin,
-      },
-    ],
-  },
-  "arrow-curved": {
-    width: 24,
-    height: 24,
-    anchorKind: "right",
-    globeOffset: [0.2, 0],
-    olAnchor: [1, 0.5],
-    olScale: 0.8,
-    elements: [
-      {
-        d: "M2,12 Q6,12 10,4 L24,12 L10,20 Q6,12 2,12 Z",
-        fill: true,
-      },
-    ],
-  },
-  "arrow-stealth": {
-    width: 24,
-    height: 24,
-    anchorKind: "right",
-    globeOffset: [0, 0],
-    olAnchor: [1, 0.5],
-    olScale: 0.8,
-    elements: [
-      {
-        d: "M2,2 L24,12 L2,22 L6,12 Z",
-        fill: true,
-      },
-    ],
-  },
-  "arrow-double": {
-    width: 24,
-    height: 24,
-    anchorKind: "right",
-    globeOffset: [0.2, 0],
-    olAnchor: [1, 0.5],
-    olScale: 0.8,
-    elements: [
-      {
-        d: "M2,2 L12,12 L2,22 Z M10,2 L24,12 L10,22 Z",
-        fill: true,
-      },
-    ],
-  },
-  "arrow-hand-drawn": {
-    width: 48,
-    height: 48,
-    anchorKind: "right",
-    globeOffset: [0.45, 0],
-    olAnchor: [1, 0.5],
-    olScale: 0.4,
-    elements: [
-      {
-        d: "M12 10 C18 16 34 22 48 24 C34 26 18 32 12 38",
-        stroke: true,
-        strokeWidth: 2.5,
-        lineCap: sharedLineCap,
-        lineJoin: sharedLineJoin,
-      },
-      {
-        d: "M14 14 C20 18 30 22 44 24 C30 26 20 30 14 34",
-        stroke: true,
-        strokeWidth: 2,
-        lineCap: sharedLineCap,
-        lineJoin: sharedLineJoin,
-      },
-    ],
-  },
-  "arrow-double-hand-drawn": {
-    width: 48,
-    height: 48,
-    anchorKind: "right",
-    globeOffset: [0.45, 0],
-    olAnchor: [1, 0.5],
-    olScale: 0.4,
-    elements: [
-      {
-        d: "M4 10 C10 16 26 22 36 24 C26 26 10 32 4 38",
-        stroke: true,
-        strokeWidth: 2.5,
-        lineCap: sharedLineCap,
-        lineJoin: sharedLineJoin,
-      },
-      {
-        d: "M6 14 C12 18 22 22 32 24 C22 26 12 30 6 34",
-        stroke: true,
-        strokeWidth: 2,
-        lineCap: sharedLineCap,
-        lineJoin: sharedLineJoin,
-      },
-      {
-        d: "M12 10 C18 16 34 22 48 24 C34 26 18 32 12 38",
-        stroke: true,
-        strokeWidth: 2.5,
-        lineCap: sharedLineCap,
-        lineJoin: sharedLineJoin,
-      },
-      {
-        d: "M14 14 C20 18 30 22 44 24 C30 26 20 30 14 34",
-        stroke: true,
-        strokeWidth: 2,
-        lineCap: sharedLineCap,
-        lineJoin: sharedLineJoin,
-      },
-    ],
-  },
-  dot: {
-    width: 24,
-    height: 24,
-    anchorKind: "center",
-    globeOffset: [0, 0],
-    olAnchor: [0.5, 0.5],
-    olScale: 1,
-    elements: [
-      {
-        d: "M12 7.68 A4.32 4.32 0 1 1 11.999 7.68 Z",
-        fill: true,
-      },
-    ],
-  },
-  square: {
-    width: 24,
-    height: 24,
-    anchorKind: "center",
-    globeOffset: [0, 0],
-    olAnchor: [0.5, 0.5],
-    olScale: 1,
-    elements: [
-      {
-        d: "M8.16 8.16 H15.84 V15.84 H8.16 Z",
-        fill: true,
-      },
-    ],
-  },
-  diamond: {
-    width: 24,
-    height: 24,
-    anchorKind: "center",
-    globeOffset: [0, 0],
-    olAnchor: [0.5, 0.5],
-    olScale: 1,
-    elements: [
-      {
-        d: "M12 7.2 L16.8 12 L12 16.8 L7.2 12 Z",
-        fill: true,
-      },
-    ],
-  },
-  bar: {
-    width: 24,
-    height: 24,
-    anchorKind: "center",
-    globeOffset: [0, 0],
-    olAnchor: [0.5, 0.5],
-    olScale: 1,
-    elements: [
-      {
-        d: "M12 4.32 L12 19.68",
-        stroke: true,
-        strokeWidth: 2.5,
-        lineCap: sharedLineCap,
-      },
-    ],
-  },
-};
+// Tips for stroked arrowheads are inset ~1 viewBox unit from the right edge so
+// round joins/caps are not clipped by the SVG viewport (SVG clips strokes that
+// extend beyond width/height). Filled arrowheads do not need the inset.
+const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinition> =
+  Object.freeze({
+    arrow: {
+      width: 24,
+      height: 24,
+      tip: [20, 12],
+      anchorKind: "right",
+      olScale: 0.85,
+      elements: [
+        {
+          d: "M2.84 4.32 L23 12 L2.84 19.68 Z",
+          fill: true,
+          stroke: true,
+          strokeWidth: 2,
+          lineJoin: sharedLineJoin,
+        },
+      ],
+    },
+    "arrow-open": {
+      width: 24,
+      height: 24,
+      tip: [20, 12],
+      anchorKind: "right",
+      olScale: 0.85,
+      elements: [
+        {
+          d: "M4.28 4.32 L23 12 L4.28 19.68",
+          stroke: true,
+          strokeWidth: 2,
+          lineCap: sharedLineCap,
+          lineJoin: sharedLineJoin,
+        },
+      ],
+    },
+    "arrow-curved": {
+      width: 24,
+      height: 24,
+      tip: [21, 12],
+      anchorKind: "right",
+      olScale: 0.8,
+      elements: [
+        {
+          d: "M2,12 Q6,12 10,4 L24,12 L10,20 Q6,12 2,12 Z",
+          fill: true,
+        },
+      ],
+    },
+    "arrow-stealth": {
+      width: 24,
+      height: 24,
+      tip: [21, 12],
+      anchorKind: "right",
+      olScale: 0.8,
+      elements: [
+        {
+          d: "M2,2 L24,12 L2,22 L6,12 Z",
+          fill: true,
+        },
+      ],
+    },
+    "arrow-double": {
+      width: 24,
+      height: 24,
+      tip: [21, 12],
+      anchorKind: "right",
+      olScale: 0.8,
+      elements: [
+        {
+          d: "M2,2 L12,12 L2,22 Z M10,2 L24,12 L10,22 Z",
+          fill: true,
+        },
+      ],
+    },
+    "arrow-hand-drawn": {
+      width: 48,
+      height: 48,
+      tip: [42, 24],
+      anchorKind: "right",
+      olScale: 0.4,
+      elements: [
+        {
+          d: "M12 10 C18 16 34 22 47 24 C34 26 18 32 12 38",
+          stroke: true,
+          strokeWidth: 2.5,
+          lineCap: sharedLineCap,
+          lineJoin: sharedLineJoin,
+        },
+        {
+          d: "M14 14 C20 18 30 22 43 24 C30 26 20 30 14 34",
+          stroke: true,
+          strokeWidth: 2,
+          lineCap: sharedLineCap,
+          lineJoin: sharedLineJoin,
+        },
+      ],
+    },
+    "arrow-double-hand-drawn": {
+      width: 48,
+      height: 48,
+      tip: [42, 24],
+      anchorKind: "right",
+      olScale: 0.4,
+      elements: [
+        {
+          d: "M4 10 C10 16 26 22 36 24 C26 26 10 32 4 38",
+          stroke: true,
+          strokeWidth: 2.5,
+          lineCap: sharedLineCap,
+          lineJoin: sharedLineJoin,
+        },
+        {
+          d: "M6 14 C12 18 22 22 32 24 C22 26 12 30 6 34",
+          stroke: true,
+          strokeWidth: 2,
+          lineCap: sharedLineCap,
+          lineJoin: sharedLineJoin,
+        },
+        {
+          d: "M12 10 C18 16 34 22 47 24 C34 26 18 32 12 38",
+          stroke: true,
+          strokeWidth: 2.5,
+          lineCap: sharedLineCap,
+          lineJoin: sharedLineJoin,
+        },
+        {
+          d: "M14 14 C20 18 30 22 43 24 C30 26 20 30 14 34",
+          stroke: true,
+          strokeWidth: 2,
+          lineCap: sharedLineCap,
+          lineJoin: sharedLineJoin,
+        },
+      ],
+    },
+    dot: {
+      width: 24,
+      height: 24,
+      tip: [12, 12],
+      anchorKind: "center",
+      olScale: 1,
+      elements: [
+        {
+          d: "M7.68 12 A4.32 4.32 0 1 0 16.32 12 A4.32 4.32 0 1 0 7.68 12 Z",
+          fill: true,
+        },
+      ],
+    },
+    square: {
+      width: 24,
+      height: 24,
+      tip: [12, 12],
+      anchorKind: "center",
+      olScale: 1,
+      elements: [
+        {
+          d: "M8.16 8.16 H15.84 V15.84 H8.16 Z",
+          fill: true,
+        },
+      ],
+    },
+    diamond: {
+      width: 24,
+      height: 24,
+      tip: [12, 12],
+      anchorKind: "center",
+      olScale: 1,
+      elements: [
+        {
+          d: "M12 7.2 L16.8 12 L12 16.8 L7.2 12 Z",
+          fill: true,
+        },
+      ],
+    },
+    bar: {
+      width: 24,
+      height: 24,
+      tip: [12, 12],
+      anchorKind: "center",
+      olScale: 1,
+      elements: [
+        {
+          d: "M12 4.32 L12 19.68",
+          stroke: true,
+          strokeWidth: 2.5,
+          lineCap: sharedLineCap,
+        },
+      ],
+    },
+  });
 
-function encodeSvg(svg: string) {
-  if (typeof btoa === "function") {
-    return btoa(svg);
-  }
-  return Buffer.from(svg).toString("base64");
+// Shared scale formula for arrow markers. Used by both the OpenLayers
+// `createArrowStyles` and the globe `buildFeatureData` so the two renderers
+// size arrowheads identically relative to stroke width.
+export function getArrowRenderScale(strokeWidth: number): number {
+  return Math.max(0.4, strokeWidth / 2.5);
+}
+
+// Native sprite canvas size (in pixels) for a given sprite scale bucket. The
+// globe uses larger canvases at higher bucket scales to avoid upscaling raster
+// data; OpenLayers does not use this and scales vector SVGs directly.
+export function getArrowSpriteCanvasSize(spriteScale: number): number {
+  return Math.max(
+    GLOBE_SPRITE_BASE_SIZE,
+    Math.round(GLOBE_SPRITE_BASE_SIZE * spriteScale),
+  );
+}
+
+export function getArrowOlAnchor(def: ArrowSymbolDefinition): [number, number] {
+  return [def.tip[0] / def.width, def.tip[1] / def.height];
+}
+
+// Returns the MapLibre `icon-offset` (in native sprite pixels at icon-size 1)
+// needed to bring the definition's logical tip onto the feature endpoint.
+// MapLibre places the preset `icon-anchor` at the feature coord then *displaces
+// the icon* by `icon-offset`, so the offset is the vector from the tip (in
+// sprite coords) back to the anchor preset — positive pushes the icon forward
+// so its tip lands on the endpoint. Depends on sprite canvas size because
+// MapLibre multiplies the declared offset by `icon-size`; groups that
+// reference this must key on the sprite scale.
+export function getArrowGlobeIconOffset(
+  def: ArrowSymbolDefinition,
+  spriteCanvasSize: number,
+): [number, number] {
+  const anchorX = def.anchorKind === "right" ? def.width : def.width / 2;
+  const anchorY = def.height / 2;
+  const offsetX = ((anchorX - def.tip[0]) / def.width) * spriteCanvasSize;
+  const offsetY = ((anchorY - def.tip[1]) / def.height) * spriteCanvasSize;
+  return [offsetX, offsetY];
+}
+
+// URL-encoded `data:image/svg+xml;utf8,...` is smaller and more debuggable
+// than base64, and avoids the btoa non-ASCII trap.
+function encodeSvgForDataUri(svg: string) {
+  return svg
+    .replace(/%/g, "%25")
+    .replace(/"/g, "%22")
+    .replace(/#/g, "%23")
+    .replace(/</g, "%3C")
+    .replace(/>/g, "%3E")
+    .replace(/\s+/g, " ");
 }
 
 export function getArrowSymbolDefinition(
@@ -263,7 +310,7 @@ export function getArrowSvgMarkup(arrowType: ArrowType, color: string): string |
 export function getArrowSvgDataUri(arrowType: ArrowType, color: string): string | null {
   const svg = getArrowSvgMarkup(arrowType, color);
   if (!svg) return null;
-  return `data:image/svg+xml;base64,${encodeSvg(svg)}`;
+  return `data:image/svg+xml;utf8,${encodeSvgForDataUri(svg)}`;
 }
 
 export function drawArrowSymbol(

--- a/src/geo/arrowSymbols.ts
+++ b/src/geo/arrowSymbols.ts
@@ -14,6 +14,7 @@ export type ArrowSymbolDefinition = {
   width: number;
   height: number;
   anchorKind: "center" | "right";
+  globeOffset: [number, number];
   olAnchor: [number, number];
   olScale: number;
   elements: ArrowSvgElement[];
@@ -27,11 +28,12 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 24,
     height: 24,
     anchorKind: "right",
-    olAnchor: [0.86, 0.5],
+    globeOffset: [0, 0],
+    olAnchor: [1, 0.5],
     olScale: 0.85,
     elements: [
       {
-        d: "M3.84 4.32 L20.64 12 L3.84 19.68 Z",
+        d: "M3.84 4.32 L24 12 L3.84 19.68 Z",
         fill: true,
         stroke: true,
         strokeWidth: 2,
@@ -43,11 +45,12 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 24,
     height: 24,
     anchorKind: "right",
-    olAnchor: [0.82, 0.5],
+    globeOffset: [0.35, 0],
+    olAnchor: [1, 0.5],
     olScale: 0.85,
     elements: [
       {
-        d: "M5.28 4.32 L19.68 12 L5.28 19.68",
+        d: "M5.28 4.32 L24 12 L5.28 19.68",
         stroke: true,
         strokeWidth: 2,
         lineCap: sharedLineCap,
@@ -59,11 +62,12 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 24,
     height: 24,
     anchorKind: "right",
-    olAnchor: [0.86, 0.5],
+    globeOffset: [0.2, 0],
+    olAnchor: [1, 0.5],
     olScale: 0.8,
     elements: [
       {
-        d: "M2,12 Q6,12 10,4 L22,12 L10,20 Q6,12 2,12 Z",
+        d: "M2,12 Q6,12 10,4 L24,12 L10,20 Q6,12 2,12 Z",
         fill: true,
       },
     ],
@@ -72,11 +76,12 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 24,
     height: 24,
     anchorKind: "right",
-    olAnchor: [0.86, 0.5],
+    globeOffset: [0, 0],
+    olAnchor: [1, 0.5],
     olScale: 0.8,
     elements: [
       {
-        d: "M2,2 L22,12 L2,22 L6,12 Z",
+        d: "M2,2 L24,12 L2,22 L6,12 Z",
         fill: true,
       },
     ],
@@ -85,11 +90,12 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 24,
     height: 24,
     anchorKind: "right",
-    olAnchor: [0.83, 0.5],
+    globeOffset: [0.2, 0],
+    olAnchor: [1, 0.5],
     olScale: 0.8,
     elements: [
       {
-        d: "M2,2 L12,12 L2,22 Z M10,2 L20,12 L10,22 Z",
+        d: "M2,2 L12,12 L2,22 Z M10,2 L24,12 L10,22 Z",
         fill: true,
       },
     ],
@@ -98,18 +104,19 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 48,
     height: 48,
     anchorKind: "right",
-    olAnchor: [44 / 48, 0.5],
+    globeOffset: [0.45, 0],
+    olAnchor: [1, 0.5],
     olScale: 0.4,
     elements: [
       {
-        d: "M12 10 C18 16 34 22 44 24 C34 26 18 32 12 38",
+        d: "M12 10 C18 16 34 22 48 24 C34 26 18 32 12 38",
         stroke: true,
         strokeWidth: 2.5,
         lineCap: sharedLineCap,
         lineJoin: sharedLineJoin,
       },
       {
-        d: "M14 14 C20 18 30 22 40 24 C30 26 20 30 14 34",
+        d: "M14 14 C20 18 30 22 44 24 C30 26 20 30 14 34",
         stroke: true,
         strokeWidth: 2,
         lineCap: sharedLineCap,
@@ -121,7 +128,8 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 48,
     height: 48,
     anchorKind: "right",
-    olAnchor: [44 / 48, 0.5],
+    globeOffset: [0.45, 0],
+    olAnchor: [1, 0.5],
     olScale: 0.4,
     elements: [
       {
@@ -139,14 +147,14 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
         lineJoin: sharedLineJoin,
       },
       {
-        d: "M12 10 C18 16 34 22 44 24 C34 26 18 32 12 38",
+        d: "M12 10 C18 16 34 22 48 24 C34 26 18 32 12 38",
         stroke: true,
         strokeWidth: 2.5,
         lineCap: sharedLineCap,
         lineJoin: sharedLineJoin,
       },
       {
-        d: "M14 14 C20 18 30 22 40 24 C30 26 20 30 14 34",
+        d: "M14 14 C20 18 30 22 44 24 C30 26 20 30 14 34",
         stroke: true,
         strokeWidth: 2,
         lineCap: sharedLineCap,
@@ -158,6 +166,7 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 24,
     height: 24,
     anchorKind: "center",
+    globeOffset: [0, 0],
     olAnchor: [0.5, 0.5],
     olScale: 1,
     elements: [
@@ -171,6 +180,7 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 24,
     height: 24,
     anchorKind: "center",
+    globeOffset: [0, 0],
     olAnchor: [0.5, 0.5],
     olScale: 1,
     elements: [
@@ -184,6 +194,7 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 24,
     height: 24,
     anchorKind: "center",
+    globeOffset: [0, 0],
     olAnchor: [0.5, 0.5],
     olScale: 1,
     elements: [
@@ -197,6 +208,7 @@ const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinitio
     width: 24,
     height: 24,
     anchorKind: "center",
+    globeOffset: [0, 0],
     olAnchor: [0.5, 0.5],
     olScale: 1,
     elements: [

--- a/src/geo/arrowSymbols.ts
+++ b/src/geo/arrowSymbols.ts
@@ -1,0 +1,283 @@
+import type { ArrowType } from "./simplestyle";
+
+type ArrowRenderableType = Exclude<ArrowType, "none">;
+type ArrowSvgElement = {
+  d: string;
+  fill?: boolean;
+  stroke?: boolean;
+  strokeWidth?: number;
+  lineCap?: "butt" | "round" | "square";
+  lineJoin?: "miter" | "round" | "bevel";
+};
+
+export type ArrowSymbolDefinition = {
+  width: number;
+  height: number;
+  anchorKind: "center" | "right";
+  olAnchor: [number, number];
+  olScale: number;
+  elements: ArrowSvgElement[];
+};
+
+const sharedLineJoin = "round" as const;
+const sharedLineCap = "round" as const;
+
+const ARROW_SYMBOL_DEFINITIONS: Record<ArrowRenderableType, ArrowSymbolDefinition> = {
+  arrow: {
+    width: 24,
+    height: 24,
+    anchorKind: "right",
+    olAnchor: [0.86, 0.5],
+    olScale: 0.85,
+    elements: [
+      {
+        d: "M3.84 4.32 L20.64 12 L3.84 19.68 Z",
+        fill: true,
+        stroke: true,
+        strokeWidth: 2,
+        lineJoin: sharedLineJoin,
+      },
+    ],
+  },
+  "arrow-open": {
+    width: 24,
+    height: 24,
+    anchorKind: "right",
+    olAnchor: [0.82, 0.5],
+    olScale: 0.85,
+    elements: [
+      {
+        d: "M5.28 4.32 L19.68 12 L5.28 19.68",
+        stroke: true,
+        strokeWidth: 2,
+        lineCap: sharedLineCap,
+        lineJoin: sharedLineJoin,
+      },
+    ],
+  },
+  "arrow-curved": {
+    width: 24,
+    height: 24,
+    anchorKind: "right",
+    olAnchor: [0.86, 0.5],
+    olScale: 0.8,
+    elements: [
+      {
+        d: "M2,12 Q6,12 10,4 L22,12 L10,20 Q6,12 2,12 Z",
+        fill: true,
+      },
+    ],
+  },
+  "arrow-stealth": {
+    width: 24,
+    height: 24,
+    anchorKind: "right",
+    olAnchor: [0.86, 0.5],
+    olScale: 0.8,
+    elements: [
+      {
+        d: "M2,2 L22,12 L2,22 L6,12 Z",
+        fill: true,
+      },
+    ],
+  },
+  "arrow-double": {
+    width: 24,
+    height: 24,
+    anchorKind: "right",
+    olAnchor: [0.83, 0.5],
+    olScale: 0.8,
+    elements: [
+      {
+        d: "M2,2 L12,12 L2,22 Z M10,2 L20,12 L10,22 Z",
+        fill: true,
+      },
+    ],
+  },
+  "arrow-hand-drawn": {
+    width: 48,
+    height: 48,
+    anchorKind: "right",
+    olAnchor: [44 / 48, 0.5],
+    olScale: 0.4,
+    elements: [
+      {
+        d: "M12 10 C18 16 34 22 44 24 C34 26 18 32 12 38",
+        stroke: true,
+        strokeWidth: 2.5,
+        lineCap: sharedLineCap,
+        lineJoin: sharedLineJoin,
+      },
+      {
+        d: "M14 14 C20 18 30 22 40 24 C30 26 20 30 14 34",
+        stroke: true,
+        strokeWidth: 2,
+        lineCap: sharedLineCap,
+        lineJoin: sharedLineJoin,
+      },
+    ],
+  },
+  "arrow-double-hand-drawn": {
+    width: 48,
+    height: 48,
+    anchorKind: "right",
+    olAnchor: [44 / 48, 0.5],
+    olScale: 0.4,
+    elements: [
+      {
+        d: "M4 10 C10 16 26 22 36 24 C26 26 10 32 4 38",
+        stroke: true,
+        strokeWidth: 2.5,
+        lineCap: sharedLineCap,
+        lineJoin: sharedLineJoin,
+      },
+      {
+        d: "M6 14 C12 18 22 22 32 24 C22 26 12 30 6 34",
+        stroke: true,
+        strokeWidth: 2,
+        lineCap: sharedLineCap,
+        lineJoin: sharedLineJoin,
+      },
+      {
+        d: "M12 10 C18 16 34 22 44 24 C34 26 18 32 12 38",
+        stroke: true,
+        strokeWidth: 2.5,
+        lineCap: sharedLineCap,
+        lineJoin: sharedLineJoin,
+      },
+      {
+        d: "M14 14 C20 18 30 22 40 24 C30 26 20 30 14 34",
+        stroke: true,
+        strokeWidth: 2,
+        lineCap: sharedLineCap,
+        lineJoin: sharedLineJoin,
+      },
+    ],
+  },
+  dot: {
+    width: 24,
+    height: 24,
+    anchorKind: "center",
+    olAnchor: [0.5, 0.5],
+    olScale: 1,
+    elements: [
+      {
+        d: "M12 7.68 A4.32 4.32 0 1 1 11.999 7.68 Z",
+        fill: true,
+      },
+    ],
+  },
+  square: {
+    width: 24,
+    height: 24,
+    anchorKind: "center",
+    olAnchor: [0.5, 0.5],
+    olScale: 1,
+    elements: [
+      {
+        d: "M8.16 8.16 H15.84 V15.84 H8.16 Z",
+        fill: true,
+      },
+    ],
+  },
+  diamond: {
+    width: 24,
+    height: 24,
+    anchorKind: "center",
+    olAnchor: [0.5, 0.5],
+    olScale: 1,
+    elements: [
+      {
+        d: "M12 7.2 L16.8 12 L12 16.8 L7.2 12 Z",
+        fill: true,
+      },
+    ],
+  },
+  bar: {
+    width: 24,
+    height: 24,
+    anchorKind: "center",
+    olAnchor: [0.5, 0.5],
+    olScale: 1,
+    elements: [
+      {
+        d: "M12 4.32 L12 19.68",
+        stroke: true,
+        strokeWidth: 2.5,
+        lineCap: sharedLineCap,
+      },
+    ],
+  },
+};
+
+function encodeSvg(svg: string) {
+  if (typeof btoa === "function") {
+    return btoa(svg);
+  }
+  return Buffer.from(svg).toString("base64");
+}
+
+export function getArrowSymbolDefinition(
+  arrowType: ArrowType,
+): ArrowSymbolDefinition | null {
+  if (arrowType === "none") return null;
+  return ARROW_SYMBOL_DEFINITIONS[arrowType];
+}
+
+export function getArrowSvgMarkup(arrowType: ArrowType, color: string): string | null {
+  const definition = getArrowSymbolDefinition(arrowType);
+  if (!definition) return null;
+  const body = definition.elements
+    .map((element) => {
+      const attrs = [
+        `d="${element.d}"`,
+        `fill="${element.fill ? color : "none"}"`,
+        `stroke="${element.stroke ? color : "none"}"`,
+        typeof element.strokeWidth === "number"
+          ? `stroke-width="${element.strokeWidth}"`
+          : "",
+        element.lineCap ? `stroke-linecap="${element.lineCap}"` : "",
+        element.lineJoin ? `stroke-linejoin="${element.lineJoin}"` : "",
+      ]
+        .filter(Boolean)
+        .join(" ");
+      return `<path ${attrs} />`;
+    })
+    .join("");
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${definition.width}" height="${definition.height}" viewBox="0 0 ${definition.width} ${definition.height}">${body}</svg>`;
+}
+
+export function getArrowSvgDataUri(arrowType: ArrowType, color: string): string | null {
+  const svg = getArrowSvgMarkup(arrowType, color);
+  if (!svg) return null;
+  return `data:image/svg+xml;base64,${encodeSvg(svg)}`;
+}
+
+export function drawArrowSymbol(
+  context: CanvasRenderingContext2D,
+  arrowType: ArrowType,
+  color: string,
+  size: number,
+) {
+  const definition = getArrowSymbolDefinition(arrowType);
+  if (!definition || typeof Path2D === "undefined") return;
+
+  context.save();
+  context.scale(size / definition.width, size / definition.height);
+  for (const element of definition.elements) {
+    const path = new Path2D(element.d);
+    if (element.fill) {
+      context.fillStyle = color;
+      context.fill(path);
+    }
+    if (element.stroke) {
+      context.strokeStyle = color;
+      context.lineWidth = element.strokeWidth ?? 2;
+      context.lineCap = element.lineCap ?? "butt";
+      context.lineJoin = element.lineJoin ?? "miter";
+      context.stroke(path);
+    }
+  }
+  context.restore();
+}

--- a/src/modules/globeview/maplibreScenarioFeatures.test.ts
+++ b/src/modules/globeview/maplibreScenarioFeatures.test.ts
@@ -134,9 +134,15 @@ describe("buildScenarioFeatureRenderPlan", () => {
     });
 
     const arrowLayer = plan.layerDefinitions.find((layer) => layer.id.includes("arrows"));
+    // `arrow` has its attach point (tip) at [20, 12] in a 24-wide viewBox —
+    // several units behind the visual tip so the arrow body overshoots the
+    // line endpoint and covers the line's round-cap. At spriteScale 1 (28px
+    // native canvas) MapLibre places the `right` anchor at the feature and
+    // displaces the icon forward by (24-20)/24*28 ≈ 4.667 so the tip lands
+    // on the endpoint.
     expect(arrowLayer?.spec.layout).toMatchObject({
       "icon-anchor": "right",
-      "icon-offset": ["literal", [0, 0]],
+      "icon-offset": ["literal", [((24 - 20) / 24) * 28, 0]],
       "icon-size": ["get", "iconScale"],
       "icon-rotation-alignment": "map",
       "icon-pitch-alignment": "map",
@@ -335,9 +341,13 @@ describe("buildScenarioFeatureRenderPlan", () => {
     );
 
     const arrowLayer = plan.layerDefinitions.find((layer) => layer.id.includes("arrows"));
+    // `arrow-hand-drawn` has its attach point at [42, 24] in a 48-wide
+    // viewBox; at 28px sprite canvas (spriteScale 1) the icon-offset
+    // (48-42)/48*28 = 3.5 pushes the icon forward so the tip lands on the
+    // endpoint.
     expect(arrowLayer?.spec.layout).toMatchObject({
       "icon-anchor": "right",
-      "icon-offset": ["literal", [0.45, 0]],
+      "icon-offset": ["literal", [((48 - 42) / 48) * 28, 0]],
     });
   });
 });

--- a/src/modules/globeview/maplibreScenarioFeatures.test.ts
+++ b/src/modules/globeview/maplibreScenarioFeatures.test.ts
@@ -135,9 +135,14 @@ describe("buildScenarioFeatureRenderPlan", () => {
 
     const arrowLayer = plan.layerDefinitions.find((layer) => layer.id.includes("arrows"));
     expect(arrowLayer?.spec.layout).toMatchObject({
-      "icon-anchor": ["get", "iconAnchor"],
+      "icon-anchor": "right",
+      "icon-offset": ["literal", [0, 0]],
+      "icon-size": ["get", "iconScale"],
       "icon-rotation-alignment": "map",
       "icon-pitch-alignment": "map",
+    });
+    expect(arrowLayer?.spec.paint).toMatchObject({
+      "icon-opacity": ["get", "sourceOpacity"],
     });
   });
 
@@ -189,5 +194,150 @@ describe("buildScenarioFeatureRenderPlan", () => {
     expect(endArrow?.properties?.rotation).toBeCloseTo(-90, 5);
     expect(startArrow?.properties?.iconAnchor).toBe("right");
     expect(endArrow?.properties?.iconAnchor).toBe("right");
+    expect(startArrow?.properties?.iconScale).toBeCloseTo(0.8, 5);
+    expect(endArrow?.properties?.iconScale).toBeCloseTo(0.8, 5);
+  });
+
+  it("scales globe arrowheads with stroke width", () => {
+    const plan = buildScenarioFeatureRenderPlan(
+      {
+        id: "layer-4",
+        kind: "overlay",
+        name: "Layer 4",
+        items: [
+          {
+            id: "line-3",
+            kind: "geometry",
+            _pid: "layer-4",
+            type: "Feature",
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [0, 0],
+                [0, 1],
+              ],
+            },
+            properties: {},
+            meta: {
+              type: "LineString",
+            },
+            style: {
+              "arrow-end": "bar",
+              "stroke-width": 10,
+            },
+          },
+        ],
+      } as any,
+      {
+        filterVisible: true,
+        selectedFeatureIds: new Set(),
+      },
+    );
+
+    const arrow = plan.arrowData.features.find(
+      (feature) => feature.id === "line-3-arrow-end",
+    );
+    const imageDefinition = Array.from(plan.imageDefinitions.values()).find(
+      (definition) => definition.kind === "arrow",
+    );
+
+    expect(arrow?.properties?.iconScale).toBeCloseTo(1, 5);
+    expect(arrow?.properties?.iconAnchor).toBe("center");
+    expect(imageDefinition).toMatchObject({
+      kind: "arrow",
+      spriteScale: 4,
+    });
+  });
+
+  it("buckets globe arrow sprites upward to avoid bitmap upscaling", () => {
+    const plan = buildScenarioFeatureRenderPlan(
+      {
+        id: "layer-5",
+        kind: "overlay",
+        name: "Layer 5",
+        items: [
+          {
+            id: "line-4",
+            kind: "geometry",
+            _pid: "layer-5",
+            type: "Feature",
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [0, 0],
+                [1, 0],
+              ],
+            },
+            properties: {},
+            meta: {
+              type: "LineString",
+            },
+            style: {
+              "arrow-end": "arrow",
+              "stroke-width": 4,
+            },
+          },
+        ],
+      } as any,
+      {
+        filterVisible: true,
+        selectedFeatureIds: new Set(),
+      },
+    );
+
+    const arrow = plan.arrowData.features.find(
+      (feature) => feature.id === "line-4-arrow-end",
+    );
+    const imageDefinition = Array.from(plan.imageDefinitions.values()).find(
+      (definition) => definition.kind === "arrow",
+    );
+
+    expect(arrow?.properties?.iconScale).toBeCloseTo(0.8, 5);
+    expect(imageDefinition).toMatchObject({
+      kind: "arrow",
+      spriteScale: 2,
+    });
+  });
+
+  it("uses per-arrow globe placement metadata for open hand-drawn heads", () => {
+    const plan = buildScenarioFeatureRenderPlan(
+      {
+        id: "layer-6",
+        kind: "overlay",
+        name: "Layer 6",
+        items: [
+          {
+            id: "line-5",
+            kind: "geometry",
+            _pid: "layer-6",
+            type: "Feature",
+            geometry: {
+              type: "LineString",
+              coordinates: [
+                [0, 0],
+                [1, 1],
+              ],
+            },
+            properties: {},
+            meta: {
+              type: "LineString",
+            },
+            style: {
+              "arrow-end": "arrow-hand-drawn",
+            },
+          },
+        ],
+      } as any,
+      {
+        filterVisible: true,
+        selectedFeatureIds: new Set(),
+      },
+    );
+
+    const arrowLayer = plan.layerDefinitions.find((layer) => layer.id.includes("arrows"));
+    expect(arrowLayer?.spec.layout).toMatchObject({
+      "icon-anchor": "right",
+      "icon-offset": ["literal", [0.45, 0]],
+    });
   });
 });

--- a/src/modules/globeview/maplibreScenarioFeatures.test.ts
+++ b/src/modules/globeview/maplibreScenarioFeatures.test.ts
@@ -135,6 +135,7 @@ describe("buildScenarioFeatureRenderPlan", () => {
 
     const arrowLayer = plan.layerDefinitions.find((layer) => layer.id.includes("arrows"));
     expect(arrowLayer?.spec.layout).toMatchObject({
+      "icon-anchor": ["get", "iconAnchor"],
       "icon-rotation-alignment": "map",
       "icon-pitch-alignment": "map",
     });
@@ -177,10 +178,16 @@ describe("buildScenarioFeatureRenderPlan", () => {
       },
     );
 
-    const startArrow = plan.arrowData.features.find((feature) => feature.id === "line-2-arrow-start");
-    const endArrow = plan.arrowData.features.find((feature) => feature.id === "line-2-arrow-end");
+    const startArrow = plan.arrowData.features.find(
+      (feature) => feature.id === "line-2-arrow-start",
+    );
+    const endArrow = plan.arrowData.features.find(
+      (feature) => feature.id === "line-2-arrow-end",
+    );
 
     expect(startArrow?.properties?.rotation).toBeCloseTo(-180, 5);
     expect(endArrow?.properties?.rotation).toBeCloseTo(-90, 5);
+    expect(startArrow?.properties?.iconAnchor).toBe("right");
+    expect(endArrow?.properties?.iconAnchor).toBe("right");
   });
 });

--- a/src/modules/globeview/maplibreScenarioFeatures.ts
+++ b/src/modules/globeview/maplibreScenarioFeatures.ts
@@ -17,7 +17,14 @@ import type {
   MapStyleImageMissingEvent,
 } from "maplibre-gl";
 import { fromString as parseColor } from "ol/color";
-import { drawArrowSymbol, getArrowSymbolDefinition } from "@/geo/arrowSymbols";
+import {
+  drawArrowSymbol,
+  getArrowGlobeIconOffset,
+  getArrowRenderScale,
+  getArrowSpriteCanvasSize,
+  getArrowSymbolDefinition,
+  type ArrowSymbolDefinition,
+} from "@/geo/arrowSymbols";
 import type { FeatureId } from "@/types/scenarioGeoModels";
 import type {
   FullScenarioLayerItemsLayer,
@@ -205,22 +212,33 @@ function getVisibilityGroup(style: StyleLike, suffix: string, layerId: string) {
   } satisfies GroupDefinition;
 }
 
+// Derive the arrow visibility group from a symbol definition and its sprite
+// scale. `icon-offset` is computed from the definition's tip position (in
+// native sprite pixels) so the MapLibre `icon-anchor` preset lands on the
+// logical tip; because offset pixels depend on sprite canvas size, the group
+// is keyed on spriteScale as well.
 function getArrowVisibilityGroup(
   style: StyleLike,
   suffix: string,
   layerId: string,
-  placement: Pick<ArrowGroupDefinition, "iconAnchor" | "iconOffset">,
+  symbolDefinition: ArrowSymbolDefinition | null,
+  spriteScale: number,
 ) {
   const baseGroup = getVisibilityGroup(style, suffix, layerId);
+  const iconAnchor = symbolDefinition?.anchorKind ?? "center";
+  const iconOffset: [number, number] = symbolDefinition
+    ? getArrowGlobeIconOffset(symbolDefinition, getArrowSpriteCanvasSize(spriteScale))
+    : [0, 0];
   return {
     ...baseGroup,
     id: hashObject({
       baseGroupId: baseGroup.id,
-      iconAnchor: placement.iconAnchor,
-      iconOffset: placement.iconOffset,
+      iconAnchor,
+      iconOffset,
+      spriteScale,
     }),
-    iconAnchor: placement.iconAnchor,
-    iconOffset: placement.iconOffset,
+    iconAnchor,
+    iconOffset,
   } satisfies ArrowGroupDefinition;
 }
 
@@ -350,7 +368,6 @@ function buildFeatureData(
   const arrows: RenderableGeoJsonFeature<ArrowFeatureProperties>[] = [];
   const renderGroups = new Set<string>();
   const labelGroups = new Set<string>();
-  const arrowGroups = new Set<string>();
   const renderGroupDefs = new Map<string, GroupDefinition>();
   const labelGroupDefs = new Map<string, GroupDefinition>();
   const arrowGroupDefs = new Map<string, ArrowGroupDefinition>();
@@ -374,7 +391,7 @@ function buildFeatureData(
     const markerColor = toRgbaColor(style["marker-color"], 1, "#7e7e7e");
     const markerSize = getMarkerSize(style);
     const strokeWidth = getStrokeWidth(style);
-    const arrowScale = Math.max(0.4, strokeWidth / 2.5);
+    const arrowScale = getArrowRenderScale(strokeWidth);
     const arrowSpriteScale = quantizeArrowSpriteScale(arrowScale);
     const arrowIconScale = arrowScale / arrowSpriteScale;
     const markerSymbol = style["marker-symbol"] || "circle";
@@ -460,11 +477,13 @@ function buildFeatureData(
       const endArrow = style["arrow-end"];
       if (startArrow && startArrow !== "none") {
         const symbolDefinition = getArrowSymbolDefinition(startArrow);
-        const group = getArrowVisibilityGroup(style, "arrow-start", layerId, {
-          iconAnchor: symbolDefinition?.anchorKind ?? "center",
-          iconOffset: symbolDefinition?.globeOffset ?? [0, 0],
-        });
-        arrowGroups.add(group.id);
+        const group = getArrowVisibilityGroup(
+          style,
+          "arrow-start",
+          layerId,
+          symbolDefinition,
+          arrowSpriteScale,
+        );
         arrowGroupDefs.set(group.id, group);
         const imageId = arrowImageId(startArrow, strokeColor, arrowSpriteScale);
         imageDefinitions.set(imageId, {
@@ -493,11 +512,13 @@ function buildFeatureData(
       }
       if (endArrow && endArrow !== "none") {
         const symbolDefinition = getArrowSymbolDefinition(endArrow);
-        const group = getArrowVisibilityGroup(style, "arrow-end", layerId, {
-          iconAnchor: symbolDefinition?.anchorKind ?? "center",
-          iconOffset: symbolDefinition?.globeOffset ?? [0, 0],
-        });
-        arrowGroups.add(group.id);
+        const group = getArrowVisibilityGroup(
+          style,
+          "arrow-end",
+          layerId,
+          symbolDefinition,
+          arrowSpriteScale,
+        );
         arrowGroupDefs.set(group.id, group);
         const imageId = arrowImageId(endArrow, strokeColor, arrowSpriteScale);
         imageDefinitions.set(imageId, {
@@ -538,7 +559,7 @@ function buildFeatureData(
     structureKey: hashObject({
       renderGroups: Array.from(renderGroups).sort(),
       labelGroups: Array.from(labelGroups).sort(),
-      arrowGroups: Array.from(arrowGroups).sort(),
+      arrowGroups: Array.from(arrowGroupDefs.keys()).sort(),
       isHidden: layer.isHidden ?? false,
     }),
   };
@@ -969,7 +990,7 @@ function createMarkerImage(definition: Extract<ImageDefinition, { kind: "marker"
 }
 
 function createArrowImage(definition: Extract<ImageDefinition, { kind: "arrow" }>) {
-  const size = Math.max(28, Math.round(28 * definition.spriteScale));
+  const size = getArrowSpriteCanvasSize(definition.spriteScale);
   return ensureCanvasImageData(size, size, (context) => {
     drawArrowSymbol(context, definition.arrowType, definition.color, size);
   });

--- a/src/modules/globeview/maplibreScenarioFeatures.ts
+++ b/src/modules/globeview/maplibreScenarioFeatures.ts
@@ -78,6 +78,7 @@ type ArrowFeatureProperties = {
   zIndex: number;
   arrowImageId: string;
   iconAnchor: "center" | "right";
+  iconScale: number;
   rotation: number;
   sourceOpacity: number;
 };
@@ -89,6 +90,11 @@ type GroupDefinition = {
   id: string;
   minzoom?: number;
   maxzoom?: number;
+};
+
+type ArrowGroupDefinition = GroupDefinition & {
+  iconAnchor: "center" | "right";
+  iconOffset: [number, number];
 };
 
 type ScenarioLayerRenderPlan = {
@@ -115,6 +121,7 @@ type ImageDefinition =
       kind: "arrow";
       arrowType: ArrowType;
       color: string;
+      spriteScale: number;
     };
 
 function toRgbaColor(
@@ -196,6 +203,25 @@ function getVisibilityGroup(style: StyleLike, suffix: string, layerId: string) {
     minzoom: style.minZoom ?? 0,
     maxzoom: style.maxZoom ?? 24,
   } satisfies GroupDefinition;
+}
+
+function getArrowVisibilityGroup(
+  style: StyleLike,
+  suffix: string,
+  layerId: string,
+  placement: Pick<ArrowGroupDefinition, "iconAnchor" | "iconOffset">,
+) {
+  const baseGroup = getVisibilityGroup(style, suffix, layerId);
+  return {
+    ...baseGroup,
+    id: hashObject({
+      baseGroupId: baseGroup.id,
+      iconAnchor: placement.iconAnchor,
+      iconOffset: placement.iconOffset,
+    }),
+    iconAnchor: placement.iconAnchor,
+    iconOffset: placement.iconOffset,
+  } satisfies ArrowGroupDefinition;
 }
 
 function getTextVisibilityGroup(style: StyleLike, layerId: string) {
@@ -299,11 +325,16 @@ function markerImageId(markerSymbol: string, markerColor: string, markerSize: nu
   })}`;
 }
 
-function arrowImageId(arrowType: string, color: string) {
+function arrowImageId(arrowType: string, color: string, spriteScale: number) {
   return `${GLOBE_SCENARIO_FEATURE_PREFIX}-arrow-${hashObject({
     arrowType,
     color,
+    spriteScale,
   })}`;
+}
+
+function quantizeArrowSpriteScale(scale: number) {
+  return Math.max(1, Math.ceil(scale * 2) / 2);
 }
 
 function buildFeatureData(
@@ -322,7 +353,7 @@ function buildFeatureData(
   const arrowGroups = new Set<string>();
   const renderGroupDefs = new Map<string, GroupDefinition>();
   const labelGroupDefs = new Map<string, GroupDefinition>();
-  const arrowGroupDefs = new Map<string, GroupDefinition>();
+  const arrowGroupDefs = new Map<string, ArrowGroupDefinition>();
   const imageDefinitions = new Map<string, ImageDefinition>();
 
   for (const item of layer.items.filter(isNGeometryLayerItem)) {
@@ -342,6 +373,10 @@ function buildFeatureData(
     const fillColor = toRgbaColor(style.fill, fillOpacity, "#555555");
     const markerColor = toRgbaColor(style["marker-color"], 1, "#7e7e7e");
     const markerSize = getMarkerSize(style);
+    const strokeWidth = getStrokeWidth(style);
+    const arrowScale = Math.max(0.4, strokeWidth / 2.5);
+    const arrowSpriteScale = quantizeArrowSpriteScale(arrowScale);
+    const arrowIconScale = arrowScale / arrowSpriteScale;
     const markerSymbol = style["marker-symbol"] || "circle";
     const markerRenderKind = getMarkerRenderKind(style);
     const markerId =
@@ -374,7 +409,7 @@ function buildFeatureData(
           selected: selectedFeatureIds.has(item.id),
           zIndex: item.meta._zIndex ?? index,
           strokeColor,
-          strokeWidth: getStrokeWidth(style),
+          strokeWidth,
           strokeStyle: style["stroke-style"] || "solid",
           fillColor,
           fillOpacity,
@@ -424,14 +459,19 @@ function buildFeatureData(
       const startArrow = style["arrow-start"];
       const endArrow = style["arrow-end"];
       if (startArrow && startArrow !== "none") {
-        const group = getVisibilityGroup(style, "arrow-start", layerId);
+        const symbolDefinition = getArrowSymbolDefinition(startArrow);
+        const group = getArrowVisibilityGroup(style, "arrow-start", layerId, {
+          iconAnchor: symbolDefinition?.anchorKind ?? "center",
+          iconOffset: symbolDefinition?.globeOffset ?? [0, 0],
+        });
         arrowGroups.add(group.id);
         arrowGroupDefs.set(group.id, group);
-        const imageId = arrowImageId(startArrow, strokeColor);
+        const imageId = arrowImageId(startArrow, strokeColor, arrowSpriteScale);
         imageDefinitions.set(imageId, {
           kind: "arrow",
           arrowType: startArrow,
           color: strokeColor,
+          spriteScale: arrowSpriteScale,
         });
         arrows.push({
           type: "Feature",
@@ -444,21 +484,27 @@ function buildFeatureData(
             selected: selectedFeatureIds.has(item.id),
             zIndex: item.meta._zIndex ?? 0,
             arrowImageId: imageId,
-            iconAnchor: getArrowSymbolDefinition(startArrow)?.anchorKind ?? "center",
+            iconAnchor: group.iconAnchor,
+            iconScale: arrowIconScale,
             rotation: getLineRotation(arrowAnchors.startAdjacent, arrowAnchors.start),
             sourceOpacity,
           },
         });
       }
       if (endArrow && endArrow !== "none") {
-        const group = getVisibilityGroup(style, "arrow-end", layerId);
+        const symbolDefinition = getArrowSymbolDefinition(endArrow);
+        const group = getArrowVisibilityGroup(style, "arrow-end", layerId, {
+          iconAnchor: symbolDefinition?.anchorKind ?? "center",
+          iconOffset: symbolDefinition?.globeOffset ?? [0, 0],
+        });
         arrowGroups.add(group.id);
         arrowGroupDefs.set(group.id, group);
-        const imageId = arrowImageId(endArrow, strokeColor);
+        const imageId = arrowImageId(endArrow, strokeColor, arrowSpriteScale);
         imageDefinitions.set(imageId, {
           kind: "arrow",
           arrowType: endArrow,
           color: strokeColor,
+          spriteScale: arrowSpriteScale,
         });
         arrows.push({
           type: "Feature",
@@ -471,7 +517,8 @@ function buildFeatureData(
             selected: selectedFeatureIds.has(item.id),
             zIndex: item.meta._zIndex ?? 0,
             arrowImageId: imageId,
-            iconAnchor: getArrowSymbolDefinition(endArrow)?.anchorKind ?? "center",
+            iconAnchor: group.iconAnchor,
+            iconScale: arrowIconScale,
             rotation: getLineRotation(arrowAnchors.endAdjacent, arrowAnchors.end),
             sourceOpacity,
           },
@@ -770,8 +817,10 @@ function createLayerDefinitions(
         layout: {
           visibility: layoutVisibility,
           "icon-image": ["get", "arrowImageId"],
+          "icon-size": ["get", "iconScale"],
           "icon-rotate": ["get", "rotation"],
-          "icon-anchor": ["get", "iconAnchor"],
+          "icon-anchor": group.iconAnchor,
+          "icon-offset": ["literal", group.iconOffset],
           "icon-rotation-alignment": "map",
           "icon-pitch-alignment": "map",
           "icon-allow-overlap": true,
@@ -920,7 +969,7 @@ function createMarkerImage(definition: Extract<ImageDefinition, { kind: "marker"
 }
 
 function createArrowImage(definition: Extract<ImageDefinition, { kind: "arrow" }>) {
-  const size = 28;
+  const size = Math.max(28, Math.round(28 * definition.spriteScale));
   return ensureCanvasImageData(size, size, (context) => {
     drawArrowSymbol(context, definition.arrowType, definition.color, size);
   });

--- a/src/modules/globeview/maplibreScenarioFeatures.ts
+++ b/src/modules/globeview/maplibreScenarioFeatures.ts
@@ -17,6 +17,7 @@ import type {
   MapStyleImageMissingEvent,
 } from "maplibre-gl";
 import { fromString as parseColor } from "ol/color";
+import { drawArrowSymbol, getArrowSymbolDefinition } from "@/geo/arrowSymbols";
 import type { FeatureId } from "@/types/scenarioGeoModels";
 import type {
   FullScenarioLayerItemsLayer,
@@ -24,6 +25,7 @@ import type {
 } from "@/types/scenarioLayerItems";
 import { isNGeometryLayerItem } from "@/types/scenarioLayerItems";
 import { hashObject } from "@/utils";
+import type { ArrowType } from "@/geo/simplestyle";
 
 export const GLOBE_SCENARIO_FEATURE_PREFIX = "scenario-feature";
 
@@ -75,6 +77,7 @@ type ArrowFeatureProperties = {
   selected: boolean;
   zIndex: number;
   arrowImageId: string;
+  iconAnchor: "center" | "right";
   rotation: number;
   sourceOpacity: number;
 };
@@ -110,7 +113,7 @@ type ImageDefinition =
     }
   | {
       kind: "arrow";
-      arrowType: string;
+      arrowType: ArrowType;
       color: string;
     };
 
@@ -253,9 +256,7 @@ function getLabelGeometry(geometry: Geometry): Point | undefined {
   }
 }
 
-function getLineArrowAnchors(
-  geometry: Geometry,
-):
+function getLineArrowAnchors(geometry: Geometry):
   | {
       start: Position;
       startAdjacent: Position;
@@ -443,6 +444,7 @@ function buildFeatureData(
             selected: selectedFeatureIds.has(item.id),
             zIndex: item.meta._zIndex ?? 0,
             arrowImageId: imageId,
+            iconAnchor: getArrowSymbolDefinition(startArrow)?.anchorKind ?? "center",
             rotation: getLineRotation(arrowAnchors.startAdjacent, arrowAnchors.start),
             sourceOpacity,
           },
@@ -469,6 +471,7 @@ function buildFeatureData(
             selected: selectedFeatureIds.has(item.id),
             zIndex: item.meta._zIndex ?? 0,
             arrowImageId: imageId,
+            iconAnchor: getArrowSymbolDefinition(endArrow)?.anchorKind ?? "center",
             rotation: getLineRotation(arrowAnchors.endAdjacent, arrowAnchors.end),
             sourceOpacity,
           },
@@ -768,6 +771,7 @@ function createLayerDefinitions(
           visibility: layoutVisibility,
           "icon-image": ["get", "arrowImageId"],
           "icon-rotate": ["get", "rotation"],
+          "icon-anchor": ["get", "iconAnchor"],
           "icon-rotation-alignment": "map",
           "icon-pitch-alignment": "map",
           "icon-allow-overlap": true,
@@ -915,126 +919,10 @@ function createMarkerImage(definition: Extract<ImageDefinition, { kind: "marker"
   });
 }
 
-function drawArrow(
-  context: CanvasRenderingContext2D,
-  arrowType: string,
-  color: string,
-  size: number,
-) {
-  const c = size / 2;
-  context.strokeStyle = color;
-  context.fillStyle = color;
-  context.lineWidth = 2;
-
-  if (arrowType === "dot") {
-    context.beginPath();
-    context.arc(c, c, size * 0.18, 0, Math.PI * 2);
-    context.fill();
-    return;
-  }
-  if (arrowType === "square") {
-    context.fillRect(c - size * 0.16, c - size * 0.16, size * 0.32, size * 0.32);
-    return;
-  }
-  if (arrowType === "diamond") {
-    context.beginPath();
-    context.moveTo(c, c - size * 0.2);
-    context.lineTo(c + size * 0.2, c);
-    context.lineTo(c, c + size * 0.2);
-    context.lineTo(c - size * 0.2, c);
-    context.closePath();
-    context.fill();
-    return;
-  }
-  if (arrowType === "bar") {
-    context.beginPath();
-    context.moveTo(c, size * 0.18);
-    context.lineTo(c, size * 0.82);
-    context.stroke();
-    return;
-  }
-
-  if (arrowType === "arrow-open" || arrowType === "arrow-hand-drawn") {
-    context.beginPath();
-    context.moveTo(size * 0.22, size * 0.18);
-    context.lineTo(size * 0.82, c);
-    context.lineTo(size * 0.22, size * 0.82);
-    context.stroke();
-    if (arrowType === "arrow-hand-drawn") {
-      context.beginPath();
-      context.moveTo(size * 0.28, size * 0.28);
-      context.lineTo(size * 0.74, c);
-      context.lineTo(size * 0.28, size * 0.72);
-      context.stroke();
-    }
-    return;
-  }
-
-  if (arrowType === "arrow-curved") {
-    context.beginPath();
-    context.moveTo(size * 0.16, size * 0.18);
-    context.quadraticCurveTo(size * 0.46, size * 0.18, size * 0.56, size * 0.06);
-    context.lineTo(size * 0.86, c);
-    context.lineTo(size * 0.56, size * 0.94);
-    context.quadraticCurveTo(size * 0.46, size * 0.82, size * 0.16, size * 0.82);
-    context.quadraticCurveTo(size * 0.36, size * 0.6, size * 0.36, c);
-    context.quadraticCurveTo(size * 0.36, size * 0.4, size * 0.16, size * 0.18);
-    context.closePath();
-    context.fill();
-    return;
-  }
-
-  if (arrowType === "arrow-double" || arrowType === "arrow-double-hand-drawn") {
-    context.beginPath();
-    context.moveTo(size * 0.08, size * 0.18);
-    context.lineTo(size * 0.44, c);
-    context.lineTo(size * 0.08, size * 0.82);
-    context.closePath();
-    context.fill();
-    context.beginPath();
-    context.moveTo(size * 0.38, size * 0.18);
-    context.lineTo(size * 0.82, c);
-    context.lineTo(size * 0.38, size * 0.82);
-    context.closePath();
-    context.fill();
-    if (arrowType === "arrow-double-hand-drawn") {
-      context.beginPath();
-      context.moveTo(size * 0.16, size * 0.28);
-      context.lineTo(size * 0.4, c);
-      context.lineTo(size * 0.16, size * 0.72);
-      context.stroke();
-      context.beginPath();
-      context.moveTo(size * 0.44, size * 0.28);
-      context.lineTo(size * 0.74, c);
-      context.lineTo(size * 0.44, size * 0.72);
-      context.stroke();
-    }
-    return;
-  }
-
-  if (arrowType === "arrow-stealth") {
-    context.beginPath();
-    context.moveTo(size * 0.12, size * 0.18);
-    context.lineTo(size * 0.86, c);
-    context.lineTo(size * 0.12, size * 0.82);
-    context.lineTo(size * 0.28, c);
-    context.closePath();
-    context.fill();
-    return;
-  }
-
-  context.beginPath();
-  context.moveTo(size * 0.16, size * 0.18);
-  context.lineTo(size * 0.86, c);
-  context.lineTo(size * 0.16, size * 0.82);
-  context.closePath();
-  context.fill();
-}
-
 function createArrowImage(definition: Extract<ImageDefinition, { kind: "arrow" }>) {
   const size = 28;
   return ensureCanvasImageData(size, size, (context) => {
-    drawArrow(context, definition.arrowType, definition.color, size);
+    drawArrowSymbol(context, definition.arrowType, definition.color, size);
   });
 }
 


### PR DESCRIPTION
## Summary

- Collapse duplicated arrow rendering into `arrowSymbols.ts`: each symbol carries one `tip` attach point, and both the OpenLayers icon anchor and the MapLibre `icon-offset` are derived from it. Sprite scale bucketing, the render-scale formula, and the sprite canvas size now live in one place and are reused by both renderers.
- Shift each directional arrow's `tip` a few units behind the visual apex so the arrow body overshoots the line endpoint and cleanly covers the line's round-cap.
- Fix an inverted sign in the globe offset formula. MapLibre places the `icon-anchor` preset at the feature and then displaces the icon by `icon-offset`, so the offset must point from the tip back to the anchor.
- Inset stroked arrow paths by one viewBox unit to stop round joins/caps from being clipped at the SVG boundary. The `dot` symbol now uses two explicit 180° arcs instead of the degenerate full-circle hack.
- Arrow visibility groups on the globe now key on sprite scale as well, so each layer carries a correct static `icon-offset` instead of a single empirical constant that only worked at one bucket.
- Data URIs switched from base64 to `data:image/svg+xml;utf8,…`, the redundant `arrowGroups` set in `buildFeatureData` is gone, and `DrawArrow.vue` / tests now import `getArrowSvgDataUri` directly from `arrowSymbols`.