### PR TITLE
Support shift+click multi-select in globe mode

### DIFF
--- a/src/composables/geoUnitLayers.ts
+++ b/src/composables/geoUnitLayers.ts
@@ -33,6 +33,7 @@ import { activeScenarioKey } from "@/components/injects";
 import type { EntityId } from "@/types/base";
 import type { TScenario } from "@/scenariostore";
 import { useSelectedItems } from "@/stores/selectedStore";
+import { useSelectionActions } from "@/composables/selectionActions";
 import type { FeatureLike } from "ol/Feature";
 import BaseEvent from "ol/events/Event";
 import { useMapDropTarget } from "@/composables/useMapDropTarget";
@@ -548,11 +549,8 @@ export function useUnitSelectInteraction(
   const enableRef = ref(options.enable ?? true);
   const enableBoxSelectRef = ref(options.enableBoxSelect ?? true);
 
-  const {
-    selectedUnitIds: selectedIds,
-    selectedFeatureIds,
-    clear: clearSelectedItems,
-  } = useSelectedItems();
+  const { selectedUnitIds: selectedIds, clear: clearSelectedItems } = useSelectedItems();
+  const { canAdditivelySelectUnit } = useSelectionActions();
   const activeScenario = injectStrict(activeScenarioKey);
   const {
     geo,
@@ -569,7 +567,7 @@ export function useUnitSelectInteraction(
       clickCondition(event) &&
       getTopHitLayerType(olMap, event.pixel, hitTolerance) !==
         LayerTypes.scenarioFeature &&
-      !(event.originalEvent.shiftKey && selectedFeatureIds.value.size > 0),
+      (!event.originalEvent.shiftKey || canAdditivelySelectUnit()),
     removeCondition: altKeyOnly,
   });
 

--- a/src/composables/selectionActions.test.ts
+++ b/src/composables/selectionActions.test.ts
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useSelectionActions } from "@/composables/selectionActions";
+import { useSelectedItems } from "@/stores/selectedStore";
+
+describe("useSelectionActions", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    const { selectedUnitIds, selectedFeatureIds } = useSelectedItems();
+    selectedUnitIds.value.clear();
+    selectedFeatureIds.value.clear();
+  });
+
+  it("toggles a unit into and out of the selection", () => {
+    const { toggleUnitSelection } = useSelectionActions();
+    const { selectedUnitIds } = useSelectedItems();
+
+    toggleUnitSelection("u-1");
+    expect(selectedUnitIds.value.has("u-1")).toBe(true);
+
+    toggleUnitSelection("u-2");
+    expect(selectedUnitIds.value.has("u-2")).toBe(true);
+    expect(selectedUnitIds.value.size).toBe(2);
+
+    toggleUnitSelection("u-1");
+    expect(selectedUnitIds.value.has("u-1")).toBe(false);
+    expect(selectedUnitIds.value.size).toBe(1);
+  });
+
+  it("refuses to additively select a unit while features are selected", () => {
+    const { toggleUnitSelection, canAdditivelySelectUnit } = useSelectionActions();
+    const { selectedUnitIds, selectedFeatureIds } = useSelectedItems();
+
+    selectedFeatureIds.value.add("f-1");
+    expect(canAdditivelySelectUnit()).toBe(false);
+
+    toggleUnitSelection("u-1");
+    expect(selectedUnitIds.value.size).toBe(0);
+    expect(selectedFeatureIds.value.has("f-1")).toBe(true);
+  });
+
+  it("toggles a feature into and out of the selection", () => {
+    const { toggleFeatureSelection } = useSelectionActions();
+    const { selectedFeatureIds } = useSelectedItems();
+
+    toggleFeatureSelection("f-1");
+    expect(selectedFeatureIds.value.has("f-1")).toBe(true);
+
+    toggleFeatureSelection("f-1");
+    expect(selectedFeatureIds.value.has("f-1")).toBe(false);
+  });
+
+  it("refuses to additively select a feature while units are selected", () => {
+    const { toggleFeatureSelection, canAdditivelySelectFeature } = useSelectionActions();
+    const { selectedUnitIds, selectedFeatureIds } = useSelectedItems();
+
+    selectedUnitIds.value.add("u-1");
+    expect(canAdditivelySelectFeature()).toBe(false);
+
+    toggleFeatureSelection("f-1");
+    expect(selectedFeatureIds.value.size).toBe(0);
+    expect(selectedUnitIds.value.has("u-1")).toBe(true);
+  });
+});

--- a/src/composables/selectionActions.ts
+++ b/src/composables/selectionActions.ts
@@ -1,0 +1,40 @@
+import { useSelectedItems } from "@/stores/selectedStore";
+import type { EntityId } from "@/types/base";
+import type { FeatureId } from "@/types/scenarioGeoModels";
+
+export function useSelectionActions() {
+  const { selectedUnitIds, selectedFeatureIds } = useSelectedItems();
+
+  function canAdditivelySelectUnit() {
+    return selectedFeatureIds.value.size === 0;
+  }
+
+  function canAdditivelySelectFeature() {
+    return selectedUnitIds.value.size === 0;
+  }
+
+  function toggleUnitSelection(unitId: EntityId) {
+    if (!canAdditivelySelectUnit()) return;
+    if (selectedUnitIds.value.has(unitId)) {
+      selectedUnitIds.value.delete(unitId);
+    } else {
+      selectedUnitIds.value.add(unitId);
+    }
+  }
+
+  function toggleFeatureSelection(featureId: FeatureId) {
+    if (!canAdditivelySelectFeature()) return;
+    if (selectedFeatureIds.value.has(featureId)) {
+      selectedFeatureIds.value.delete(featureId);
+    } else {
+      selectedFeatureIds.value.add(featureId);
+    }
+  }
+
+  return {
+    canAdditivelySelectUnit,
+    canAdditivelySelectFeature,
+    toggleUnitSelection,
+    toggleFeatureSelection,
+  };
+}

--- a/src/modules/globeview/MaplibreMap.test.ts
+++ b/src/modules/globeview/MaplibreMap.test.ts
@@ -8,6 +8,7 @@ const setStyle = vi.fn();
 const setProjection = vi.fn();
 const addControl = vi.fn();
 const remove = vi.fn();
+const boxZoomDisable = vi.fn();
 const listeners = new Map<string, Array<(event?: any) => void>>();
 
 vi.mock("maplibre-gl", () => {
@@ -15,6 +16,7 @@ vi.mock("maplibre-gl", () => {
     constructor(_options: unknown) {}
 
     addControl = addControl;
+    boxZoom = { disable: boxZoomDisable };
 
     on(event: string, handler: (event?: any) => void) {
       const handlers = listeners.get(event) ?? [];
@@ -51,6 +53,7 @@ describe("MaplibreMap", () => {
     setProjection.mockClear();
     addControl.mockClear();
     remove.mockClear();
+    boxZoomDisable.mockClear();
     listeners.clear();
   });
 
@@ -90,6 +93,7 @@ describe("MaplibreMap", () => {
 
     expect(setStyle).toHaveBeenCalledTimes(1);
     expect(setProjection).toHaveBeenCalled();
+    expect(boxZoomDisable).toHaveBeenCalled();
   });
 
   it("updates the map style when the style changes without a basemap id change", async () => {

--- a/src/modules/globeview/MaplibreMap.vue
+++ b/src/modules/globeview/MaplibreMap.vue
@@ -34,6 +34,7 @@ onMounted(async () => {
     center: [0, 0], // starting position [lng, lat]
     zoom: 3, // starting zoom
   });
+  mlMap.boxZoom.disable();
   mlMap.addControl(new GlobeControl(), "top-left");
   mlMap.addControl(
     new NavigationControl({

--- a/src/modules/globeview/MlMapLogic.test.ts
+++ b/src/modules/globeview/MlMapLogic.test.ts
@@ -6,6 +6,7 @@ import { computed, ref, shallowRef } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import MlMapLogic from "@/modules/globeview/MlMapLogic.vue";
 import { activeScenarioMapEngineKey, searchActionsKey } from "@/components/injects";
+import { useSelectedItems } from "@/stores/selectedStore";
 
 vi.mock("@/modules/globeview/useGlobeMapDrop.ts", () => ({
   useGlobeMapDrop: () => ({
@@ -215,7 +216,10 @@ describe("MlMapLogic", () => {
       },
     ]);
 
-    mockMap.emit("click", { point: { x: 12, y: 20 } });
+    mockMap.emit("click", {
+      point: { x: 12, y: 20 },
+      originalEvent: { shiftKey: false },
+    });
 
     expect(featureSelectSpy).toHaveBeenCalledWith({
       featureId: "feature-1",
@@ -281,7 +285,10 @@ describe("MlMapLogic", () => {
     ]);
 
     mockMap.emit("mousemove", { point: { x: 1, y: 2 } });
-    mockMap.emit("click", { point: { x: 1, y: 2 } });
+    mockMap.emit("click", {
+      point: { x: 1, y: 2 },
+      originalEvent: { shiftKey: false },
+    });
 
     expect(mockMap.canvas.style.cursor).toBe("pointer");
     expect(unitSelectSpy).toHaveBeenCalledWith({
@@ -289,5 +296,315 @@ describe("MlMapLogic", () => {
       options: { noZoom: true },
     });
     expect(featureSelectSpy).not.toHaveBeenCalled();
+  });
+
+  it("toggles unit selection on shift+click instead of replacing it", () => {
+    const mockMap = createMockMap();
+    const searchActions = createSearchActions();
+    const unitSelectSpy = vi.spyOn(searchActions.onUnitSelectHook, "trigger");
+    const refreshScenarioFeatureLayers = vi.fn();
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-shift",
+          currentTime: 0,
+          featureStateCounter: 0,
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => []),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    const { selectedUnitIds } = useSelectedItems();
+    selectedUnitIds.value.clear();
+    selectedUnitIds.value.add("unit-existing");
+
+    mount(MlMapLogic, {
+      props: {
+        mlMap: mockMap.map,
+        activeScenario,
+      },
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            map: {},
+            layers: { refreshScenarioFeatureLayers },
+          } as any),
+          [searchActionsKey as symbol]: searchActions,
+        },
+      },
+    });
+
+    mockMap.map.queryRenderedFeatures.mockReturnValue([
+      {
+        layer: { id: "unitLayer" },
+        properties: { id: "unit-1" },
+      },
+    ]);
+
+    mockMap.emit("click", {
+      point: { x: 1, y: 2 },
+      originalEvent: { shiftKey: true },
+    });
+
+    expect(unitSelectSpy).not.toHaveBeenCalled();
+    expect(selectedUnitIds.value.has("unit-existing")).toBe(true);
+    expect(selectedUnitIds.value.has("unit-1")).toBe(true);
+
+    mockMap.emit("click", {
+      point: { x: 1, y: 2 },
+      originalEvent: { shiftKey: true },
+    });
+
+    expect(selectedUnitIds.value.has("unit-1")).toBe(false);
+    expect(selectedUnitIds.value.has("unit-existing")).toBe(true);
+  });
+
+  it("clears the selection when clicking empty map area", () => {
+    const mockMap = createMockMap();
+    const searchActions = createSearchActions();
+    const refreshScenarioFeatureLayers = vi.fn();
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-empty-click",
+          currentTime: 0,
+          featureStateCounter: 0,
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => []),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    const { selectedUnitIds, selectedFeatureIds } = useSelectedItems();
+    selectedUnitIds.value.clear();
+    selectedFeatureIds.value.clear();
+    selectedUnitIds.value.add("unit-existing");
+    selectedFeatureIds.value.add("feature-existing");
+
+    mount(MlMapLogic, {
+      props: {
+        mlMap: mockMap.map,
+        activeScenario,
+      },
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            map: {},
+            layers: { refreshScenarioFeatureLayers },
+          } as any),
+          [searchActionsKey as symbol]: searchActions,
+        },
+      },
+    });
+
+    mockMap.map.queryRenderedFeatures.mockReturnValue([]);
+
+    mockMap.emit("click", {
+      point: { x: 1, y: 2 },
+      originalEvent: { shiftKey: false },
+    });
+
+    expect(selectedUnitIds.value.size).toBe(0);
+    expect(selectedFeatureIds.value.size).toBe(0);
+  });
+
+  it("preserves the selection when shift+clicking empty map area", () => {
+    const mockMap = createMockMap();
+    const searchActions = createSearchActions();
+    const refreshScenarioFeatureLayers = vi.fn();
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-empty-shift-click",
+          currentTime: 0,
+          featureStateCounter: 0,
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => []),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    const { selectedUnitIds, selectedFeatureIds } = useSelectedItems();
+    selectedUnitIds.value.clear();
+    selectedFeatureIds.value.clear();
+    selectedUnitIds.value.add("unit-existing");
+
+    mount(MlMapLogic, {
+      props: {
+        mlMap: mockMap.map,
+        activeScenario,
+      },
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            map: {},
+            layers: { refreshScenarioFeatureLayers },
+          } as any),
+          [searchActionsKey as symbol]: searchActions,
+        },
+      },
+    });
+
+    mockMap.map.queryRenderedFeatures.mockReturnValue([]);
+
+    mockMap.emit("click", {
+      point: { x: 1, y: 2 },
+      originalEvent: { shiftKey: true },
+    });
+
+    expect(selectedUnitIds.value.has("unit-existing")).toBe(true);
+  });
+
+  it("does not add a unit to the selection on shift+click when features are selected", () => {
+    const mockMap = createMockMap();
+    const searchActions = createSearchActions();
+    const unitSelectSpy = vi.spyOn(searchActions.onUnitSelectHook, "trigger");
+    const refreshScenarioFeatureLayers = vi.fn();
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-cross-type",
+          currentTime: 0,
+          featureStateCounter: 0,
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => []),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    const { selectedUnitIds, selectedFeatureIds } = useSelectedItems();
+    selectedUnitIds.value.clear();
+    selectedFeatureIds.value.clear();
+    selectedFeatureIds.value.add("feature-existing");
+
+    mount(MlMapLogic, {
+      props: {
+        mlMap: mockMap.map,
+        activeScenario,
+      },
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            map: {},
+            layers: { refreshScenarioFeatureLayers },
+          } as any),
+          [searchActionsKey as symbol]: searchActions,
+        },
+      },
+    });
+
+    mockMap.map.queryRenderedFeatures.mockReturnValue([
+      {
+        layer: { id: "unitLayer" },
+        properties: { id: "unit-1" },
+      },
+    ]);
+
+    mockMap.emit("click", {
+      point: { x: 1, y: 2 },
+      originalEvent: { shiftKey: true },
+    });
+
+    expect(unitSelectSpy).not.toHaveBeenCalled();
+    expect(selectedUnitIds.value.has("unit-1")).toBe(false);
+    expect(selectedFeatureIds.value.has("feature-existing")).toBe(true);
+  });
+
+  it("toggles feature selection on shift+click instead of replacing it", () => {
+    const mockMap = createMockMap();
+    const searchActions = createSearchActions();
+    const featureSelectSpy = vi.spyOn(searchActions.onFeatureSelectHook, "trigger");
+    const refreshScenarioFeatureLayers = vi.fn();
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-shift-feature",
+          currentTime: 0,
+          featureStateCounter: 0,
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => []),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    const { selectedFeatureIds } = useSelectedItems();
+    selectedFeatureIds.value.clear();
+    selectedFeatureIds.value.add("feature-existing");
+
+    mount(MlMapLogic, {
+      props: {
+        mlMap: mockMap.map,
+        activeScenario,
+      },
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            map: {},
+            layers: { refreshScenarioFeatureLayers },
+          } as any),
+          [searchActionsKey as symbol]: searchActions,
+        },
+      },
+    });
+
+    mockMap.map.queryRenderedFeatures.mockReturnValue([
+      {
+        layer: { id: "scenario-feature-layer-1-line" },
+        properties: {
+          featureId: "feature-1",
+          layerId: "layer-1",
+        },
+      },
+    ]);
+
+    mockMap.emit("click", {
+      point: { x: 1, y: 2 },
+      originalEvent: { shiftKey: true },
+    });
+
+    expect(featureSelectSpy).not.toHaveBeenCalled();
+    expect(selectedFeatureIds.value.has("feature-existing")).toBe(true);
+    expect(selectedFeatureIds.value.has("feature-1")).toBe(true);
   });
 });

--- a/src/modules/globeview/MlMapLogic.vue
+++ b/src/modules/globeview/MlMapLogic.vue
@@ -27,6 +27,7 @@ import {
   isManagedScenarioFeatureLayerId,
 } from "@/modules/globeview/maplibreScenarioFeatures";
 import { useSelectedItems } from "@/stores/selectedStore";
+import { useSelectionActions } from "@/composables/selectionActions";
 import { useUiStore } from "@/stores/uiStore";
 
 const { mlMap, activeScenario } = defineProps<{
@@ -51,7 +52,12 @@ const playback = usePlaybackStore();
 const uiStore = useUiStore();
 const engineRef = injectStrict(activeScenarioMapEngineKey);
 const { onUnitSelectHook, onFeatureSelectHook } = injectStrict(searchActionsKey);
-const { selectedFeatureIds, selectedUnitIds } = useSelectedItems();
+const {
+  selectedFeatureIds,
+  selectedUnitIds,
+  clear: clearSelectedItems,
+} = useSelectedItems();
+const { toggleUnitSelection, toggleFeatureSelection } = useSelectionActions();
 const doNotFilterLayers = computed(() => uiStore.layersPanelActive);
 
 const { isDragging, formattedPosition } = useGlobeMapDrop(
@@ -141,16 +147,28 @@ function queryInteractiveFeatures(point: PointLike) {
 
 function onMapClick(e: MapMouseEvent) {
   const topHit = queryInteractiveFeatures(e.point)[0];
-  if (!topHit) return;
+  const additive = e.originalEvent.shiftKey;
+  if (!topHit) {
+    if (!additive) clearSelectedItems();
+    return;
+  }
   if (topHit.layer.id === "unitLayer") {
     const unitId = topHit.properties?.id;
     if (!unitId) return;
+    if (additive) {
+      toggleUnitSelection(unitId);
+      return;
+    }
     onUnitSelectHook.trigger({ unitId, options: { noZoom: true } });
     return;
   }
   const featureId = getFeatureIdFromRenderedFeature(topHit);
   const layerId = getLayerIdFromRenderedFeature(topHit);
   if (!(featureId && layerId)) return;
+  if (additive) {
+    toggleFeatureSelection(featureId);
+    return;
+  }
   onFeatureSelectHook.trigger({ featureId, layerId, options: { noZoom: true } });
 }
 

--- a/src/modules/scenarioeditor/featureLayerUtils.ts
+++ b/src/modules/scenarioeditor/featureLayerUtils.ts
@@ -47,6 +47,7 @@ import {
   isNGeometryLayerItem,
 } from "@/types/scenarioLayerItems";
 import { useScenarioFeatureSelection } from "@/modules/scenarioeditor/useScenarioFeatureSelection";
+import { useSelectionActions } from "@/composables/selectionActions";
 
 const selectStyle = new Style({
   stroke: new Stroke({ color: "#ffff00", width: 9 }),
@@ -240,8 +241,9 @@ export function useScenarioFeatureSelect(
     VectorLayer<any>
   >;
   const { applyScenarioFeatureSelection } = useScenarioFeatureSelection();
+  const { canAdditivelySelectFeature } = useSelectionActions();
 
-  const { selectedFeatureIds: selectedIds, selectedUnitIds } = useSelectedItems();
+  const { selectedFeatureIds: selectedIds } = useSelectedItems();
 
   const enableRef = ref(options.enable ?? true);
   const hitTolerance = 20;
@@ -256,7 +258,7 @@ export function useScenarioFeatureSelect(
       ) {
         return false;
       }
-      return !(event.originalEvent.shiftKey && selectedUnitIds.value.size > 0);
+      return !event.originalEvent.shiftKey || canAdditivelySelectFeature();
     },
     hitTolerance,
     layers: scenarioLayersOl.getArray(),


### PR DESCRIPTION
## Summary
- Disable MapLibre's shift+drag box zoom on the globe map and make the globe click handler toggle units/features in the selection on shift+click, matching OL behavior. Plain clicks on empty map area now clear the selection.
- Extract the "units and features can't be mixed in the same selection" rule into a shared `useSelectionActions` composable so both OL `Select` condition callbacks and the globe click handler enforce it through a single predicate.