### PR TITLE
Align globe context menu with map mode actions

### DIFF
--- a/src/modules/globeview/GlobeContextMenu.test.ts
+++ b/src/modules/globeview/GlobeContextMenu.test.ts
@@ -3,11 +3,57 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent, h, inject, ref, toRef } from "vue";
 import { mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
+import {
+  activeLayerKey,
+  activeScenarioKey,
+  searchActionsKey,
+} from "@/components/injects";
 import GlobeContextMenu from "@/modules/globeview/GlobeContextMenu.vue";
 import { useBaseLayersStore } from "@/stores/baseLayersStore";
 import { GLOBE_VECTOR_BASEMAP_ID } from "@/modules/globeview/globeBasemaps";
 import { usePlaybackStore } from "@/stores/playbackStore";
 import { useUiStore } from "@/stores/uiStore";
+import { useSelectedItems } from "@/stores/selectedStore";
+import { useRecordingStore } from "@/stores/recordingStore";
+
+vi.mock("@/composables/mainToolbarData", () => ({
+  useActiveSidc: () => ({
+    sidc: ref("SFGPUCI----K"),
+    symbolOptions: ref({}),
+  }),
+}));
+
+vi.mock("@/stores/dragStore", () => ({
+  useActiveUnitStore: () => ({
+    activeParent: ref({
+      id: "parent-1",
+      subUnits: [],
+    }),
+  }),
+}));
+
+vi.mock("@/stores/mainToolbarStore.ts", () => ({
+  useMainToolbarStore: () => ({
+    currentDrawStyle: {},
+  }),
+}));
+
+vi.mock("@/stores/timeFormatStore", () => ({
+  useTimeFormatStore: () => ({
+    scenarioFormatter: {
+      format: (value: number) => `time:${value}`,
+    },
+  }),
+}));
+
+vi.mock("@/modules/scenarioeditor/featureLayerUtils", () => ({
+  getGeometryIcon: vi.fn(() =>
+    defineComponent({
+      name: "GeometryIconStub",
+      template: "<span />",
+    }),
+  ),
+}));
 
 const radioGroupKey = Symbol("radio-group");
 
@@ -149,15 +195,70 @@ describe("GlobeContextMenu", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
     vi.useRealTimers();
+    useSelectedItems().clear();
+    const playback = usePlaybackStore();
+    playback.playbackRunning = false;
+    playback.playbackLooping = false;
+    playback.clearMarkers();
   });
 
   function mountMenu(props?: Record<string, unknown>) {
-    return mount(GlobeContextMenu, {
+    const feature = {
+      id: "feature-1",
+      meta: {
+        name: "Feature 1",
+      },
+    };
+    const scenario = {
+      store: {
+        state: {
+          currentTime: 123,
+        },
+        groupUpdate: (fn: () => void) => fn(),
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+        isUnitLocked: vi.fn(() => false),
+        createSubordinateUnit: vi.fn(() => "unit-2"),
+      },
+      geo: {
+        addUnitPosition: vi.fn(),
+        addFeature: vi.fn(),
+        getLayerById: vi.fn(() => ({ id: "layer-1", items: [] })),
+        getGeometryLayerItemById: vi.fn((id: string) => ({
+          layerItem: id === "feature-1" ? feature : undefined,
+        })),
+        layerItemsLayers: ref([{ id: "layer-1", items: [] }]),
+      },
+      helpers: {
+        getUnitById: vi.fn((id: string) =>
+          id === "unit-1"
+            ? {
+                id: "unit-1",
+                sidc: "SFGPUCI----K",
+                name: "Unit 1",
+              }
+            : undefined,
+        ),
+      },
+    } as any;
+    const searchHooks = {
+      onScenarioActionHook: {
+        trigger: vi.fn(),
+      },
+    } as any;
+
+    const wrapper = mount(GlobeContextMenu, {
       props,
       slots: {
         default: "<div data-testid='trigger'>Trigger</div>",
       },
       global: {
+        provide: {
+          [activeScenarioKey as symbol]: scenario,
+          [activeLayerKey as symbol]: ref("layer-1"),
+          [searchActionsKey as symbol]: searchHooks,
+        },
         stubs: {
           ContextMenu: ContextMenuStub,
           ContextMenuTrigger: ContextMenuTriggerStub,
@@ -171,9 +272,13 @@ describe("GlobeContextMenu", () => {
           ContextMenuSubTrigger: ContextMenuSubTriggerStub,
           ContextMenuRadioGroup: ContextMenuRadioGroupStub,
           ContextMenuRadioItem: ContextMenuRadioItemStub,
+          MilitarySymbol: true,
+          UnitSymbol: true,
         },
       },
     });
+
+    return { wrapper, scenario, searchHooks };
   }
 
   it("updates the bound globe basemap when a basemap is selected", async () => {
@@ -199,7 +304,7 @@ describe("GlobeContextMenu", () => {
       },
     ] as any;
 
-    const wrapper = mountMenu({
+    const { wrapper } = mountMenu({
       baseMapId: selectedBasemap.value,
       "onUpdate:baseMapId": async (value: string) => {
         selectedBasemap.value = value;
@@ -213,7 +318,7 @@ describe("GlobeContextMenu", () => {
   });
 
   it("re-dispatches captured contextmenu events through the trigger", async () => {
-    const wrapper = mountMenu();
+    const { wrapper } = mountMenu();
 
     const triggerWrapper = wrapper.get(".h-full.w-full");
     const dispatchSpy = vi.spyOn(triggerWrapper.element, "dispatchEvent");
@@ -231,7 +336,7 @@ describe("GlobeContextMenu", () => {
   it("opens the context menu on touch long press", async () => {
     vi.useFakeTimers();
 
-    const wrapper = mountMenu();
+    const { wrapper } = mountMenu();
 
     const triggerWrapper = wrapper.get(".h-full.w-full");
     const dispatchSpy = vi.spyOn(triggerWrapper.element, "dispatchEvent");
@@ -255,7 +360,7 @@ describe("GlobeContextMenu", () => {
   });
 
   it("defaults to the vector globe basemap", () => {
-    const wrapper = mountMenu();
+    const { wrapper } = mountMenu();
 
     expect(wrapper.exists()).toBe(true);
     expect(
@@ -269,7 +374,7 @@ describe("GlobeContextMenu", () => {
     uiStore.showTimeline = true;
     uiStore.showOrbatBreadcrumbs = true;
 
-    const wrapper = mountMenu();
+    const { wrapper } = mountMenu();
     const buttons = wrapper.findAll("button");
 
     await buttons.find((button) => button.text() === "Map toolbar")?.trigger("click");
@@ -290,17 +395,69 @@ describe("GlobeContextMenu", () => {
     const increaseSpy = vi.spyOn(playback, "increaseSpeed");
     const decreaseSpy = vi.spyOn(playback, "decreaseSpeed");
 
-    const wrapper = mountMenu();
+    const { wrapper } = mountMenu();
     const buttons = wrapper.findAll("button");
 
     await buttons.find((button) => button.text().includes("Play"))?.trigger("click");
     await buttons.find((button) => button.text().includes("Speed up"))?.trigger("click");
     await buttons.find((button) => button.text().includes("Slow down"))?.trigger("click");
     await buttons.find((button) => button.text() === "Loop playback")?.trigger("click");
+    await buttons
+      .find((button) => button.text().includes("Add marker"))
+      ?.trigger("click");
+    await buttons.find((button) => button.text() === "Clear markers")?.trigger("click");
 
     expect(playback.playbackRunning).toBe(true);
     expect(increaseSpy).toHaveBeenCalled();
     expect(decreaseSpy).toHaveBeenCalled();
     expect(playback.playbackLooping).toBe(true);
+    expect(playback.startMarker).toBeUndefined();
+    expect(playback.endMarker).toBeUndefined();
+  });
+
+  it("shows clicked units and features from the globe map hit test", async () => {
+    const mapRef = {
+      getContainer: () => ({
+        getBoundingClientRect: () => ({ left: 0, top: 0 }),
+      }),
+      unproject: () => ({ lng: 10, lat: 20 }),
+      getZoom: () => 7,
+      queryRenderedFeatures: () => [
+        {
+          layer: { id: "unitLayer" },
+          properties: { id: "unit-1" },
+        },
+        {
+          layer: { id: "scenario-feature-layer-1-fill" },
+          properties: { featureId: "feature-1", layerId: "layer-1" },
+        },
+      ],
+    };
+
+    const { wrapper } = mountMenu({ mapRef });
+
+    await wrapper.get(".h-full.w-full").trigger("contextmenu", {
+      button: 2,
+      clientX: 10,
+      clientY: 20,
+    });
+
+    expect(wrapper.text()).toContain("Unit 1");
+    expect(wrapper.text()).toContain("Feature 1");
+    expect(wrapper.text()).toContain("Open in");
+    expect(wrapper.text()).toContain("Map as image");
+  });
+
+  it("triggers the shared export action from the globe context menu", async () => {
+    const { wrapper, searchHooks } = mountMenu();
+
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Map as image")
+      ?.trigger("click");
+
+    expect(searchHooks.onScenarioActionHook.trigger).toHaveBeenCalledWith({
+      action: "exportToImage",
+    });
   });
 });

--- a/src/modules/globeview/GlobeContextMenu.vue
+++ b/src/modules/globeview/GlobeContextMenu.vue
@@ -14,24 +14,74 @@ import {
   ContextMenuTrigger,
 } from "@/components/ui/context-menu";
 import {
+  IconClockEnd,
+  IconClockStart,
+  IconContentCopy,
+  IconMapMarker as PointIcon,
   IconPause,
   IconPlay,
   IconSpeedometer,
   IconSpeedometerSlow,
 } from "@iconify-prerendered/vue-mdi";
+import type { Position } from "geojson";
+import type { Map as MlMap } from "maplibre-gl";
 import { useBaseLayersStore } from "@/stores/baseLayersStore";
 import { computed, ref } from "vue";
-import { breakpointsTailwind, useBreakpoints } from "@vueuse/core";
+import { breakpointsTailwind, useBreakpoints, useClipboard } from "@vueuse/core";
 import {
   GLOBE_VECTOR_BASEMAP_ID,
   getSupportedGlobeBasemaps,
 } from "@/modules/globeview/globeBasemaps";
+import {
+  getFeatureIdFromRenderedFeature,
+  isManagedScenarioFeatureLayerId,
+} from "@/modules/globeview/maplibreScenarioFeatures";
 import { usePlaybackStore } from "@/stores/playbackStore";
 import { useUiStore } from "@/stores/uiStore";
+import { useMapSettingsStore } from "@/stores/mapSettingsStore";
+import { getCoordinateFormatFunction } from "@/utils/geoConvert";
+import { storeToRefs } from "pinia";
+import { useNotifications } from "@/composables/notifications";
+import { getGeometryIcon } from "@/modules/scenarioeditor/featureLayerUtils";
+import { injectStrict, nanoid } from "@/utils";
+import {
+  activeLayerKey,
+  activeScenarioKey,
+  searchActionsKey,
+} from "@/components/injects";
+import type { NGeometryLayerItem, NUnit } from "@/types/internalModels";
+import { useSelectedItems } from "@/stores/selectedStore";
+import MilitarySymbol from "@/components/MilitarySymbol.vue";
+import { useTimeFormatStore } from "@/stores/timeFormatStore";
+import { useActiveSidc } from "@/composables/mainToolbarData";
+import { useActiveUnitStore } from "@/stores/dragStore";
+import { useMainToolbarStore } from "@/stores/mainToolbarStore.ts";
+import UnitSymbol from "@/components/UnitSymbol.vue";
+import { useRecordingStore } from "@/stores/recordingStore";
 
 const baseLayersStore = useBaseLayersStore();
+const {
+  store,
+  unitActions,
+  geo,
+  helpers: { getUnitById },
+} = injectStrict(activeScenarioKey);
+const activeLayerId = injectStrict(activeLayerKey);
+const { onScenarioActionHook } = injectStrict(searchActionsKey);
 const playback = usePlaybackStore();
+const tm = useTimeFormatStore();
 const uiSettings = useUiStore();
+const mainToolbarStore = useMainToolbarStore();
+const recordingStore = useRecordingStore();
+const { send } = useNotifications();
+const { copy: copyToClipboard } = useClipboard();
+const { coordinateFormat } = storeToRefs(useMapSettingsStore());
+const { activeUnitId, activeFeatureId, selectedUnitIds, selectedFeatureIds } =
+  useSelectedItems();
+const { activeParent } = useActiveUnitStore();
+const { sidc, symbolOptions } = useActiveSidc();
+
+const props = defineProps<{ mapRef?: MlMap }>();
 const baseMapId = defineModel<string>("baseMapId", {
   default: GLOBE_VECTOR_BASEMAP_ID,
 });
@@ -41,6 +91,10 @@ const breakpoints = useBreakpoints(breakpointsTailwind);
 const isMobile = breakpoints.smallerOrEqual("md");
 
 const triggerRef = ref<HTMLDivElement | null>(null);
+const clickedUnits = ref<NUnit[]>([]);
+const clickedFeatures = ref<NGeometryLayerItem[]>([]);
+const dropPosition = ref<Position>([0, 0]);
+const mapZoomLevel = ref(0);
 const LONG_PRESS_MS = 550;
 const MOVE_TOLERANCE_PX = 10;
 
@@ -48,6 +102,10 @@ let longPressTimer: ReturnType<typeof setTimeout> | null = null;
 let activePointerId: number | null = null;
 let startX = 0;
 let startY = 0;
+
+const formattedPosition = computed(() =>
+  getCoordinateFormatFunction(coordinateFormat.value)(dropPosition.value),
+);
 
 function clearLongPressTimer() {
   if (longPressTimer) {
@@ -105,6 +163,151 @@ function onPointerEnd(event: PointerEvent) {
   clearLongPressTimer();
   activePointerId = null;
 }
+
+function returnMapProviders(lonLat: Position, zoomLevel: number) {
+  return [
+    {
+      name: "Bing Maps",
+      url: `https://www.bing.com/maps?cp=${lonLat[1]}~${lonLat[0]}&lvl=${zoomLevel}`,
+    },
+    {
+      name: "Geohack",
+      url: `https://geohack.toolforge.org/geohack.php?params=${lonLat[1]}_N_${lonLat[0]}_E`,
+    },
+    {
+      name: "Google Maps",
+      url: `https://www.google.com/maps/@${lonLat[1]},${lonLat[0]},${zoomLevel}z`,
+    },
+    {
+      name: "Google Street View",
+      url:
+        "https://www.google.com/maps/@?api=1&map_action=pano&viewpoint=" +
+        lonLat[1] +
+        "," +
+        lonLat[0],
+    },
+    {
+      name: "OpenStreetMap",
+      url: `https://www.openstreetmap.org/#map=15/${lonLat[1]}/${lonLat[0]}`,
+    },
+  ];
+}
+
+async function onCopy() {
+  await copyToClipboard(formattedPosition.value);
+  send({
+    message: `Copied ${formattedPosition.value} to the clipboard`,
+  });
+}
+
+async function onExport() {
+  await onScenarioActionHook.trigger({ action: "exportToImage" });
+}
+
+function onUnitSelect(unit: NUnit, event: MouseEvent | PointerEvent | KeyboardEvent) {
+  if (event.shiftKey) {
+    if (selectedUnitIds.value.has(unit.id)) {
+      selectedUnitIds.value.delete(unit.id);
+    } else {
+      selectedUnitIds.value.add(unit.id);
+    }
+  } else {
+    activeUnitId.value = unit.id;
+  }
+}
+
+function onFeatureSelect(
+  feature: NGeometryLayerItem,
+  event: MouseEvent | PointerEvent | KeyboardEvent,
+) {
+  if (event.shiftKey) {
+    if (selectedFeatureIds.value.has(feature.id)) {
+      selectedFeatureIds.value.delete(feature.id);
+    } else {
+      selectedFeatureIds.value.add(feature.id);
+    }
+  } else {
+    activeFeatureId.value = feature.id;
+  }
+}
+
+function onAddUnit() {
+  if (!recordingStore.isRecordingLocation) return;
+  store.groupUpdate(() => {
+    if (!activeParent.value || unitActions.isUnitLocked(activeParent.value.id)) return;
+
+    const name = `${(activeParent.value.subUnits?.length ?? 0) + 1}`;
+
+    const unitId = unitActions.createSubordinateUnit(activeParent.value.id, {
+      sidc: sidc.value,
+      name,
+    });
+    unitId && geo.addUnitPosition(unitId, dropPosition.value);
+  });
+}
+
+function onAddPoint() {
+  const activeLayer = geo.getLayerById(
+    activeLayerId.value ?? geo.layerItemsLayers.value[0]?.id,
+  );
+  if (!activeLayer) return;
+  const name = `Point ${(activeLayer.items.length ?? 0) + 1}`;
+
+  const newFeature: Omit<NGeometryLayerItem, "_pid"> = {
+    kind: "geometry" as const,
+    type: "Feature",
+    id: nanoid(),
+    meta: {
+      type: "Point",
+      name,
+    },
+    geometry: {
+      type: "Point",
+      coordinates: dropPosition.value,
+    },
+    style: mainToolbarStore.currentDrawStyle ?? {},
+    properties: {},
+  };
+  geo.addFeature(newFeature, activeLayer.id);
+}
+
+function onContextMenu(event: MouseEvent) {
+  const { mapRef } = props;
+  if (!mapRef) return;
+
+  const rect = mapRef.getContainer().getBoundingClientRect();
+  const point: [number, number] = [event.clientX - rect.left, event.clientY - rect.top];
+  const lngLat = mapRef.unproject(point);
+
+  dropPosition.value = [lngLat.lng, lngLat.lat];
+  mapZoomLevel.value = mapRef.getZoom() ?? 0;
+  clickedUnits.value = [];
+  clickedFeatures.value = [];
+
+  const seenUnitIds = new Set<string>();
+  const seenFeatureIds = new Set<string>();
+
+  for (const renderedFeature of mapRef.queryRenderedFeatures(point)) {
+    if (renderedFeature.layer.id === "unitLayer") {
+      const unitId = renderedFeature.properties?.id
+        ? String(renderedFeature.properties.id)
+        : undefined;
+      if (!unitId || seenUnitIds.has(unitId)) continue;
+      seenUnitIds.add(unitId);
+      const unit = getUnitById(unitId);
+      unit && clickedUnits.value.push(unit);
+      continue;
+    }
+
+    if (!isManagedScenarioFeatureLayerId(renderedFeature.layer.id)) continue;
+
+    const featureId = getFeatureIdFromRenderedFeature(renderedFeature);
+    if (!featureId || seenFeatureIds.has(featureId)) continue;
+    seenFeatureIds.add(featureId);
+    const { layerItem } = geo.getGeometryLayerItemById(featureId);
+    layerItem && clickedFeatures.value.push(layerItem);
+  }
+}
 </script>
 
 <template>
@@ -113,6 +316,7 @@ function onPointerEnd(event: PointerEvent) {
       <div
         ref="triggerRef"
         class="h-full w-full"
+        @contextmenu="onContextMenu"
         @pointerdown="onPointerDown"
         @pointermove="onPointerMove"
         @pointerup="onPointerEnd"
@@ -122,6 +326,94 @@ function onPointerEnd(event: PointerEvent) {
       </div>
     </ContextMenuTrigger>
     <ContextMenuContent>
+      <ContextMenuItem @select.prevent="onCopy()">
+        <IconContentCopy class="mr-2 h-4 w-4" />
+        <span>{{ formattedPosition }}</span>
+      </ContextMenuItem>
+      <ContextMenuSeparator />
+      <ContextMenuSub v-if="clickedUnits.length > 0">
+        <ContextMenuSubTrigger inset
+          ><span>Units</span>&nbsp;
+          <span class="text-muted-foreground font-medium"
+            >({{ clickedUnits.length }})</span
+          ></ContextMenuSubTrigger
+        >
+        <ContextMenuSubContent class="max-h-[95vh] overflow-auto">
+          <ContextMenuItem
+            v-for="unit in clickedUnits"
+            :key="unit.id"
+            @select.prevent
+            @click="onUnitSelect(unit, $event)"
+          >
+            <div class="flex items-center">
+              <span class="flex w-7 items-center">
+                <UnitSymbol
+                  :sidc="unit.sidc"
+                  class="w-6"
+                  :options="unitActions.getCombinedSymbolOptions(unit)"
+                />
+              </span>
+              <span :class="[selectedUnitIds.has(unit.id) ? 'font-semibold' : '']">{{
+                unit.name
+              }}</span>
+            </div>
+          </ContextMenuItem>
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+      <ContextMenuSub v-if="clickedFeatures.length > 0">
+        <ContextMenuSubTrigger inset
+          ><span>Features</span>&nbsp;
+          <span class="text-muted-foreground font-medium"
+            >({{ clickedFeatures.length }})</span
+          ></ContextMenuSubTrigger
+        >
+        <ContextMenuSubContent class="max-h-[95vh] overflow-auto">
+          <ContextMenuItem
+            v-for="feature in clickedFeatures"
+            :key="feature.id"
+            @select.prevent
+            @click="onFeatureSelect(feature, $event)"
+          >
+            <div class="flex items-center">
+              <component
+                :is="getGeometryIcon(feature)"
+                class="text-muted-foreground mr-1 h-5 w-5"
+              />
+              <span :class="[selectedFeatureIds.has(feature.id) ? 'font-semibold' : '']">
+                {{ feature.meta.name }}
+              </span>
+            </div>
+          </ContextMenuItem>
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+      <ContextMenuSeparator v-if="clickedFeatures.length || clickedUnits.length" />
+      <ContextMenuSub>
+        <ContextMenuSubTrigger inset><span>Add</span></ContextMenuSubTrigger>
+        <ContextMenuSubContent>
+          <ContextMenuItem
+            @select.prevent="onAddUnit"
+            :disabled="!recordingStore.isRecordingLocation"
+          >
+            <MilitarySymbol
+              :sidc="sidc"
+              :options="symbolOptions"
+              :size="15"
+              class="w-8"
+            />
+            Unit
+          </ContextMenuItem>
+          <ContextMenuItem @select.prevent="onAddPoint">
+            <PointIcon />
+            Point/marker
+          </ContextMenuItem>
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+      <ContextMenuSub>
+        <ContextMenuSubTrigger inset><span>Export</span></ContextMenuSubTrigger>
+        <ContextMenuSubContent>
+          <ContextMenuItem @select.prevent="onExport()">Map as image</ContextMenuItem>
+        </ContextMenuSubContent>
+      </ContextMenuSub>
       <ContextMenuSub>
         <ContextMenuSubTrigger inset>Map base layer</ContextMenuSubTrigger>
         <ContextMenuSubContent>
@@ -134,6 +426,19 @@ function onPointerEnd(event: PointerEvent) {
               {{ option.title }}
             </ContextMenuRadioItem>
           </ContextMenuRadioGroup>
+        </ContextMenuSubContent>
+      </ContextMenuSub>
+      <ContextMenuSub>
+        <ContextMenuSubTrigger inset><span>Open in</span></ContextMenuSubTrigger>
+        <ContextMenuSubContent>
+          <ContextMenuItem
+            v-for="{ name, url } in returnMapProviders(dropPosition, mapZoomLevel)"
+            :key="url"
+            inset
+            as-child
+          >
+            <a :href="url" target="_blank">{{ name }}</a>
+          </ContextMenuItem>
         </ContextMenuSubContent>
       </ContextMenuSub>
       <ContextMenuSub>
@@ -159,6 +464,37 @@ function onPointerEnd(event: PointerEvent) {
           <ContextMenuCheckboxItem v-model="playback.playbackLooping" @select.prevent>
             Loop playback
           </ContextMenuCheckboxItem>
+          <ContextMenuItem
+            inset
+            @select.prevent="playback.addMarker(store.state.currentTime)"
+          >
+            Add marker
+            <span class="ml-1"
+              >({{
+                playback.startMarker && playback.endMarker
+                  ? 2
+                  : playback.startMarker || playback.endMarker
+                    ? 1
+                    : 0
+              }}
+              / 2)</span
+            >
+          </ContextMenuItem>
+          <ContextMenuItem
+            inset
+            @select.prevent="playback.clearMarkers()"
+            :disabled="!playback.startMarker && !playback.endMarker"
+          >
+            Clear markers
+          </ContextMenuItem>
+          <ContextMenuItem v-if="playback.startMarker !== undefined" disabled>
+            <IconClockStart class="mr-2 h-4 w-4" />
+            <span>{{ tm.scenarioFormatter.format(playback.startMarker) }}</span>
+          </ContextMenuItem>
+          <ContextMenuItem v-if="playback.endMarker !== undefined" disabled>
+            <IconClockEnd class="mr-2 h-4 w-4" />
+            <span>{{ tm.scenarioFormatter.format(playback.endMarker) }}</span>
+          </ContextMenuItem>
         </ContextMenuSubContent>
       </ContextMenuSub>
       <ContextMenuSeparator />

--- a/src/modules/globeview/MaplibreMap.test.ts
+++ b/src/modules/globeview/MaplibreMap.test.ts
@@ -10,10 +10,13 @@ const addControl = vi.fn();
 const remove = vi.fn();
 const boxZoomDisable = vi.fn();
 const listeners = new Map<string, Array<(event?: any) => void>>();
+const mapConstructor = vi.fn();
 
 vi.mock("maplibre-gl", () => {
   class MockMap {
-    constructor(_options: unknown) {}
+    constructor(options: unknown) {
+      mapConstructor(options);
+    }
 
     addControl = addControl;
     boxZoom = { disable: boxZoomDisable };
@@ -54,6 +57,7 @@ describe("MaplibreMap", () => {
     addControl.mockClear();
     remove.mockClear();
     boxZoomDisable.mockClear();
+    mapConstructor.mockClear();
     listeners.clear();
   });
 
@@ -94,6 +98,11 @@ describe("MaplibreMap", () => {
     expect(setStyle).toHaveBeenCalledTimes(1);
     expect(setProjection).toHaveBeenCalled();
     expect(boxZoomDisable).toHaveBeenCalled();
+    expect(mapConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        canvasContextAttributes: expect.objectContaining({ preserveDrawingBuffer: true }),
+      }),
+    );
   });
 
   it("updates the map style when the style changes without a basemap id change", async () => {

--- a/src/modules/globeview/MaplibreMap.vue
+++ b/src/modules/globeview/MaplibreMap.vue
@@ -33,6 +33,9 @@ onMounted(async () => {
     style: props.styleSpec,
     center: [0, 0], // starting position [lng, lat]
     zoom: 3, // starting zoom
+    canvasContextAttributes: {
+      preserveDrawingBuffer: true,
+    },
   });
   mlMap.boxZoom.disable();
   mlMap.addControl(new GlobeControl(), "top-left");

--- a/src/modules/globeview/MlMapLogic.test.ts
+++ b/src/modules/globeview/MlMapLogic.test.ts
@@ -8,6 +8,10 @@ import MlMapLogic from "@/modules/globeview/MlMapLogic.vue";
 import { activeScenarioMapEngineKey, searchActionsKey } from "@/components/injects";
 import { useSelectedItems } from "@/stores/selectedStore";
 
+const { saveMapLibreMapAsPng } = vi.hoisted(() => ({
+  saveMapLibreMapAsPng: vi.fn(),
+}));
+
 vi.mock("@/modules/globeview/useGlobeMapDrop.ts", () => ({
   useGlobeMapDrop: () => ({
     isDragging: ref(false),
@@ -37,6 +41,10 @@ vi.mock("@vueuse/core", async () => {
     }),
   };
 });
+
+vi.mock("@/modules/globeview/mapLibreExport", () => ({
+  saveMapLibreMapAsPng,
+}));
 
 function createSearchActions() {
   return {
@@ -105,6 +113,7 @@ function createMockMap() {
 describe("MlMapLogic", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    saveMapLibreMapAsPng.mockReset();
   });
 
   it("creates the unit layer immediately when mounted after the initial map load", () => {
@@ -610,5 +619,50 @@ describe("MlMapLogic", () => {
     expect(featureSelectSpy).not.toHaveBeenCalled();
     expect(selectedFeatureIds.value.has("feature-existing")).toBe(true);
     expect(selectedFeatureIds.value.has("feature-1")).toBe(true);
+  });
+
+  it("exports the globe map when the shared scenario action is triggered", async () => {
+    const mockMap = createMockMap();
+    const searchActions = createSearchActions();
+    const refreshScenarioFeatureLayers = vi.fn();
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-export",
+          currentTime: 0,
+          featureStateCounter: 0,
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => []),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    mount(MlMapLogic, {
+      props: {
+        mlMap: mockMap.map,
+        activeScenario,
+      },
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            map: {},
+            layers: { refreshScenarioFeatureLayers },
+          } as any),
+          [searchActionsKey as symbol]: searchActions,
+        },
+      },
+    });
+
+    await searchActions.onScenarioActionHook.trigger({ action: "exportToImage" });
+
+    expect(saveMapLibreMapAsPng).toHaveBeenCalledWith(mockMap.map);
   });
 });

--- a/src/modules/globeview/MlMapLogic.vue
+++ b/src/modules/globeview/MlMapLogic.vue
@@ -34,6 +34,7 @@ import {
   UNIT_HISTORY_LAYER_IDS,
   useGlobeUnitHistory,
 } from "@/composables/globeUnitHistory";
+import { saveMapLibreMapAsPng } from "@/modules/globeview/mapLibreExport";
 
 const { mlMap, activeScenario } = defineProps<{
   mlMap: MlMap;
@@ -56,7 +57,8 @@ let shouldCenterOnNextStyleLoad = true;
 const playback = usePlaybackStore();
 const uiStore = useUiStore();
 const engineRef = injectStrict(activeScenarioMapEngineKey);
-const { onUnitSelectHook, onFeatureSelectHook } = injectStrict(searchActionsKey);
+const { onUnitSelectHook, onFeatureSelectHook, onScenarioActionHook } =
+  injectStrict(searchActionsKey);
 const {
   selectedFeatureIds,
   selectedUnitIds,
@@ -274,6 +276,11 @@ watch(
     });
   },
 );
+
+onScenarioActionHook.on(async ({ action }) => {
+  if (action !== "exportToImage") return;
+  await saveMapLibreMapAsPng(mlMap);
+});
 
 function addUnits(initial = false) {
   const source = mlMap.getSource("unitSource") as GeoJSONSource;

--- a/src/modules/globeview/ScenarioEditorGlobe.vue
+++ b/src/modules/globeview/ScenarioEditorGlobe.vue
@@ -255,7 +255,7 @@ const headerControlsStyle = computed(() =>
     @close-details-panel="onCloseDetailsPanel()"
   >
     <template #map>
-      <GlobeContextMenu v-model:base-map-id="globeBaseMapId">
+      <GlobeContextMenu v-model:base-map-id="globeBaseMapId" :map-ref="mlMap">
         <MaplibreMap
           @ready="onMapReady"
           :basemap-id="activeGlobeBasemap.id"

--- a/src/modules/globeview/mapLibreExport.ts
+++ b/src/modules/globeview/mapLibreExport.ts
@@ -1,0 +1,18 @@
+import type { Map as MlMap } from "maplibre-gl";
+import { saveBlobToLocalFile } from "@/utils/files";
+
+export async function saveMapLibreMapAsPng(
+  map: MlMap,
+  options: { fileName?: string } = {},
+) {
+  const fileName = options.fileName ?? "image.png";
+  const canvas = map.getCanvas();
+  if (!(canvas instanceof HTMLCanvasElement)) return;
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/png"),
+  );
+  if (!blob) return;
+
+  await saveBlobToLocalFile(blob, fileName);
+}


### PR DESCRIPTION
## Summary
- Add missing globe context menu actions to match map mode outside of the existing base layer and map settings differences
- Support globe-specific hit testing for units and features, coordinate copy, add actions, export, open-in links, and playback markers
- Wire globe image export through the shared `exportToImage` action and add a MapLibre PNG export helper
- Configure the MapLibre canvas for export and pass the live map instance into the globe context menu
- Expand globe tests to cover the new menu entries and export path

## Testing
- `npm test -- GlobeContextMenu.test.ts`
- `npm test -- MlMapLogic.test.ts`
- `npm test -- MaplibreMap.test.ts`
- `pnpm type-check`