### PR TITLE
Add unit history support to globe mode

### DIFF
--- a/src/composables/globeUnitHistory.ts
+++ b/src/composables/globeUnitHistory.ts
@@ -1,0 +1,405 @@
+import type {
+  GeoJSONSource,
+  MapLayerMouseEvent,
+  MapMouseEvent,
+  Map as MlMap,
+} from "maplibre-gl";
+import type { FeatureCollection } from "geojson";
+import { storeToRefs } from "pinia";
+import { watch } from "vue";
+import { getDistance } from "ol/sphere";
+import type { TScenario } from "@/scenariostore";
+import { createUnitPathGeoJson } from "@/geo/history";
+import { useSelectedItems } from "@/stores/selectedStore";
+import { useSelectedWaypoints } from "@/stores/selectedWaypoints";
+import { useUnitSettingsStore } from "@/stores/geoStore";
+import { useTimeFormatStore } from "@/stores/timeFormatStore";
+import { convertSpeedToMetric } from "@/utils/convert";
+
+const ARC_SOURCE_ID = "unitHistoryArcSource";
+const LEG_SOURCE_ID = "unitHistoryLegSource";
+const WAYPOINT_SOURCE_ID = "unitHistoryWaypointSource";
+const VIA_SOURCE_ID = "unitHistoryViaSource";
+
+const ARC_LAYER_ID = "unitHistoryArcLayer";
+const LEG_LAYER_ID = "unitHistoryLegLayer";
+const WAYPOINT_LAYER_ID = "unitHistoryWaypointLayer";
+const WAYPOINT_LABEL_LAYER_ID = "unitHistoryWaypointLabelLayer";
+const VIA_LAYER_ID = "unitHistoryViaLayer";
+
+export const UNIT_HISTORY_LAYER_IDS = [
+  ARC_LAYER_ID,
+  LEG_LAYER_ID,
+  VIA_LAYER_ID,
+  WAYPOINT_LAYER_ID,
+  WAYPOINT_LABEL_LAYER_ID,
+];
+
+const EMPTY_FC: FeatureCollection = { type: "FeatureCollection", features: [] };
+
+export function useGlobeUnitHistory(mlMap: MlMap, activeScenario: TScenario) {
+  const { geo, unitActions } = activeScenario;
+  const state = activeScenario.store.state;
+  const getUnitById = (id: string) => activeScenario.helpers?.getUnitById(id);
+
+  const { selectedUnitIds } = useSelectedItems();
+  const { selectedWaypointIds } = useSelectedWaypoints();
+  selectedWaypointIds.value.clear();
+  const unitSettings = useUnitSettingsStore();
+  const { showHistory, editHistory, showWaypointTimestamps } = storeToRefs(unitSettings);
+  const fmt = useTimeFormatStore();
+
+  const appliedWaypointStates = new Set<string>();
+  let dragState: {
+    unitId: string;
+    waypointId: string;
+    t: number;
+    isInitial: boolean;
+  } | null = null;
+
+  function setupUnitHistoryLayers(beforeLayerId?: string) {
+    for (const id of [ARC_SOURCE_ID, LEG_SOURCE_ID, WAYPOINT_SOURCE_ID, VIA_SOURCE_ID]) {
+      if (!mlMap.getSource(id)) {
+        mlMap.addSource(id, { type: "geojson", data: EMPTY_FC });
+      }
+    }
+    if (!mlMap.getLayer(ARC_LAYER_ID)) {
+      mlMap.addLayer(
+        {
+          id: ARC_LAYER_ID,
+          type: "line",
+          source: ARC_SOURCE_ID,
+          paint: {
+            "line-color": "rgba(255,0,0,0.65)",
+            "line-width": 2,
+          },
+        },
+        beforeLayerId,
+      );
+    }
+    if (!mlMap.getLayer(LEG_LAYER_ID)) {
+      mlMap.addLayer(
+        {
+          id: LEG_LAYER_ID,
+          type: "line",
+          source: LEG_SOURCE_ID,
+          paint: {
+            "line-color": "rgba(255,0,0,0.65)",
+            "line-width": 2,
+          },
+        },
+        beforeLayerId,
+      );
+    }
+    if (!mlMap.getLayer(VIA_LAYER_ID)) {
+      mlMap.addLayer(
+        {
+          id: VIA_LAYER_ID,
+          type: "circle",
+          source: VIA_SOURCE_ID,
+          paint: {
+            "circle-radius": 4,
+            "circle-color": "rgba(101,213,57,0.73)",
+            "circle-stroke-color": "green",
+            "circle-stroke-width": 1,
+          },
+        },
+        beforeLayerId,
+      );
+    }
+    if (!mlMap.getLayer(WAYPOINT_LAYER_ID)) {
+      mlMap.addLayer(
+        {
+          id: WAYPOINT_LAYER_ID,
+          type: "circle",
+          source: WAYPOINT_SOURCE_ID,
+          paint: {
+            "circle-radius": 5,
+            "circle-color": [
+              "case",
+              ["boolean", ["feature-state", "selected"], false],
+              "red",
+              "orange",
+            ],
+            "circle-stroke-color": [
+              "case",
+              ["boolean", ["feature-state", "selected"], false],
+              "yellow",
+              "green",
+            ],
+            "circle-stroke-width": 3,
+          },
+        },
+        beforeLayerId,
+      );
+    }
+    if (!mlMap.getLayer(WAYPOINT_LABEL_LAYER_ID)) {
+      mlMap.addLayer(
+        {
+          id: WAYPOINT_LABEL_LAYER_ID,
+          type: "symbol",
+          source: WAYPOINT_SOURCE_ID,
+          layout: {
+            "text-field": ["get", "label"],
+            "text-font": ["Noto Sans Italic"],
+            "text-offset": [1, -1],
+            "text-anchor": "left",
+            "text-size": 12,
+            "text-allow-overlap": false,
+            "text-optional": true,
+            "text-ignore-placement": false,
+          },
+          paint: {
+            "text-color": "#aa3300",
+            "text-halo-color": "white",
+            "text-halo-width": 2,
+          },
+        },
+        beforeLayerId,
+      );
+    }
+    applyVisibility();
+  }
+
+  function applyVisibility() {
+    const set = (layerId: string, visible: boolean) => {
+      if (!mlMap.getLayer(layerId)) return;
+      mlMap.setLayoutProperty(layerId, "visibility", visible ? "visible" : "none");
+    };
+    const base = showHistory.value;
+    set(ARC_LAYER_ID, base);
+    set(LEG_LAYER_ID, base && editHistory.value);
+    set(VIA_LAYER_ID, base);
+    set(WAYPOINT_LAYER_ID, base);
+    set(WAYPOINT_LABEL_LAYER_ID, base && showWaypointTimestamps.value);
+    if (mlMap.getLayer(ARC_LAYER_ID)) {
+      mlMap.setPaintProperty(ARC_LAYER_ID, "line-opacity", editHistory.value ? 0.4 : 1);
+    }
+  }
+
+  function clearWaypointFeatureStates() {
+    for (const id of appliedWaypointStates) {
+      try {
+        mlMap.removeFeatureState({ source: WAYPOINT_SOURCE_ID, id });
+      } catch {
+        // source may be gone during style reload
+      }
+    }
+    appliedWaypointStates.clear();
+  }
+
+  function applyWaypointFeatureStates() {
+    clearWaypointFeatureStates();
+    selectedWaypointIds.value.forEach((id) => {
+      try {
+        mlMap.setFeatureState({ source: WAYPOINT_SOURCE_ID, id }, { selected: true });
+        appliedWaypointStates.add(id);
+      } catch {
+        // source may be gone during style reload
+      }
+    });
+  }
+
+  function drawHistory() {
+    const arcSource = mlMap.getSource(ARC_SOURCE_ID) as GeoJSONSource | undefined;
+    const legSource = mlMap.getSource(LEG_SOURCE_ID) as GeoJSONSource | undefined;
+    const waypointSource = mlMap.getSource(WAYPOINT_SOURCE_ID) as
+      | GeoJSONSource
+      | undefined;
+    const viaSource = mlMap.getSource(VIA_SOURCE_ID) as GeoJSONSource | undefined;
+    if (!arcSource || !legSource || !waypointSource || !viaSource) return;
+
+    applyVisibility();
+
+    if (!showHistory.value) {
+      arcSource.setData({ type: "FeatureCollection", features: [] });
+      legSource.setData({ type: "FeatureCollection", features: [] });
+      waypointSource.setData({ type: "FeatureCollection", features: [] });
+      viaSource.setData({ type: "FeatureCollection", features: [] });
+      clearWaypointFeatureStates();
+      return;
+    }
+
+    const allArcs: any[] = [];
+    const allLegs: any[] = [];
+    const allWaypoints: any[] = [];
+    const allVia: any[] = [];
+    selectedUnitIds.value.forEach((unitId) => {
+      const unit = getUnitById(unitId);
+      if (!unit?._state?.location) return;
+      const path = createUnitPathGeoJson(unit);
+      allArcs.push(...path.arcs);
+      if (editHistory.value) allLegs.push(...path.legs);
+      allWaypoints.push(...path.waypoints);
+      allVia.push(...path.viaPoints);
+    });
+
+    arcSource.setData({ type: "FeatureCollection", features: allArcs });
+    legSource.setData({ type: "FeatureCollection", features: allLegs });
+    waypointSource.setData({ type: "FeatureCollection", features: allWaypoints });
+    viaSource.setData({ type: "FeatureCollection", features: allVia });
+
+    applyWaypointFeatureStates();
+  }
+
+  function handleCtrlClick(e: MapMouseEvent): boolean {
+    if (selectedUnitIds.value.size === 0) return false;
+    const lngLat: [number, number] = [e.lngLat.lng, e.lngLat.lat];
+    selectedUnitIds.value.forEach((unitId) => {
+      const unit = getUnitById(unitId);
+      if (!unit) return;
+      const lastLocationEntry = unit.state?.filter((s) => s.location).pop();
+      let newTime: number | undefined;
+      if (lastLocationEntry) {
+        const { location, t } = lastLocationEntry;
+        const distance = getDistance(location!, lngLat);
+        const speedValue = unit.properties?.averageSpeed || unit.properties?.maxSpeed;
+        const speed = speedValue
+          ? convertSpeedToMetric(speedValue.value, speedValue.uom)
+          : convertSpeedToMetric(30, "km/h");
+        const travel = distance / speed;
+        newTime = Math.round(t + travel * 1000);
+      }
+      geo.addUnitPosition(unitId, lngLat, newTime);
+    });
+    drawHistory();
+    return true;
+  }
+
+  /**
+   * Handles a map click. Returns true if the history system consumed the event
+   * so the caller can skip its own click handling.
+   */
+  function handleMapClick(e: MapMouseEvent): boolean {
+    if (!showHistory.value) return false;
+    const originalEvent = e.originalEvent;
+    const isCtrl =
+      (originalEvent.metaKey || originalEvent.ctrlKey) &&
+      !originalEvent.shiftKey &&
+      !originalEvent.altKey;
+
+    const hits = mlMap
+      .queryRenderedFeatures(e.point, { layers: [WAYPOINT_LAYER_ID] })
+      .filter((f) => f.layer?.id === WAYPOINT_LAYER_ID);
+    if (hits.length > 0) {
+      const feature = hits[0];
+      const unitId = feature.properties?.unitId as string | undefined;
+      const waypointId = feature.id as string | undefined;
+      const stateIndex = (feature.properties?.stateIndex as number) ?? -1;
+      const isInitial = feature.properties?.isInitial === true;
+
+      if (originalEvent.altKey && !originalEvent.shiftKey) {
+        if (unitId && !isInitial && stateIndex >= 0) {
+          unitActions.deleteUnitStateEntry(unitId, stateIndex);
+          drawHistory();
+        }
+        return true;
+      }
+      if (waypointId) {
+        if (selectedWaypointIds.value.has(waypointId)) {
+          selectedWaypointIds.value.delete(waypointId);
+        } else {
+          selectedWaypointIds.value.add(waypointId);
+        }
+        applyWaypointFeatureStates();
+      }
+      return true;
+    }
+
+    if (isCtrl) return handleCtrlClick(e);
+    return false;
+  }
+
+  function onWaypointMouseDown(e: MapLayerMouseEvent) {
+    if (!editHistory.value) return;
+    const feature = e.features?.[0];
+    if (!feature) return;
+    const unitId = feature.properties?.unitId as string | undefined;
+    const waypointId = feature.id as string | undefined;
+    const t = feature.properties?.t as number | undefined;
+    const isInitial = feature.properties?.isInitial === true;
+    if (!unitId || !waypointId || t === undefined) return;
+
+    e.preventDefault();
+    dragState = { unitId, waypointId, t, isInitial };
+    mlMap.getCanvas().style.cursor = "grabbing";
+    mlMap.on("mousemove", onDragMove);
+    mlMap.once("mouseup", onDragEnd);
+  }
+
+  function onDragMove(e: MapMouseEvent) {
+    if (!dragState) return;
+    const waypointSource = mlMap.getSource(WAYPOINT_SOURCE_ID) as
+      | GeoJSONSource
+      | undefined;
+    if (!waypointSource) return;
+    // Visually move just the dragged waypoint by rewriting its coordinates.
+    const data = (waypointSource as any)._data as FeatureCollection | undefined;
+    if (!data) return;
+    const next: FeatureCollection = {
+      type: "FeatureCollection",
+      features: data.features.map((f) => {
+        if (f.id !== dragState!.waypointId) return f;
+        return {
+          ...f,
+          geometry: {
+            type: "Point",
+            coordinates: [e.lngLat.lng, e.lngLat.lat],
+          },
+        };
+      }),
+    };
+    waypointSource.setData(next);
+  }
+
+  function onDragEnd(e: MapMouseEvent) {
+    mlMap.off("mousemove", onDragMove);
+    if (!dragState) return;
+    const { unitId, t, isInitial } = dragState;
+    dragState = null;
+    mlMap.getCanvas().style.cursor = "";
+    const lngLat: [number, number] = [e.lngLat.lng, e.lngLat.lat];
+    if (isInitial) {
+      // Dragging the initial location (unit origin) is not supported.
+      drawHistory();
+      return;
+    }
+    geo.addUnitPosition(unitId, lngLat, t);
+    drawHistory();
+  }
+
+  mlMap.on("mousedown", WAYPOINT_LAYER_ID, onWaypointMouseDown);
+
+  activeScenario.store.onUndoRedo?.(({ meta }) => {
+    if (meta?.value && selectedUnitIds.value.has(meta.value as string)) {
+      drawHistory();
+    }
+  });
+
+  watch([showHistory, editHistory, showWaypointTimestamps], () => drawHistory());
+  watch(
+    () => [...selectedUnitIds.value],
+    () => drawHistory(),
+  );
+  watch(
+    () => state.unitStateCounter,
+    () => drawHistory(),
+  );
+  watch(
+    () => fmt.trackFormatter,
+    () => drawHistory(),
+  );
+
+  function dispose() {
+    mlMap.off("mousedown", WAYPOINT_LAYER_ID, onWaypointMouseDown);
+    mlMap.off("mousemove", onDragMove);
+    clearWaypointFeatureStates();
+  }
+
+  return {
+    setupUnitHistoryLayers,
+    drawHistory,
+    handleMapClick,
+    dispose,
+  };
+}

--- a/src/geo/history.ts
+++ b/src/geo/history.ts
@@ -6,7 +6,12 @@ import type { LocationState, Unit } from "@/types/scenarioModels";
 import type { NUnit } from "@/types/internalModels";
 import { greatCircle } from "@turf/great-circle";
 import { getDistance } from "ol/sphere";
-import type { Position } from "geojson";
+import type {
+  Feature as GeoJsonFeature,
+  LineString as GeoJsonLineString,
+  Point as GeoJsonPoint,
+  Position,
+} from "geojson";
 import type { GeometryLayout } from "ol/geom/Geometry";
 import Fill from "ol/style/Fill";
 import Stroke from "ol/style/Stroke";
@@ -266,6 +271,128 @@ function createGreatCircleArcFeature(leg: Position[]) {
     }
   }
   return coords;
+}
+
+export interface UnitPathGeoJson {
+  legs: GeoJsonFeature<GeoJsonLineString>[];
+  arcs: GeoJsonFeature<GeoJsonLineString>[];
+  waypoints: GeoJsonFeature<GeoJsonPoint>[];
+  viaPoints: GeoJsonFeature<GeoJsonPoint>[];
+}
+
+function createArcCoords(leg: Position[]): Position[] {
+  const coords: Position[] = [];
+  for (let i = 0; i < leg.length - 1; i++) {
+    const from = leg[i];
+    const to = leg[i + 1];
+    const distance = getDistance(from, to);
+    if (distance > 100000) {
+      const arcLine = greatCircle(from, to, {
+        offset: -100000,
+        npoints: Math.min(Math.ceil(distance / 200000), 50),
+      });
+      if (arcLine.geometry.type === "LineString") {
+        coords.push(...(arcLine.geometry.coordinates as Position[]));
+      } else {
+        for (const line of arcLine.geometry.coordinates) {
+          coords.push(...(line as Position[]));
+        }
+      }
+    } else {
+      coords.push(from, to);
+    }
+  }
+  return coords;
+}
+
+export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
+  const fmt = useTimeFormatStore();
+  const state = [
+    { location: unit.location, t: Number.MIN_SAFE_INTEGER },
+    ...(unit.state || []),
+  ].filter((s) => s.location !== undefined) as LocationState[];
+
+  const parts = splitLocationStateIntoParts(state);
+
+  const waypoints: GeoJsonFeature<GeoJsonPoint>[] = [];
+  const viaPoints: GeoJsonFeature<GeoJsonPoint>[] = [];
+  const legs: GeoJsonFeature<GeoJsonLineString>[] = [];
+  const arcs: GeoJsonFeature<GeoJsonLineString>[] = [];
+
+  let waypointIndex = 0;
+  parts.forEach((part) => {
+    part.forEach((s) => {
+      waypointIndex += 1;
+      const isInitial = s.t === Number.MIN_SAFE_INTEGER;
+      const label = isInitial
+        ? `#${waypointIndex}`
+        : `#${waypointIndex} ${fmt.trackFormatter.format(s.t)}`;
+      const stateIndex = isInitial
+        ? -1
+        : (unit.state?.findIndex((entry) => entry.t === s.t) ?? -1);
+      const feature: GeoJsonFeature<GeoJsonPoint> = {
+        type: "Feature",
+        geometry: {
+          type: "Point",
+          coordinates: [s.location[0], s.location[1]],
+        },
+        properties: {
+          unitId: unit.id,
+          waypointId: s.id,
+          t: s.t,
+          stateIndex,
+          label,
+          isInitial,
+        },
+      };
+      if (s.id !== undefined) feature.id = s.id;
+      waypoints.push(feature);
+      s.via?.forEach((viaCoord, viaIndex) => {
+        viaPoints.push({
+          type: "Feature",
+          geometry: {
+            type: "Point",
+            coordinates: [viaCoord[0], viaCoord[1]],
+          },
+          properties: {
+            unitId: unit.id,
+            stateIndex,
+            viaIndex,
+          },
+        });
+      });
+    });
+
+    if (part.length < 2) return;
+    const segment: Position[] = [];
+    for (let i = 0; i < part.length - 1; i++) {
+      const from = part[i];
+      const to = part[i + 1];
+      if (i === 0) segment.push([from.location[0], from.location[1]]);
+      if (to.via) {
+        to.via.forEach((v) => segment.push([v[0], v[1]]));
+      }
+      segment.push([to.location[0], to.location[1]]);
+    }
+    legs.push({
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: unwindCoordinates(segment),
+      },
+      properties: { unitId: unit.id },
+    });
+    arcs.push({
+      type: "Feature",
+      geometry: {
+        type: "LineString",
+        coordinates: unwindCoordinates(createArcCoords(segment)),
+      },
+      properties: { unitId: unit.id },
+    });
+  });
+
+  return { legs, arcs, waypoints, viaPoints };
 }
 
 function splitLocationStateIntoParts(state: LocationState[]): LocationState[][] {

--- a/src/modules/globeview/MlMapLogic.test.ts
+++ b/src/modules/globeview/MlMapLogic.test.ts
@@ -73,6 +73,10 @@ function createMockMap() {
     addLayer: vi.fn((layer: { id: string }) => {
       layers.set(layer.id, layer);
     }),
+    setLayoutProperty: vi.fn(),
+    setPaintProperty: vi.fn(),
+    setFeatureState: vi.fn(),
+    removeFeatureState: vi.fn(),
     hasImage: vi.fn(() => false),
     addImage: vi.fn(),
     queryRenderedFeatures: vi.fn(() => []),

--- a/src/modules/globeview/MlMapLogic.vue
+++ b/src/modules/globeview/MlMapLogic.vue
@@ -30,6 +30,10 @@ import { useSelectedItems } from "@/stores/selectedStore";
 import { useSelectionActions } from "@/composables/selectionActions";
 import { useUiStore } from "@/stores/uiStore";
 import { useGlobeRangeRings } from "@/composables/globeRangeRings";
+import {
+  UNIT_HISTORY_LAYER_IDS,
+  useGlobeUnitHistory,
+} from "@/composables/globeUnitHistory";
 
 const { mlMap, activeScenario } = defineProps<{
   mlMap: MlMap;
@@ -66,12 +70,20 @@ const { setupRangeRingLayers, drawRangeRings } = useGlobeRangeRings(
   activeScenario,
 );
 
+const {
+  setupUnitHistoryLayers,
+  drawHistory,
+  handleMapClick: handleHistoryMapClick,
+  dispose: disposeUnitHistory,
+} = useGlobeUnitHistory(mlMap, activeScenario);
+
 const { isDragging, formattedPosition } = useGlobeMapDrop(
   engineRef.value!.map,
   activeScenario,
   () => {
     addUnits();
     drawRangeRings();
+    drawHistory();
   },
 );
 function setupMapLayers() {
@@ -106,6 +118,7 @@ function setupMapLayers() {
     });
 
   setupRangeRingLayers("unitLayer");
+  setupUnitHistoryLayers("unitLayer");
 }
 
 function styleImageMissing(e: MapStyleImageMissingEvent) {
@@ -158,6 +171,7 @@ function onStyleLoad() {
   setupMapLayers();
   addUnits(shouldCenterOnNextStyleLoad);
   drawRangeRings();
+  drawHistory();
   shouldCenterOnNextStyleLoad = false;
 }
 
@@ -171,11 +185,13 @@ function queryInteractiveFeatures(point: PointLike) {
     .filter(
       (feature) =>
         feature.layer.id === "unitLayer" ||
+        UNIT_HISTORY_LAYER_IDS.includes(feature.layer.id) ||
         isManagedScenarioFeatureLayerId(feature.layer.id),
     );
 }
 
 function onMapClick(e: MapMouseEvent) {
+  if (handleHistoryMapClick(e)) return;
   const topHit = queryInteractiveFeatures(e.point)[0];
   const additive = e.originalEvent.shiftKey;
   if (!topHit) {
@@ -217,6 +233,14 @@ if (activeScenario.store.state.id === "demo-falklands82") {
 
 watch(
   () => activeScenario.store.state.currentTime,
+  () => {
+    addUnits();
+    drawRangeRings();
+  },
+);
+
+watch(
+  () => activeScenario.store.state.unitStateCounter,
   () => {
     addUnits();
     drawRangeRings();
@@ -292,6 +316,7 @@ function addUnits(initial = false) {
 
 onUnmounted(() => {
   if (!mlMap) return;
+  disposeUnitHistory();
   mlMap.off("styleimagemissing", styleImageMissing);
   mlMap.off("style.load", onStyleLoad);
   mlMap.off("click", onMapClick);


### PR DESCRIPTION
## Summary
- Renders unit tracks, waypoints, via points, and labels for selected units on the MapLibre globe, respecting the existing `showHistory` / `editHistory` / `showWaypointTimestamps` toggles from the Track toolbar.
- Mirrors OL interactions: ctrl/meta+click adds a position to selected units (with travel-time estimation), click toggles waypoint selection, alt+click deletes a waypoint, and dragging a waypoint in edit mode moves it.
- Factors the pure path-building logic into a new `createUnitPathGeoJson` helper in `src/geo/history.ts` so both engines share the same geometry/labeling rules.