### PR TITLE
Redraw range rings reactively and support them in globe mode

### DIFF
--- a/src/components/ScenarioMapLogic.vue
+++ b/src/components/ScenarioMapLogic.vue
@@ -255,6 +255,11 @@ watch(
   },
 );
 
+watch(
+  () => state.rangeRingStateCounter,
+  () => drawRangeRings(),
+);
+
 watch([doNotFilterLayers, () => state.featureStateCounter], () => {
   scenarioLayerController.refreshScenarioFeatureLayers({
     doClearCache: false,

--- a/src/composables/globeRangeRings.ts
+++ b/src/composables/globeRangeRings.ts
@@ -1,0 +1,158 @@
+import type { GeoJSONSource, Map as MlMap } from "maplibre-gl";
+import circle from "@turf/circle";
+import union from "@turf/union";
+import { featureCollection } from "@turf/helpers";
+import { clusterEach } from "@turf/clusters";
+import type { Feature, MultiPolygon, Polygon } from "geojson";
+import { fromString as parseColor } from "ol/color";
+import type { TScenario } from "@/scenariostore";
+import type { NUnit } from "@/types/internalModels";
+import { convertToMetric } from "@/utils/convert";
+
+const RANGE_RING_SOURCE_ID = "rangeRingSource";
+const RANGE_RING_FILL_LAYER_ID = "rangeRingFillLayer";
+const RANGE_RING_LINE_LAYER_ID = "rangeRingLineLayer";
+
+const DEFAULT_STROKE = "#f43f5e";
+
+type RingFeatureProperties = {
+  id: string;
+  isGroup: boolean;
+  strokeColor: string;
+  strokeWidth: number;
+  fillColor: string;
+};
+
+function toRgbaColor(
+  color: string | null | undefined,
+  opacity: number,
+  fallback: string,
+) {
+  const parsed = parseColor(color || fallback);
+  const [r, g, b, a = 1] = Array.isArray(parsed) ? parsed : parseColor(fallback);
+  const nextOpacity = Math.max(0, Math.min(1, a * opacity));
+  return `rgba(${Math.round(r)}, ${Math.round(g)}, ${Math.round(b)}, ${nextOpacity})`;
+}
+
+type RingIdProperties = { id: string; isGroup: boolean };
+
+function createRangeRings(unit: NUnit): Feature<Polygon, RingIdProperties>[] {
+  if (!unit.rangeRings?.length || !unit._state?.location) return [];
+  const out: Feature<Polygon, RingIdProperties>[] = [];
+  unit.rangeRings.forEach((r, i) => {
+    if (r.hidden) return;
+    const ring = circle(
+      unit._state!.location!,
+      convertToMetric(r.range, r.uom || "km") / 1000,
+      {
+        properties: {
+          id: r.group ? r.group : `${unit.id}-${i}`,
+          isGroup: !!r.group,
+        },
+      },
+    ) as Feature<Polygon, RingIdProperties>;
+    out.push(ring);
+  });
+  return out;
+}
+
+export function useGlobeRangeRings(mlMap: MlMap, activeScenario: TScenario) {
+  function setupRangeRingLayers(beforeLayerId?: string) {
+    if (!mlMap.getSource(RANGE_RING_SOURCE_ID)) {
+      mlMap.addSource(RANGE_RING_SOURCE_ID, {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      });
+    }
+    if (!mlMap.getLayer(RANGE_RING_FILL_LAYER_ID)) {
+      mlMap.addLayer(
+        {
+          id: RANGE_RING_FILL_LAYER_ID,
+          type: "fill",
+          source: RANGE_RING_SOURCE_ID,
+          paint: {
+            "fill-color": ["get", "fillColor"],
+          },
+        },
+        beforeLayerId,
+      );
+    }
+    if (!mlMap.getLayer(RANGE_RING_LINE_LAYER_ID)) {
+      mlMap.addLayer(
+        {
+          id: RANGE_RING_LINE_LAYER_ID,
+          type: "line",
+          source: RANGE_RING_SOURCE_ID,
+          paint: {
+            "line-color": ["get", "strokeColor"],
+            "line-width": ["get", "strokeWidth"],
+          },
+        },
+        beforeLayerId,
+      );
+    }
+  }
+
+  function resolveRingStyle(id: string, isGroup: boolean): RingFeatureProperties {
+    let style: Record<string, any> = {};
+    if (isGroup) {
+      style = activeScenario.store.state.rangeRingGroupMap[id]?.style ?? {};
+    } else {
+      const sep = id.lastIndexOf("-");
+      const unitId = id.slice(0, sep);
+      const index = Number(id.slice(sep + 1));
+      const unit = activeScenario.helpers.getUnitById(unitId);
+      style = unit?.rangeRings?.[index]?.style ?? {};
+    }
+    const strokeOpacity = style["stroke-opacity"] ?? 1;
+    const strokeWidth = style["stroke-width"] ?? 2;
+    const strokeColor = toRgbaColor(style.stroke, strokeOpacity, DEFAULT_STROKE);
+    const hasFill = style.fill != null && style.fill !== "";
+    const fillOpacity = hasFill ? (style["fill-opacity"] ?? 0.5) : 0;
+    const fillColor = hasFill
+      ? toRgbaColor(style.fill, fillOpacity, DEFAULT_STROKE)
+      : "rgba(0, 0, 0, 0)";
+    return { id, isGroup, strokeColor, strokeWidth, fillColor };
+  }
+
+  function drawRangeRings() {
+    const source = mlMap.getSource(RANGE_RING_SOURCE_ID) as GeoJSONSource | undefined;
+    if (!source) return;
+
+    const rings = activeScenario.geo.everyVisibleUnit.value
+      .filter((u) => u.rangeRings?.length)
+      .flatMap(createRangeRings);
+
+    const fc = featureCollection(rings);
+    const ungrouped = featureCollection(
+      fc.features.filter((r) => !r.properties!.isGroup),
+    );
+    const grouped = featureCollection(fc.features.filter((r) => r.properties!.isGroup));
+
+    const merged: Feature<Polygon | MultiPolygon>[] = [];
+    clusterEach(grouped, "id", (cluster) => {
+      const m =
+        cluster.features.length > 1
+          ? union(cluster as any, {
+              properties: {
+                id: cluster.features[0].properties!.id,
+                isGroup: true,
+              },
+            })
+          : cluster.features[0];
+      if (m) merged.push(m as Feature<Polygon | MultiPolygon>);
+    });
+
+    const features: Feature<Polygon | MultiPolygon, RingFeatureProperties>[] = [
+      ...merged,
+      ...ungrouped.features,
+    ].map((f) => ({
+      ...f,
+      properties: resolveRingStyle(f.properties!.id, f.properties!.isGroup),
+    }));
+
+    source.setData({ type: "FeatureCollection", features });
+  }
+
+  return { setupRangeRingLayers, drawRangeRings };
+}

--- a/src/modules/globeview/MlMapLogic.vue
+++ b/src/modules/globeview/MlMapLogic.vue
@@ -29,6 +29,7 @@ import {
 import { useSelectedItems } from "@/stores/selectedStore";
 import { useSelectionActions } from "@/composables/selectionActions";
 import { useUiStore } from "@/stores/uiStore";
+import { useGlobeRangeRings } from "@/composables/globeRangeRings";
 
 const { mlMap, activeScenario } = defineProps<{
   mlMap: MlMap;
@@ -60,10 +61,18 @@ const {
 const { toggleUnitSelection, toggleFeatureSelection } = useSelectionActions();
 const doNotFilterLayers = computed(() => uiStore.layersPanelActive);
 
+const { setupRangeRingLayers, drawRangeRings } = useGlobeRangeRings(
+  mlMap,
+  activeScenario,
+);
+
 const { isDragging, formattedPosition } = useGlobeMapDrop(
   engineRef.value!.map,
   activeScenario,
-  () => addUnits(),
+  () => {
+    addUnits();
+    drawRangeRings();
+  },
 );
 function setupMapLayers() {
   !mlMap.getSource("unitSource") &&
@@ -95,6 +104,8 @@ function setupMapLayers() {
         "text-field": ["get", "label"],
       },
     });
+
+  setupRangeRingLayers("unitLayer");
 }
 
 function styleImageMissing(e: MapStyleImageMissingEvent) {
@@ -128,6 +139,7 @@ function onStyleLoad() {
   usedImageIds.clear();
   setupMapLayers();
   addUnits(shouldCenterOnNextStyleLoad);
+  drawRangeRings();
   shouldCenterOnNextStyleLoad = false;
 }
 
@@ -189,7 +201,13 @@ watch(
   () => activeScenario.store.state.currentTime,
   () => {
     addUnits();
+    drawRangeRings();
   },
+);
+
+watch(
+  () => activeScenario.store.state.rangeRingStateCounter,
+  () => drawRangeRings(),
 );
 
 watch(selectedUnitIds, () => addUnits(), { deep: true });

--- a/src/scenariostore/io.test.ts
+++ b/src/scenariostore/io.test.ts
@@ -51,6 +51,7 @@ function createMinimalState(overrides: Partial<ScenarioState> = {}): ScenarioSta
     unitStateCounter: 0,
     featureStateCounter: 0,
     settingsStateCounter: 0,
+    rangeRingStateCounter: 0,
 
     ...overrides,
   } as unknown as ScenarioState;

--- a/src/scenariostore/newScenarioStore.ts
+++ b/src/scenariostore/newScenarioStore.ts
@@ -96,6 +96,7 @@ export interface ScenarioState {
   unitStateCounter: number;
   featureStateCounter: number;
   settingsStateCounter: number; // used to force reactivity
+  rangeRingStateCounter: number;
   mapSettings: MapSettings;
   symbolFillColorMap: Record<string, NSymbolFillColor>;
   customSymbolMap: Record<string, CustomSymbol>;
@@ -149,6 +150,7 @@ export function prepareScenario(newScenario: Scenario | LoadableScenario): Scena
   const unitStateCounter = 0;
   const featureStateCounter = 0;
   const settingsStateCounter = 0;
+  const rangeRingStateCounter = 0;
   const hierarchyChangeTimestamps: number[] = [];
   const hierarchyStateVersion = 0;
   const hierarchyProjectionVersion = -1;
@@ -546,6 +548,7 @@ export function prepareScenario(newScenario: Scenario | LoadableScenario): Scena
     unitStateCounter,
     featureStateCounter,
     settingsStateCounter,
+    rangeRingStateCounter,
     unitStatusMap,
     mapSettings,
     symbolFillColorMap,

--- a/src/scenariostore/rangeRingManipulations.ts
+++ b/src/scenariostore/rangeRingManipulations.ts
@@ -18,6 +18,7 @@ export function useRangeRingManipulations(store: NewScenarioStore) {
       } else {
         unit.rangeRings.push(rangeRing);
       }
+      s.rangeRingStateCounter++;
     });
   }
 
@@ -27,6 +28,7 @@ export function useRangeRingManipulations(store: NewScenarioStore) {
       if (!unit) return;
       if (!unit.rangeRings) return;
       unit.rangeRings.splice(index, 1);
+      s.rangeRingStateCounter++;
     });
   }
 
@@ -53,6 +55,7 @@ export function useRangeRingManipulations(store: NewScenarioStore) {
           unit.rangeRings[index].style = style;
         }
       }
+      s.rangeRingStateCounter++;
     });
   }
 
@@ -86,6 +89,7 @@ export function useRangeRingManipulations(store: NewScenarioStore) {
           group.style = style;
         }
       }
+      s.rangeRingStateCounter++;
     });
   }
 
@@ -97,6 +101,7 @@ export function useRangeRingManipulations(store: NewScenarioStore) {
     const newId = newGroup.id;
     update((s) => {
       s.rangeRingGroupMap[newId] = newGroup;
+      s.rangeRingStateCounter++;
     });
   }
 
@@ -111,6 +116,7 @@ export function useRangeRingManipulations(store: NewScenarioStore) {
     if (isUsed) return false;
     update((s) => {
       delete s.rangeRingGroupMap[id];
+      s.rangeRingStateCounter++;
     });
     return true;
   }


### PR DESCRIPTION
## Summary
- Fix: range rings in map mode now redraw immediately when parameters or styles change. Added a `rangeRingStateCounter` that is bumped by all range ring mutations; `ScenarioMapLogic` watches it and calls `drawRangeRings()`.
- Feature: range rings render in globe mode. New `useGlobeRangeRings` composable builds Turf circles per ring, unions rings that share a group, and publishes a GeoJSON source with fill + line layers underneath the unit symbol layer. The layers are wired into `MlMapLogic` and redraw on drop, time changes, and range ring state changes.