### PR TITLE
Add view constraints to map settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added view constraints support (max extent, min/max zoom) to map settings. Constraints are saved as part of the scenario. Not supported in globe mode yet.
+- Added view constraints support (max extent, min/max zoom) to map settings. Constraints are saved as part of the scenario.
 - Added experimental globe mode.
 - Added a standalone symbol browser page at `/symbol-browser`.
 - Added symbol export with copy and download as PNG and SVG, with configurable size and display options.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added view constraints support (max extent, min/max zoom) to map settings. Constraints are saved as part of the scenario. Not supported in globe mode yet.
 - Added experimental globe mode.
 - Added a standalone symbol browser page at `/symbol-browser`.
 - Added symbol export with copy and download as PNG and SVG, with configurable size and display options.

--- a/src/composables/geoMapLocation.test.ts
+++ b/src/composables/geoMapLocation.test.ts
@@ -65,6 +65,10 @@ function createFakeMapAdapter(initialCursor = ""): FakeMapAdapter {
     getResolutionForZoom(_zoom: number) {
       return undefined;
     },
+    getViewConstraints() {
+      return {};
+    },
+    setViewConstraints() {},
     updateSize() {},
     toLonLat(coordinate: number[]) {
       return coordinate as [number, number];

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,6 +1,6 @@
 import type { ScenarioVersion } from "@/types/scenarioModels";
 
-export const SCENARIO_FILE_VERSION: ScenarioVersion = "3.0.0";
+export const SCENARIO_FILE_VERSION: ScenarioVersion = "3.1.0";
 export const LOCALSTORAGE_KEY = "orbat-scenario4";
 export const SHARE_HISTORY_LOCALSTORAGE_KEY = "orbat-share-history";
 

--- a/src/geo/contracts/mapAdapter.ts
+++ b/src/geo/contracts/mapAdapter.ts
@@ -14,9 +14,9 @@ export interface AnimateOptions {
 }
 
 export interface ViewConstraints {
-  extent?: [number, number, number, number];
-  minZoom?: number;
-  maxZoom?: number;
+  extent?: [number, number, number, number] | null;
+  minZoom?: number | null;
+  maxZoom?: number | null;
 }
 
 export type MapEventType = "moveend" | "click" | "pointermove" | "singleclick";

--- a/src/geo/contracts/mapAdapter.ts
+++ b/src/geo/contracts/mapAdapter.ts
@@ -13,6 +13,12 @@ export interface AnimateOptions {
   duration?: number;
 }
 
+export interface ViewConstraints {
+  extent?: [number, number, number, number];
+  minZoom?: number;
+  maxZoom?: number;
+}
+
 export type MapEventType = "moveend" | "click" | "pointermove" | "singleclick";
 
 export interface MapEvent {
@@ -34,6 +40,8 @@ export interface MapAdapter {
   getResolution(): number | undefined;
   getRotation(): number;
   getResolutionForZoom(zoom: number): number | undefined;
+  getViewConstraints(): ViewConstraints;
+  setViewConstraints(constraints: ViewConstraints): void;
   updateSize(): void;
 
   // Coordinate conversion

--- a/src/geo/engines/openlayers/olMapAdapter.test.ts
+++ b/src/geo/engines/openlayers/olMapAdapter.test.ts
@@ -59,7 +59,7 @@ describe("OlMapAdapter", () => {
       const { olMap } = createMockMap();
       const adapter = new OlMapAdapter(olMap as any);
 
-      adapter.setViewConstraints({ extent: null as any });
+      adapter.setViewConstraints({ extent: null });
 
       expect(olMap.setView).toHaveBeenCalledTimes(1);
     });

--- a/src/geo/engines/openlayers/olMapAdapter.test.ts
+++ b/src/geo/engines/openlayers/olMapAdapter.test.ts
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { OlMapAdapter } from "@/geo/engines/openlayers/olMapAdapter";
+
+function createMockView(overrides: Record<string, any> = {}) {
+  return {
+    getProjection: vi.fn(() => "EPSG:3857"),
+    getCenter: vi.fn(() => [0, 0]),
+    getZoom: vi.fn(() => 5),
+    getRotation: vi.fn(() => 0),
+    getMinZoom: vi.fn(() => 0),
+    getMaxZoom: vi.fn(() => 28),
+    setMinZoom: vi.fn(),
+    setMaxZoom: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createMockMap(viewOverrides: Record<string, any> = {}) {
+  const view = createMockView(viewOverrides);
+
+  const olMap = {
+    getView: vi.fn(() => view),
+    setView: vi.fn(),
+    updateSize: vi.fn(),
+    on: vi.fn(),
+    once: vi.fn(),
+    getSize: vi.fn(() => [800, 600]),
+    getEventCoordinate: vi.fn(() => [0, 0]),
+    getTargetElement: vi.fn(() => document.createElement("div")),
+  };
+
+  return { olMap, view };
+}
+
+describe("OlMapAdapter", () => {
+  describe("setViewConstraints", () => {
+    it("sets min and max zoom on the view", () => {
+      const { olMap, view } = createMockMap();
+      const adapter = new OlMapAdapter(olMap as any);
+
+      adapter.setViewConstraints({ minZoom: 3, maxZoom: 18 });
+
+      expect(view.setMinZoom).toHaveBeenCalledWith(3);
+      expect(view.setMaxZoom).toHaveBeenCalledWith(18);
+    });
+
+    it("creates a new view when extent is set", () => {
+      const { olMap } = createMockMap();
+      const adapter = new OlMapAdapter(olMap as any);
+      const extent: [number, number, number, number] = [-10, -20, 30, 40];
+
+      adapter.setViewConstraints({ extent });
+
+      expect(olMap.setView).toHaveBeenCalledTimes(1);
+    });
+
+    it("creates a new view without extent when clearing", () => {
+      const { olMap } = createMockMap();
+      const adapter = new OlMapAdapter(olMap as any);
+
+      adapter.setViewConstraints({ extent: null as any });
+
+      expect(olMap.setView).toHaveBeenCalledTimes(1);
+    });
+
+    it("returns current constraints via getter", () => {
+      const { olMap } = createMockMap();
+      const adapter = new OlMapAdapter(olMap as any);
+
+      adapter.setViewConstraints({ minZoom: 3, maxZoom: 18 });
+
+      expect(adapter.getViewConstraints()).toEqual({ minZoom: 3, maxZoom: 18 });
+    });
+
+    it("merges constraints across multiple calls", () => {
+      const { olMap } = createMockMap();
+      const adapter = new OlMapAdapter(olMap as any);
+
+      adapter.setViewConstraints({ minZoom: 3 });
+      adapter.setViewConstraints({ maxZoom: 18 });
+
+      expect(adapter.getViewConstraints()).toEqual({ minZoom: 3, maxZoom: 18 });
+    });
+
+    it("does not replace the view when extent is not provided", () => {
+      const { olMap } = createMockMap();
+      const adapter = new OlMapAdapter(olMap as any);
+
+      adapter.setViewConstraints({ minZoom: 5 });
+
+      expect(olMap.setView).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/geo/engines/openlayers/olMapAdapter.ts
+++ b/src/geo/engines/openlayers/olMapAdapter.ts
@@ -7,15 +7,19 @@ import Feature from "ol/Feature";
 import SimpleGeometry from "ol/geom/SimpleGeometry";
 import turfEnvelope from "@turf/envelope";
 import { unByKey } from "ol/Observable";
+import View from "ol/View";
 import type {
   AnimateOptions,
   FitOptions,
   MapAdapter,
   MapEventHandler,
   MapEventType,
+  ViewConstraints,
 } from "@/geo/contracts/mapAdapter";
 
 export class OlMapAdapter implements MapAdapter {
+  private _viewConstraints: ViewConstraints = {};
+
   constructor(private olMap: OLMap) {}
 
   private get projection() {
@@ -84,6 +88,37 @@ export class OlMapAdapter implements MapAdapter {
 
   getResolutionForZoom(zoom: number): number | undefined {
     return this.olMap.getView().getResolutionForZoom(zoom);
+  }
+
+  getViewConstraints(): ViewConstraints {
+    return this._viewConstraints;
+  }
+
+  setViewConstraints(constraints: ViewConstraints): void {
+    this._viewConstraints = { ...this._viewConstraints, ...constraints };
+    const view = this.olMap.getView();
+
+    if (constraints.minZoom !== undefined) {
+      view.setMinZoom(constraints.minZoom ?? 0);
+    }
+    if (constraints.maxZoom !== undefined) {
+      view.setMaxZoom(constraints.maxZoom ?? 28);
+    }
+    if (constraints.extent !== undefined) {
+      const currentView = this.olMap.getView();
+      const newView = new View({
+        center: currentView.getCenter(),
+        zoom: currentView.getZoom(),
+        rotation: currentView.getRotation(),
+        projection: currentView.getProjection(),
+        minZoom: currentView.getMinZoom(),
+        maxZoom: currentView.getMaxZoom(),
+        extent: constraints.extent
+          ? transformExtent(constraints.extent, "EPSG:4326", this.projection)
+          : undefined,
+      });
+      this.olMap.setView(newView);
+    }
   }
 
   updateSize(): void {

--- a/src/geo/mapLibreMapAdapter.test.ts
+++ b/src/geo/mapLibreMapAdapter.test.ts
@@ -26,6 +26,9 @@ function createMockMap() {
     getContainer: vi.fn(() => document.createElement("div")),
     getCanvas: vi.fn(() => document.createElement("canvas")),
     unproject: vi.fn(() => ({ lng: 10, lat: 20 })),
+    setMaxBounds: vi.fn(),
+    setMinZoom: vi.fn(),
+    setMaxZoom: vi.fn(),
   };
 
   return { mlMap, listeners };
@@ -59,5 +62,56 @@ describe("MapLibreMapAdapter", () => {
     expect(mapPreventDefault).toHaveBeenCalledTimes(1);
     expect(stopPropagationSpy).toHaveBeenCalledTimes(1);
     expect(originalEvent.defaultPrevented).toBe(true);
+  });
+
+  describe("setViewConstraints", () => {
+    it("sets max bounds on the map", () => {
+      const { mlMap } = createMockMap();
+      const adapter = new MapLibreMapAdapter(mlMap as any);
+      const extent: [number, number, number, number] = [-10, -20, 30, 40];
+
+      adapter.setViewConstraints({ extent });
+
+      expect(mlMap.setMaxBounds).toHaveBeenCalledWith(extent);
+    });
+
+    it("ignores extent when not provided", () => {
+      const { mlMap } = createMockMap();
+      const adapter = new MapLibreMapAdapter(mlMap as any);
+
+      adapter.setViewConstraints({ minZoom: 3 });
+
+      expect(mlMap.setMaxBounds).not.toHaveBeenCalled();
+    });
+
+    it("returns current constraints via getter", () => {
+      const { mlMap } = createMockMap();
+      const adapter = new MapLibreMapAdapter(mlMap as any);
+      const extent: [number, number, number, number] = [-10, -20, 30, 40];
+
+      adapter.setViewConstraints({ extent, minZoom: 3, maxZoom: 18 });
+
+      expect(adapter.getViewConstraints()).toEqual({ extent, minZoom: 3, maxZoom: 18 });
+    });
+
+    it("merges constraints across multiple calls", () => {
+      const { mlMap } = createMockMap();
+      const adapter = new MapLibreMapAdapter(mlMap as any);
+
+      adapter.setViewConstraints({ minZoom: 3 });
+      adapter.setViewConstraints({ maxZoom: 18 });
+
+      expect(adapter.getViewConstraints()).toEqual({ minZoom: 3, maxZoom: 18 });
+    });
+
+    it("sets min and max zoom", () => {
+      const { mlMap } = createMockMap();
+      const adapter = new MapLibreMapAdapter(mlMap as any);
+
+      adapter.setViewConstraints({ minZoom: 3, maxZoom: 18 });
+
+      expect(mlMap.setMinZoom).toHaveBeenCalledWith(3);
+      expect(mlMap.setMaxZoom).toHaveBeenCalledWith(18);
+    });
   });
 });

--- a/src/geo/mapLibreMapAdapter.ts
+++ b/src/geo/mapLibreMapAdapter.ts
@@ -8,6 +8,7 @@ import type {
   MapAdapter,
   MapEventHandler,
   MapEventType,
+  ViewConstraints,
 } from "@/geo/contracts/mapAdapter";
 
 const ML_EVENT_MAP: Record<MapEventType, string> = {
@@ -32,6 +33,8 @@ function toMapEventPayload(e: MapMouseEvent) {
 }
 
 export class MapLibreMapAdapter implements MapAdapter {
+  private _viewConstraints: ViewConstraints = {};
+
   constructor(private mlMap: MlMap) {}
 
   animateView(options: AnimateOptions): void {
@@ -83,6 +86,23 @@ export class MapLibreMapAdapter implements MapAdapter {
 
   getResolutionForZoom(_zoom: number): number | undefined {
     return undefined;
+  }
+
+  getViewConstraints(): ViewConstraints {
+    return this._viewConstraints;
+  }
+
+  setViewConstraints(constraints: ViewConstraints): void {
+    this._viewConstraints = { ...this._viewConstraints, ...constraints };
+    if (constraints.extent !== undefined) {
+      this.mlMap.setMaxBounds(constraints.extent || null);
+    }
+    if (constraints.minZoom !== undefined) {
+      this.mlMap.setMinZoom(constraints.minZoom ?? null);
+    }
+    if (constraints.maxZoom !== undefined) {
+      this.mlMap.setMaxZoom(constraints.maxZoom ?? null);
+    }
   }
 
   updateSize(): void {

--- a/src/modules/globeview/ScenarioEditorGlobe.test.ts
+++ b/src/modules/globeview/ScenarioEditorGlobe.test.ts
@@ -14,6 +14,7 @@ const initializeBaseLayers = vi.fn();
 vi.mock("@/geo/mapLibreMapAdapter", () => ({
   MapLibreMapAdapter: class MockMapLibreMapAdapter {
     constructor(public map: unknown) {}
+    setViewConstraints() {}
   },
 }));
 
@@ -130,7 +131,7 @@ describe("ScenarioEditorGlobe", () => {
         plugins: [createPinia()],
         provide: {
           [activeScenarioKey as symbol]: {
-            store: { state: { id: "scenario-1" } },
+            store: { state: { id: "scenario-1", mapSettings: {} } },
           },
         },
         stubs: {

--- a/src/modules/globeview/ScenarioEditorGlobe.vue
+++ b/src/modules/globeview/ScenarioEditorGlobe.vue
@@ -116,9 +116,9 @@ watch(
   }),
   ({ engine, ...settings }) => {
     engine?.map.setViewConstraints({
-      extent: settings.extent ?? null,
-      minZoom: settings.minZoom ?? null,
-      maxZoom: settings.maxZoom ?? null,
+      extent: settings.extent,
+      minZoom: settings.minZoom,
+      maxZoom: settings.maxZoom,
     });
   },
   { immediate: true },

--- a/src/modules/globeview/ScenarioEditorGlobe.vue
+++ b/src/modules/globeview/ScenarioEditorGlobe.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
-import { computed, onBeforeUnmount, onMounted, provide, ref, shallowRef } from "vue";
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  provide,
+  ref,
+  shallowRef,
+  watch,
+} from "vue";
 import type { ShallowRef } from "vue";
 import type { Map as MlMap } from "maplibre-gl";
 import type OLMap from "ol/Map";
@@ -98,6 +106,23 @@ function onMapReady(mapInstance: MlMap) {
   cleanupScenarioBinding = layers.bindScenario(activeScenario);
   geoStore.setMapAdapter(adapter);
 }
+
+watch(
+  () => ({
+    engine: scenarioMapEngineRef.value,
+    extent: state.mapSettings.maxExtent,
+    minZoom: state.mapSettings.minZoom,
+    maxZoom: state.mapSettings.maxZoom,
+  }),
+  ({ engine, ...settings }) => {
+    engine?.map.setViewConstraints({
+      extent: settings.extent ?? null,
+      minZoom: settings.minZoom ?? null,
+      maxZoom: settings.maxZoom ?? null,
+    });
+  },
+  { immediate: true },
+);
 
 const { showHexGrid, hexResolution, autoResolution, lineColor, lineOpacity, lineWidth } =
   useH3HexGrid(mlMap);

--- a/src/modules/scenarioeditor/ScenarioEditorMap.vue
+++ b/src/modules/scenarioeditor/ScenarioEditorMap.vue
@@ -114,9 +114,9 @@ watch(
   }),
   ({ engine, ...settings }) => {
     engine?.map.setViewConstraints({
-      extent: settings.extent ?? null,
-      minZoom: settings.minZoom ?? null,
-      maxZoom: settings.maxZoom ?? null,
+      extent: settings.extent,
+      minZoom: settings.minZoom,
+      maxZoom: settings.maxZoom,
     });
   },
   { immediate: true },

--- a/src/modules/scenarioeditor/ScenarioEditorMap.vue
+++ b/src/modules/scenarioeditor/ScenarioEditorMap.vue
@@ -105,6 +105,23 @@ function onMapReady({
   featureSelectInteractionRef.value = featureSelectInteraction;
 }
 
+watch(
+  () => ({
+    engine: scenarioMapEngineRef.value,
+    extent: state.mapSettings.maxExtent,
+    minZoom: state.mapSettings.minZoom,
+    maxZoom: state.mapSettings.maxZoom,
+  }),
+  ({ engine, ...settings }) => {
+    engine?.map.setViewConstraints({
+      extent: settings.extent ?? null,
+      minZoom: settings.minZoom ?? null,
+      maxZoom: settings.maxZoom ?? null,
+    });
+  },
+  { immediate: true },
+);
+
 onUnmounted(() => {
   activeUnitStore.clearActiveUnit();
   playback.playbackRunning = false;

--- a/src/modules/scenarioeditor/ScenarioMapSettings.vue
+++ b/src/modules/scenarioeditor/ScenarioMapSettings.vue
@@ -4,13 +4,19 @@ import { injectStrict } from "@/utils";
 import { computed } from "vue";
 import { type SelectItem } from "@/components/types";
 import SimpleSelect from "@/components/SimpleSelect.vue";
+import NumberInputGroup from "@/components/NumberInputGroup.vue";
 import { useMapSettingsStore } from "@/stores/mapSettingsStore";
 import { useBaseLayersStore } from "@/stores/baseLayersStore";
+import { useGeoStore } from "@/stores/geoStore";
+import { useMapViewStore } from "@/stores/mapViewStore";
+import { Button } from "@/components/ui/button";
 
 const scn = injectStrict(activeScenarioKey);
 const { store } = scn;
 const mapSettings = useMapSettingsStore();
 const baseLayersStore = useBaseLayersStore();
+const geoStore = useGeoStore();
+const mapViewStore = useMapViewStore();
 
 const baseMapItems = computed((): SelectItem[] => {
   const layers = baseLayersStore.layers.map((l) => ({ label: l.title, value: l.name }));
@@ -27,10 +33,133 @@ const baseMap = computed({
     baseLayersStore.selectLayer(value);
   },
 });
+
+const minZoom = computed({
+  get: () => store.state.mapSettings.minZoom,
+  set: (value: number | undefined) => {
+    store.update((s) => {
+      s.mapSettings.minZoom = value;
+    });
+  },
+});
+
+const maxZoom = computed({
+  get: () => store.state.mapSettings.maxZoom,
+  set: (value: number | undefined) => {
+    store.update((s) => {
+      s.mapSettings.maxZoom = value;
+    });
+  },
+});
+
+const hasMaxExtent = computed(() => {
+  const ext = store.state.mapSettings.maxExtent;
+  return ext && ext.length === 4;
+});
+
+const formattedExtent = computed(() => {
+  const ext = store.state.mapSettings.maxExtent;
+  if (!ext || ext.length !== 4) return "Not set";
+  const [minLon, minLat, maxLon, maxLat] = ext;
+  return `SW: ${minLat.toFixed(4)}, ${minLon.toFixed(4)} — NE: ${maxLat.toFixed(4)}, ${maxLon.toFixed(4)}`;
+});
+
+function setExtentFromMapView() {
+  const bbox = geoStore.getMapViewBbox();
+  if (!bbox) return;
+  store.update((s) => {
+    s.mapSettings.maxExtent = bbox;
+  });
+}
+
+function clearExtent() {
+  store.update((s) => {
+    s.mapSettings.maxExtent = undefined;
+  });
+}
+
+function clearMinZoom() {
+  store.update((s) => {
+    s.mapSettings.minZoom = undefined;
+  });
+}
+
+function clearMaxZoom() {
+  store.update((s) => {
+    s.mapSettings.maxZoom = undefined;
+  });
+}
 </script>
 
 <template>
-  <div>
+  <div class="space-y-4">
     <SimpleSelect label="Default base map" :items="baseMapItems" v-model="baseMap" />
+
+    <section class="space-y-3">
+      <h4 class="text-sm font-medium">View constraints</h4>
+      <p class="text-muted-foreground text-sm">
+        Limit the map view to a specific area and zoom range. Current zoom:
+        {{ mapViewStore.zoomLevel.toFixed(1) }}.
+      </p>
+
+      <div class="space-y-2">
+        <div class="flex items-end gap-2">
+          <NumberInputGroup
+            label="Min zoom"
+            v-model="minZoom"
+            :min="0"
+            :max="28"
+            :step="1"
+            class="flex-1"
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            @click="clearMinZoom"
+            :disabled="minZoom == null"
+          >
+            Clear
+          </Button>
+        </div>
+        <div class="flex items-end gap-2">
+          <NumberInputGroup
+            label="Max zoom"
+            v-model="maxZoom"
+            :min="0"
+            :max="28"
+            :step="1"
+            class="flex-1"
+          />
+          <Button
+            variant="ghost"
+            size="sm"
+            @click="clearMaxZoom"
+            :disabled="maxZoom == null"
+          >
+            Clear
+          </Button>
+        </div>
+      </div>
+
+      <div class="space-y-2">
+        <label class="text-sm font-medium">Max extent</label>
+        <p class="text-sm" :class="hasMaxExtent ? '' : 'text-muted-foreground'">
+          {{ formattedExtent }}
+        </p>
+        <div class="flex flex-wrap gap-2">
+          <Button variant="outline" size="sm" @click="setExtentFromMapView">
+            Set from map view
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            @click="clearExtent"
+            :disabled="!hasMaxExtent"
+          >
+            Clear
+          </Button>
+        </div>
+      </div>
+    </section>
   </div>
 </template>

--- a/src/scenariostore/io.test.ts
+++ b/src/scenariostore/io.test.ts
@@ -65,7 +65,7 @@ describe("Scenario IO", () => {
   it("creates empty scenarios with items[] layers", () => {
     const scenario = createEmptyScenario();
 
-    expect(scenario.version).toBe("3.0.0");
+    expect(scenario.version).toBe("3.1.0");
     expect(getOverlayLayers(scenario)[0]).toHaveProperty("items");
     expect(getOverlayLayers(scenario)[0]).not.toHaveProperty("features");
     expect((getOverlayLayers(scenario)[0] as any).items).toEqual([]);
@@ -209,7 +209,7 @@ describe("Scenario IO", () => {
     const { serializeToObject } = useScenarioIO(storeRef);
     const serialized = serializeToObject();
 
-    expect(serialized.version).toBe("3.0.0");
+    expect(serialized.version).toBe("3.1.0");
     expect(getOverlayLayers(serialized)[0]).not.toHaveProperty("features");
     expect(getOverlayLayers(serialized)[0].items).toEqual([
       {

--- a/src/types/scenarioModels.ts
+++ b/src/types/scenarioModels.ts
@@ -268,6 +268,7 @@ export interface ScenarioInfo {
 
 export type SymbologyStandard = "2525" | "app6";
 export type ScenarioVersion =
+  | "3.1.0"
   | "3.0.0"
   | "2.8.0"
   | "2.7.0"
@@ -367,6 +368,9 @@ export interface CustomSymbol {
 
 export interface MapSettings {
   baseMapId: string;
+  maxExtent?: [number, number, number, number];
+  minZoom?: number;
+  maxZoom?: number;
 }
 
 export interface ScenarioMetadata {


### PR DESCRIPTION
## Summary

- Add `ViewConstraints` interface (extent, min/max zoom) to the `MapAdapter` contract with implementations for both OpenLayers and MapLibre adapters
- Add view constraints UI to scenario map settings panel, with controls for min/max zoom and max extent
- Apply constraints in both map and globe modes, persisted as part of the scenario
- Show current zoom level in the settings panel for reference
- Bump scenario file version to 3.1.0