### PR TITLE
Refactor geometry features to use layer stack metadata

### DIFF
--- a/public/scenarios/falkland82.json
+++ b/public/scenarios/falkland82.json
@@ -1,10 +1,10 @@
 {
   "id": "demo-falklands82",
   "type": "ORBAT-mapper",
-  "version": "2.7.0",
+  "version": "3.2.0",
   "meta": {
     "createdDate": "2024-02-04T14:33:50.335Z",
-    "lastModifiedDate": "2026-04-03T17:33:04.290Z"
+    "lastModifiedDate": "2026-04-13T17:46:11.404Z"
   },
   "name": "The Falklands War",
   "startTime": "1982-03-11T10:00:00-04:00",
@@ -2570,25 +2570,46 @@
       ]
     }
   ],
-  "layers": [
+  "layerStack": [
+    {
+      "id": "xj1kv8wno4",
+      "kind": "reference",
+      "name": "Battle of Goose Green map",
+      "description": "Positions and company movements during the battle of Goose Green, May 28, 1982.\n\nBased on a map from The Falklands War, 1982, Martin Middlebrook, 1985, ISBN 0141390557 ",
+      "externalUrl": "https://commons.wikimedia.org/wiki/File:Battle_of_Goose_Green.png",
+      "isHidden": true,
+      "opacity": 0.8,
+      "source": {
+        "id": "xj1kv8wno4",
+        "type": "ImageLayer",
+        "url": "/scenarios/images/Battle_of_Goose_Green.png",
+        "name": "Battle of Goose Green map",
+        "description": "Positions and company movements during the battle of Goose Green, May 28, 1982.\n\nBased on a map from The Falklands War, 1982, Martin Middlebrook, 1985, ISBN 0141390557 ",
+        "externalUrl": "https://commons.wikimedia.org/wiki/File:Battle_of_Goose_Green.png",
+        "isHidden": true,
+        "imageCenter": [-58.96816549275583, -51.79901410430646],
+        "imageRotate": 0.028235478069220242,
+        "imageScale": [19.703891001458558, 19.703891001458558],
+        "opacity": 0.8,
+        "extent": [
+          -6569354.1947099, -6771880.594125692, -6559258.116624231, -6755851.18973469
+        ]
+      }
+    },
     {
       "id": "2pf1FK",
       "name": "Features",
-      "features": [
+      "kind": "overlay",
+      "items": [
         {
-          "type": "Feature",
           "id": "feature1",
-          "properties": {},
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-59.436550429034575, -51.73994920324739]
           },
-          "meta": {
-            "type": "Circle",
-            "visibleFromT": "1982-04-11T20:00:00-04:00",
-            "name": "Maritime Exclusion Zone",
-            "description": "A [Maritime Exclusion Zone](https://en.wikipedia.org/wiki/Maritime_Exclusion_Zone \"Maritime Exclusion Zone\") (MEZ) was declared on 12 April 1982 covered a circle of radius 200 nautical miles (370 km; 230 mi) from the centre of the Falkland Islands. Any *Argentine warship* or *naval auxiliary* entering the MEZ could have been attacked by [British nuclear-powered submarines](https://en.wikipedia.org/wiki/Royal_Navy_Submarine_Service \"Royal Navy Submarine Service\") (SSN).\n\nFrom [Wikipedia](https://en.wikipedia.org/wiki/Total_Exclusion_Zone)",
-            "externalUrl": "https://en.wikipedia.org/wiki/Total_Exclusion_Zone",
+          "geometryMeta": {
+            "geometryKind": "Circle",
             "radius": 370000
           },
           "style": {
@@ -2596,7 +2617,11 @@
             "stroke-opacity": 0.4,
             "stroke": "#7F1D1D",
             "stroke-width": 4
-          }
+          },
+          "name": "Maritime Exclusion Zone",
+          "description": "A [Maritime Exclusion Zone](https://en.wikipedia.org/wiki/Maritime_Exclusion_Zone \"Maritime Exclusion Zone\") (MEZ) was declared on 12 April 1982 covered a circle of radius 200 nautical miles (370 km; 230 mi) from the centre of the Falkland Islands. Any *Argentine warship* or *naval auxiliary* entering the MEZ could have been attacked by [British nuclear-powered submarines](https://en.wikipedia.org/wiki/Royal_Navy_Submarine_Service \"Royal Navy Submarine Service\") (SSN).\n\nFrom [Wikipedia](https://en.wikipedia.org/wiki/Total_Exclusion_Zone)",
+          "externalUrl": "https://en.wikipedia.org/wiki/Total_Exclusion_Zone",
+          "visibleFromT": "1982-04-11T20:00:00-04:00"
         }
       ]
     },
@@ -2604,118 +2629,125 @@
       "id": "yBW6mLmbE5y38Kv6LzxdB",
       "name": "Landings",
       "visibleFromT": "1982-05-20T20:00:00-04:00",
-      "features": [
+      "kind": "overlay",
+      "items": [
         {
-          "type": "Feature",
+          "id": "Zn3Qm3COkjrR-11cL98fB",
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-59.08007935472968, -51.564090346897814]
           },
-          "properties": {},
-          "id": "Zn3Qm3COkjrR-11cL98fB",
-          "meta": {
-            "type": "Point",
-            "name": "Red Beach",
-            "description": "21 May: 45 Cdo"
+          "geometryMeta": {
+            "geometryKind": "Point"
           },
-          "style": {}
+          "style": {},
+          "name": "Red Beach",
+          "description": "21 May: 45 Cdo"
         },
         {
-          "type": "Feature",
+          "id": "3nXZXzD74ZoLNsrm3arDE",
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-59.032873825288405, -51.574678888182405]
           },
-          "properties": {},
-          "id": "3nXZXzD74ZoLNsrm3arDE",
-          "meta": {
-            "type": "Point",
-            "name": "Blue Beach",
-            "description": "21 May: \n - 2 Para\n - 40 Cdo\n\n1-2 Jun: \n- 1/GR\n- 1WG\n- 2SG"
+          "geometryMeta": {
+            "geometryKind": "Point"
           },
-          "style": {}
+          "style": {},
+          "name": "Blue Beach",
+          "description": "21 May: \n - 2 Para\n - 40 Cdo\n\n1-2 Jun: \n- 1/GR\n- 1WG\n- 2SG"
         },
         {
-          "type": "Feature",
+          "id": "Zi5qS3x-JmHsb_M23xL3F",
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-58.99651105330039, -51.50288926105369]
           },
-          "properties": {},
-          "id": "Zi5qS3x-JmHsb_M23xL3F",
-          "meta": {
-            "type": "Point",
-            "name": "Green Beach",
-            "description": "21 May: 3 Para, 42 Cdo"
+          "geometryMeta": {
+            "geometryKind": "Point"
           },
-          "style": {}
+          "style": {},
+          "name": "Green Beach",
+          "description": "21 May: 3 Para, 42 Cdo"
         }
       ]
     },
     {
       "id": "GBzPAQoyDW",
       "name": "Argentinian bases",
-      "features": [
+      "kind": "overlay",
+      "items": [
         {
-          "type": "Feature",
+          "id": "dm1UDXs2xW",
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-67.7557523798225, -53.77759602366957]
           },
-          "properties": {},
-          "id": "dm1UDXs2xW",
-          "meta": {
-            "type": "Point",
-            "name": "Rio Grande AB"
+          "geometryMeta": {
+            "geometryKind": "Point"
           },
           "style": {
             "marker-color": "#a40000",
             "marker-symbol": "star"
-          }
+          },
+          "name": "Rio Grande AB"
         },
         {
-          "type": "Feature",
+          "id": "dm1UssDXs2xW",
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-69.30725832955693, -51.60882330522812]
           },
-          "properties": {},
-          "id": "dm1UssDXs2xW",
-          "meta": {
-            "type": "Point",
-            "name": "Rio Gallegos AB"
+          "geometryMeta": {
+            "geometryKind": "Point"
           },
           "style": {
             "marker-color": "#a40000",
             "marker-symbol": "star"
-          }
+          },
+          "name": "Rio Gallegos AB"
         },
         {
-          "type": "Feature",
+          "id": "EYeIuLNE9V",
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-62.10384759484108, -38.891831102546085]
           },
-          "properties": {},
-          "id": "EYeIuLNE9V",
-          "meta": {
-            "type": "Point",
-            "name": "Puerto Belgrano"
+          "geometryMeta": {
+            "geometryKind": "Point"
           },
           "style": {
             "marker-color": "#a40000",
             "marker-size": "small",
             "marker-symbol": "pentagon"
-          }
+          },
+          "name": "Puerto Belgrano"
         },
         {
-          "type": "Feature",
+          "id": "uGTaeM6ZUd",
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-27.30841913424884, -59.4572127866505]
           },
-          "properties": {},
-          "id": "uGTaeM6ZUd",
+          "geometryMeta": {
+            "geometryKind": "Point"
+          },
+          "style": {
+            "showLabel": true,
+            "marker-color": "#a40000",
+            "marker-size": "medium",
+            "marker-symbol": "triangle"
+          },
+          "name": "Corbeta Uruguay base",
+          "description": "**Corbeta Uruguay base** was an [Argentine military](https://en.wikipedia.org/wiki/Military_of_Argentina \"Military of Argentina\") outpost established in November 1976 on [Thule Island](https://en.wikipedia.org/wiki/Thule_Island \"Thule Island\"), [Southern Thule](https://en.wikipedia.org/wiki/Southern_Thule \"Southern Thule\"), in the [South Sandwich Islands](https://en.wikipedia.org/wiki/South_Sandwich_Islands \"South Sandwich Islands\"). It was vacated and mostly demolished in 1982 following Britain's victory against Argentina in the Falklands War.\n\nFrom [Wikipedia](https://en.wikipedia.org/wiki/Corbeta_Uruguay_base)",
+          "externalUrl": "https://en.wikipedia.org/wiki/Corbeta_Uruguay_base",
           "media": [
             {
               "url": "https://upload.wikimedia.org/wikipedia/commons/5/58/Thule1981.jpg",
@@ -2723,28 +2755,27 @@
               "credits": "Ricardo A. R. Hermelo, Public domain, via Wikimedia Commons",
               "creditsUrl": "https://commons.wikimedia.org/wiki/File:Thule1981.jpg"
             }
-          ],
-          "meta": {
+          ]
+        },
+        {
+          "id": "Jl2579NHvw",
+          "kind": "geometry",
+          "geometry": {
             "type": "Point",
-            "name": "Corbeta Uruguay base",
-            "description": "**Corbeta Uruguay base** was an [Argentine military](https://en.wikipedia.org/wiki/Military_of_Argentina \"Military of Argentina\") outpost established in November 1976 on [Thule Island](https://en.wikipedia.org/wiki/Thule_Island \"Thule Island\"), [Southern Thule](https://en.wikipedia.org/wiki/Southern_Thule \"Southern Thule\"), in the [South Sandwich Islands](https://en.wikipedia.org/wiki/South_Sandwich_Islands \"South Sandwich Islands\"). It was vacated and mostly demolished in 1982 following Britain's victory against Argentina in the Falklands War.\n\nFrom [Wikipedia](https://en.wikipedia.org/wiki/Corbeta_Uruguay_base)",
-            "externalUrl": "https://en.wikipedia.org/wiki/Corbeta_Uruguay_base"
+            "coordinates": [-44.73800717700976, -60.738236763164295]
+          },
+          "geometryMeta": {
+            "geometryKind": "Point"
           },
           "style": {
             "showLabel": true,
             "marker-color": "#a40000",
             "marker-size": "medium",
             "marker-symbol": "triangle"
-          }
-        },
-        {
-          "type": "Feature",
-          "geometry": {
-            "type": "Point",
-            "coordinates": [-44.73800717700976, -60.738236763164295]
           },
-          "properties": {},
-          "id": "Jl2579NHvw",
+          "name": "Orcadas",
+          "description": "**Base Orcadas** is an [Argentine](https://en.wikipedia.org/wiki/Argentina \"Argentina\") scientific station in [Antarctica](https://en.wikipedia.org/wiki/Antarctica \"Antarctica\"), and the oldest of the stations in Antarctica still in operation. It is located on [Laurie Island](https://en.wikipedia.org/wiki/Laurie_Island \"Laurie Island\"), one of the [South Orkney Islands](https://en.wikipedia.org/wiki/South_Orkney_Islands \"South Orkney Islands\") ([Spanish](https://en.wikipedia.org/wiki/Spanish_language \"Spanish language\"): *Islas Orcadas del Sur*), at 4 meters (13 ft) above sea level and 170 meters (558 ft) from the coastline.\n\nFrom [Wikipedia](https://en.wikipedia.org/wiki/Orcadas_Base)\n",
+          "externalUrl": "https://en.wikipedia.org/wiki/Orcadas_Base",
           "media": [
             {
               "url": "https://upload.wikimedia.org/wikipedia/commons/a/a2/Orcadas_Base.jpg",
@@ -2752,78 +2783,64 @@
               "credits": "Antarctic96, CC BY-SA 3.0, via Wikimedia Commons",
               "creditsUrl": "https://commons.wikimedia.org/wiki/File:Orcadas_Base.jpg"
             }
-          ],
-          "meta": {
-            "type": "Point",
-            "name": "Orcadas",
-            "description": "**Base Orcadas** is an [Argentine](https://en.wikipedia.org/wiki/Argentina \"Argentina\") scientific station in [Antarctica](https://en.wikipedia.org/wiki/Antarctica \"Antarctica\"), and the oldest of the stations in Antarctica still in operation. It is located on [Laurie Island](https://en.wikipedia.org/wiki/Laurie_Island \"Laurie Island\"), one of the [South Orkney Islands](https://en.wikipedia.org/wiki/South_Orkney_Islands \"South Orkney Islands\") ([Spanish](https://en.wikipedia.org/wiki/Spanish_language \"Spanish language\"): *Islas Orcadas del Sur*), at 4 meters (13 ft) above sea level and 170 meters (558 ft) from the coastline.\n\nFrom [Wikipedia](https://en.wikipedia.org/wiki/Orcadas_Base)\n",
-            "externalUrl": "https://en.wikipedia.org/wiki/Orcadas_Base"
-          },
-          "style": {
-            "showLabel": true,
-            "marker-color": "#a40000",
-            "marker-size": "medium",
-            "marker-symbol": "triangle"
-          }
+          ]
         }
       ]
     },
     {
       "id": "Vy8yJW8rOS",
       "name": "British bases",
-      "features": [
+      "kind": "overlay",
+      "items": [
         {
-          "type": "Feature",
+          "id": "VIyMHgWoWS",
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-14.40257026225315, -7.968535001150471]
           },
-          "properties": {},
-          "id": "VIyMHgWoWS",
-          "meta": {
-            "type": "Point",
-            "name": "RAF Ascension Island"
+          "geometryMeta": {
+            "geometryKind": "Point"
           },
           "style": {
             "marker-color": "#3465a4",
             "marker-symbol": "star"
-          }
+          },
+          "name": "RAF Ascension Island"
         },
         {
-          "type": "Feature",
+          "id": "ibuQYToiiN",
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-1.104852842922037, 50.8046643899244]
           },
-          "properties": {},
-          "id": "ibuQYToiiN",
-          "meta": {
-            "type": "Point",
-            "name": "HMNB Portsmouth"
+          "geometryMeta": {
+            "geometryKind": "Point"
           },
           "style": {
             "marker-color": "#3465a4",
             "marker-size": "small",
             "marker-symbol": "pentagon"
-          }
+          },
+          "name": "HMNB Portsmouth"
         },
         {
-          "type": "Feature",
+          "id": "9GEGHFNoIK",
+          "kind": "geometry",
           "geometry": {
             "type": "Point",
             "coordinates": [-36.4948515401756, -54.28327179945222]
           },
-          "properties": {},
-          "id": "9GEGHFNoIK",
-          "meta": {
-            "type": "Point",
-            "name": "British Antarctic Survey"
+          "geometryMeta": {
+            "geometryKind": "Point"
           },
           "style": {
             "marker-color": "#4e9a06",
             "marker-size": "small",
             "marker-symbol": "triangle"
-          }
+          },
+          "name": "British Antarctic Survey"
         }
       ]
     }
@@ -2918,24 +2935,6 @@
       "title": "Battle of Goose Green",
       "startTime": "1982-05-26T20:00:00-04:00",
       "id": "L7sLKYe3xMRELH2bEA7Da"
-    }
-  ],
-  "mapLayers": [
-    {
-      "id": "xj1kv8wno4",
-      "type": "ImageLayer",
-      "url": "/scenarios/images/Battle_of_Goose_Green.png",
-      "name": "Battle of Goose Green map",
-      "description": "Positions and company movements during the battle of Goose Green, May 28, 1982.\n\nBased on a map from The Falklands War, 1982, Martin Middlebrook, 1985, ISBN 0141390557 ",
-      "externalUrl": "https://commons.wikimedia.org/wiki/File:Battle_of_Goose_Green.png",
-      "isHidden": true,
-      "imageCenter": [-58.96816549275583, -51.79901410430646],
-      "imageRotate": 0.028235478069220242,
-      "imageScale": [19.703891001458558, 19.703891001458558],
-      "opacity": 0.8,
-      "extent": [
-        -6569354.1947099, -6771880.594125692, -6559258.116624231, -6755851.18973469
-      ]
     }
   ],
   "equipment": [],

--- a/public/scenarios/narvik40.json
+++ b/public/scenarios/narvik40.json
@@ -1,10 +1,10 @@
 {
   "id": "demo-narvik40",
   "type": "ORBAT-mapper",
-  "version": "2.2.0",
+  "version": "3.2.0",
   "meta": {
     "createdDate": "2024-04-01T17:14:51.567Z",
-    "lastModifiedDate": "2026-02-08T12:36:40.409Z"
+    "lastModifiedDate": "2026-04-15T18:43:36.899Z"
   },
   "name": "Battles of Narvik",
   "startTime": "1940-04-09T01:00:00+02:00",
@@ -658,15 +658,15 @@
       ]
     }
   ],
-  "layers": [
+  "layerStack": [
     {
       "name": "Features",
       "id": "vN7ltfakRq23",
-      "features": []
+      "kind": "overlay",
+      "items": []
     }
   ],
   "events": [],
-  "mapLayers": [],
   "equipment": [],
   "personnel": [],
   "supplyCategories": [],

--- a/src/components/BaseLayerSwitcher.vue
+++ b/src/components/BaseLayerSwitcher.vue
@@ -57,7 +57,7 @@ const selectedId = computed({
                 >Default</span
               >
             </Label>
-            <span v-if="setting.title === 'None'" />
+            <span v-if="setting.title === 'None' || setting.supportsOpacity === false" />
             <OpacityInput
               v-else
               :model-value="setting.opacity"

--- a/src/components/BaseLayerSwitcher.vue
+++ b/src/components/BaseLayerSwitcher.vue
@@ -6,14 +6,14 @@ import OpacityInput from "./OpacityInput.vue";
 import { computed } from "vue";
 
 interface Props {
-  settings: LayerInfo<any>[];
+  settings: LayerInfo[];
   defaultLayerName?: string;
 }
 
 const props = defineProps<Props>();
 defineEmits(["update:layerOpacity"]);
 
-const selected = defineModel<LayerInfo<any>>();
+const selected = defineModel<LayerInfo>();
 const nsettings = computed(() => [...props.settings]);
 
 const selectedId = computed({

--- a/src/components/ImportGeojsonStep.vue
+++ b/src/components/ImportGeojsonStep.vue
@@ -188,19 +188,19 @@ function loadAsUnits() {
 function loadAsFeatures() {
   if (!activeLayer.value) return;
   const features = selectedFeatures.value.map((f): NGeometryLayerItem => {
+    const userData = { ...(f.properties ?? {}) } as Record<string, unknown>;
+    delete userData[nameColumn.value];
     return {
-      ...f,
       kind: "geometry",
       _pid: activeLayer.value,
       id: nanoid(),
-      meta: {
-        type: f.geometry.type,
-        name: f.properties?.[nameColumn.value] || "New feature",
+      name: String(f.properties?.[nameColumn.value] || "New feature"),
+      geometryMeta: {
+        geometryKind: f.geometry.type,
       },
+      geometry: f.geometry,
       style: {},
-      properties: {
-        // ...(f.properties ?? {}),
-      },
+      userData,
     };
   });
   scnStore.groupUpdate(() => {

--- a/src/components/ImportGeojsonStep.vue
+++ b/src/components/ImportGeojsonStep.vue
@@ -76,7 +76,8 @@ const computedColumns = computed((): (ColumnDef<GeoJSONFeature, any> | false)[] 
       },
     },
     {
-      accessorFn: (f) => f.properties?.[nameColumn.value] ?? "Feature",
+      accessorFn: (f) =>
+        normalizeImportedName(f.properties?.[nameColumn.value], "Feature"),
       id: "name",
       header: "Name",
     },
@@ -148,6 +149,11 @@ function findLikelySymbolColumn(columnNames: string[]) {
   return columnNames[0];
 }
 
+function normalizeImportedName(rawName: unknown, fallback: string): string {
+  if (typeof rawName === "string") return rawName.trim() || fallback;
+  return String(rawName ?? fallback);
+}
+
 const activeLayer = ref(existingLayers.value[0].value);
 const nameColumn = ref(findLikelyNameColumn([...propertyNames.value]));
 const symbolColumn = ref(findLikelySymbolColumn([...propertyNames.value]));
@@ -169,7 +175,7 @@ function loadAsUnits() {
     const sidc = f.properties?.[symbolColumn.value]?.trim() || "10031000000000000000";
     return {
       id: nanoid(),
-      name: f.properties?.[nameColumn.value] || "New unit",
+      name: normalizeImportedName(f.properties?.[nameColumn.value], "New unit"),
       sidc: setCharAt(sidc, SID_INDEX, side.standardIdentity),
       subUnits: [],
       _pid: "",
@@ -194,7 +200,7 @@ function loadAsFeatures() {
       kind: "geometry",
       _pid: activeLayer.value,
       id: nanoid(),
-      name: String(f.properties?.[nameColumn.value] || "New feature"),
+      name: normalizeImportedName(f.properties?.[nameColumn.value], "New feature"),
       geometryMeta: {
         geometryKind: f.geometry.type,
       },

--- a/src/components/LayersPanel.test.ts
+++ b/src/components/LayersPanel.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { defineComponent, reactive, ref } from "vue";
+import LayersPanel from "@/components/LayersPanel.vue";
+import { activeScenarioKey } from "@/components/injects";
+import { useMapSettingsStore } from "@/stores/mapSettingsStore";
+import { useMaplibreLayersStore } from "@/stores/maplibreLayersStore";
+
+const routeState = vi.hoisted(() => ({
+  currentRouteName: "MaplibreRoute",
+}));
+
+vi.mock("vue-router", () => ({
+  useRoute: () => ({
+    name: routeState.currentRouteName,
+  }),
+}));
+
+const BaseLayerSwitcherStub = defineComponent({
+  name: "BaseLayerSwitcher",
+  props: ["settings", "modelValue"],
+  emits: ["update:modelValue", "update:layerOpacity"],
+  template: "<div />",
+});
+
+const OpacityInputStub = defineComponent({
+  name: "OpacityInput",
+  props: ["modelValue"],
+  emits: ["update:modelValue"],
+  template:
+    "<button type='button' data-test='opacity-trigger' @click=\"$emit('update:modelValue', 0.25)\" />",
+});
+
+describe("LayersPanel", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+    routeState.currentRouteName = "MaplibreRoute";
+  });
+
+  it("updates maplibre basemaps and scenario overlay layers", async () => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const mapSettings = useMapSettingsStore();
+    const maplibreLayersStore = useMaplibreLayersStore();
+    maplibreLayersStore.layers = [
+      {
+        name: "osmRaster",
+        title: "OSM Raster",
+        sourceType: "raster",
+        tiles: ["https://example.com/{z}/{x}/{y}.png"],
+        opacity: 0.6,
+      },
+      {
+        name: "bright",
+        title: "Bright",
+        sourceType: "style",
+        styleUrl: "https://example.com/style.json",
+      },
+    ];
+
+    const state = reactive({
+      mapSettings: {
+        baseMapId: "osmRaster",
+      },
+    });
+    const update = vi.fn((fn: (draft: typeof state) => void) => fn(state));
+    const updateLayer = vi.fn();
+    const layerItemsLayers = ref([
+      {
+        id: "overlay-1",
+        name: "Overlay 1",
+        opacity: 0.4,
+        isHidden: false,
+        items: [],
+      },
+    ]);
+
+    const wrapper = mount(LayersPanel, {
+      global: {
+        plugins: [pinia],
+        provide: {
+          [activeScenarioKey as symbol]: {
+            store: {
+              state,
+              update,
+            },
+            geo: {
+              layerItemsLayers,
+              updateLayer,
+            },
+          },
+        },
+        stubs: {
+          BaseLayerSwitcher: BaseLayerSwitcherStub,
+          OpacityInput: OpacityInputStub,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain("Overlay 1");
+
+    const baseLayerSwitcher = wrapper.getComponent(BaseLayerSwitcherStub);
+    const baseLayerSettings = baseLayerSwitcher.props("settings") as Array<{
+      id: string;
+      supportsOpacity?: boolean;
+    }>;
+    expect(
+      baseLayerSettings.find((setting) => setting.id === "bright")?.supportsOpacity,
+    ).toBe(false);
+
+    const brightLayer = baseLayerSettings.find((setting) => setting.id === "bright");
+    baseLayerSwitcher.vm.$emit("update:modelValue", brightLayer);
+    await wrapper.vm.$nextTick();
+
+    expect(update).toHaveBeenCalled();
+    expect(state.mapSettings.baseMapId).toBe("bright");
+    expect(mapSettings.baseLayerName).toBe("bright");
+
+    const rasterLayer = baseLayerSettings.find((setting) => setting.id === "osmRaster");
+    baseLayerSwitcher.vm.$emit("update:layerOpacity", rasterLayer, 0.3);
+    await wrapper.vm.$nextTick();
+
+    expect(
+      maplibreLayersStore.layers.find((layer) => layer.name === "osmRaster")?.opacity,
+    ).toBe(0.3);
+
+    const overlayButtons = wrapper.findAll("li button");
+    await overlayButtons[0]!.trigger("click");
+    expect(updateLayer).toHaveBeenCalledWith("overlay-1", { opacity: 0.25 });
+
+    await overlayButtons[1]!.trigger("click");
+    expect(updateLayer).toHaveBeenCalledWith("overlay-1", { isHidden: true });
+  });
+});

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -1,64 +1,113 @@
 <script setup lang="ts">
-import { computed, markRaw, ref, shallowRef, watch } from "vue";
-import { useGeoStore } from "@/stores/geoStore";
-import BaseLayer from "ol/layer/Base";
-import TileLayer from "ol/layer/Tile";
-import VectorLayer from "ol/layer/Vector";
-import LayerGroup from "ol/layer/Group";
+import { computed, inject, markRaw, ref, watchEffect } from "vue";
+import { useRoute } from "vue-router";
 import { EyeIcon, EyeSlashIcon } from "@heroicons/vue/24/solid";
-import BaseLayerSwitcher from "./BaseLayerSwitcher.vue";
-import type { AnyTileLayer, AnyVectorLayer } from "@/geo/types";
-import TileSource from "ol/source/Tile";
-
-import OpacityInput from "./OpacityInput.vue";
-import { getUid } from "ol/util";
-import { type LayerType } from "@/modules/scenarioeditor/featureLayerUtils";
-import { useMapSettingsStore } from "@/stores/mapSettingsStore";
+import BaseLayer from "ol/layer/Base";
+import LayerGroup from "ol/layer/Group";
+import VectorLayer from "ol/layer/Vector";
 import ImageLayer from "ol/layer/Image";
+import { getUid } from "ol/util";
+import BaseLayerSwitcher from "./BaseLayerSwitcher.vue";
+import OpacityInput from "./OpacityInput.vue";
+import { useGeoStore } from "@/stores/geoStore";
+import { useMapSettingsStore } from "@/stores/mapSettingsStore";
 import { useBaseLayersStore } from "@/stores/baseLayersStore";
+import { useMaplibreLayersStore } from "@/stores/maplibreLayersStore";
+import { activeScenarioKey } from "@/components/injects";
+import { MAPLIBRE_ROUTE } from "@/router/names";
+import { type LayerType } from "@/modules/scenarioeditor/featureLayerUtils";
+import {
+  getSupportedMaplibreBasemaps,
+  resolveMaplibreBasemap,
+} from "@/modules/maplibreview/maplibreBasemaps";
+import type { FeatureId } from "@/types/scenarioGeoModels";
+import type { TScenario } from "@/scenariostore";
 
-export interface LayerInfo<T extends BaseLayer = BaseLayer> {
+export interface LayerInfo {
   id: string;
   name: string;
   title: string;
   visible: boolean;
   zIndex: number;
   opacity: number;
-  layer: T;
-  subLayers?: LayerInfo<T>[];
+  subLayers?: LayerInfo[];
   description?: string;
-  layerType?: LayerType | "baselayer";
+  layerType?: LayerType | "baselayer" | "map-layer";
+  supportsOpacity?: boolean;
 }
 
+type PanelLayerInfo =
+  | (LayerInfo & {
+      kind: "openlayers";
+      layer: BaseLayer;
+    })
+  | (LayerInfo & {
+      kind: "scenario-layer";
+      layerId: FeatureId;
+    });
+
+const route = useRoute();
 const geoStore = useGeoStore();
 const mapSettings = useMapSettingsStore();
 const baseLayersStore = useBaseLayersStore();
+const maplibreLayersStore = useMaplibreLayersStore();
+const activeScenario = inject<TScenario | null>(activeScenarioKey, null);
 
-const vectorLayers = ref<LayerInfo<AnyVectorLayer>[]>([]);
+const otherLayers = ref<PanelLayerInfo[]>([]);
+const isMaplibreMode = computed(() => route.name === MAPLIBRE_ROUTE);
 
-// Adapt store layers to the format expected by BaseLayerSwitcher
-// BaseLayerSwitcher expects LayerInfo<any>[] but mostly cares about id, title, description
-const baseLayers = computed(() => {
-  return baseLayersStore.layers.map((l) => ({
-    id: l.name,
-    name: l.name,
-    title: l.title,
-    visible: baseLayersStore.activeLayerName === l.name,
+const selectedBaseLayerId = computed(() => {
+  if (isMaplibreMode.value) {
+    return resolveMaplibreBasemap(
+      activeScenario?.store.state.mapSettings.baseMapId,
+      maplibreLayersStore.layers,
+    ).id;
+  }
+  return (
+    activeScenario?.store.state.mapSettings.baseMapId ?? baseLayersStore.activeLayerName
+  );
+});
+
+const baseLayers = computed<LayerInfo[]>(() => {
+  if (isMaplibreMode.value) {
+    const activeId = selectedBaseLayerId.value;
+    return getSupportedMaplibreBasemaps(maplibreLayersStore.layers).map((layer) => {
+      const config = maplibreLayersStore.layers.find((entry) => entry.name === layer.id);
+      return {
+        id: layer.id,
+        name: layer.id,
+        title: layer.title,
+        visible: activeId === layer.id,
+        zIndex: 0,
+        opacity: config?.opacity ?? 1,
+        description: "",
+        layerType: "baselayer" as const,
+        supportsOpacity: config?.sourceType === "raster",
+      };
+    });
+  }
+
+  const activeId = selectedBaseLayerId.value;
+  return baseLayersStore.layers.map((layer) => ({
+    id: layer.name,
+    name: layer.name,
+    title: layer.title,
+    visible: activeId === layer.name,
     zIndex: 0,
-    opacity: l.opacity,
-    layer: null as any, // We don't need the OL layer instance here for the switcher anymore
+    opacity: layer.opacity,
     description: "",
     layerType: "baselayer" as const,
+    supportsOpacity: true,
   }));
 });
 
-// We need a writable computed or something to handle v-model from BaseLayerSwitcher
 const activeBaseLayer = computed({
-  get: () => baseLayers.value.find((l) => l.name === baseLayersStore.activeLayerName),
-  set: (layerInfo) => {
-    if (layerInfo) {
+  get: () => baseLayers.value.find((layer) => layer.id === selectedBaseLayerId.value),
+  set: (layerInfo?: LayerInfo) => {
+    if (!layerInfo) return;
+    setScenarioBaseMapId(layerInfo.name);
+    if (!isMaplibreMode.value) {
       baseLayersStore.selectLayer(layerInfo.name);
-      mapSettings.baseLayerName = layerInfo.name;
     }
   },
 });
@@ -71,68 +120,121 @@ const mapView = computed(() => {
   };
 });
 
-watch(
-  () => geoStore.mapAdapter,
-  (v) => v && updateLayers(),
-  { immediate: true },
-);
+function setScenarioBaseMapId(baseMapId: string) {
+  mapSettings.baseLayerName = baseMapId;
+  if (!activeScenario) return;
 
-function updateLayers() {
-  const nativeMap = geoStore.olMap;
-  if (!nativeMap) return;
+  if (typeof activeScenario.store.update === "function") {
+    activeScenario.store.update((state) => {
+      state.mapSettings.baseMapId = baseMapId;
+    });
+    return;
+  }
 
-  const transformLayer = (layer: BaseLayer): LayerInfo => {
-    const l: LayerInfo = {
-      id: getUid(layer),
-      title: layer.get("title") || layer.get("name"),
-      name: layer.get("name"),
-      layerType: layer.get("layerType"),
-      visible: layer.getVisible(),
-      zIndex: layer.getZIndex() || 0,
-      opacity: layer.getOpacity(),
-      layer: markRaw(layer),
-      subLayers: [],
-    };
-    if (layer instanceof LayerGroup) {
-      l.subLayers = layer
-        .getLayers()
-        .getArray()
-        .filter((l) => l.get("title"))
-        .map(transformLayer);
-    }
-    return l;
+  activeScenario.store.state.mapSettings.baseMapId = baseMapId;
+}
+
+function transformLayer(layer: BaseLayer): PanelLayerInfo {
+  const layerInfo: PanelLayerInfo = {
+    kind: "openlayers",
+    id: getUid(layer),
+    title: layer.get("title") || layer.get("name"),
+    name: layer.get("name"),
+    layerType: layer.get("layerType"),
+    visible: layer.getVisible(),
+    zIndex: layer.getZIndex() || 0,
+    opacity: layer.getOpacity(),
+    layer: markRaw(layer),
+    subLayers: [],
   };
+
+  if (layer instanceof LayerGroup) {
+    layerInfo.subLayers = layer
+      .getLayers()
+      .getArray()
+      .filter((child) => child.get("title"))
+      .map((child) => transformLayer(child));
+  }
+
+  return layerInfo;
+}
+
+function syncLayers() {
+  if (isMaplibreMode.value) {
+    otherLayers.value =
+      activeScenario?.geo.layerItemsLayers.value.map((layer, index) => ({
+        kind: "scenario-layer",
+        id: String(layer.id),
+        layerId: layer.id,
+        title: layer.name,
+        name: layer.name,
+        visible: !(layer.isHidden ?? false),
+        zIndex: index,
+        opacity: layer.opacity ?? 1,
+        layerType: layer.layerType,
+      })) ?? [];
+    return;
+  }
+
+  const nativeMap = geoStore.olMap;
+  if (!nativeMap) {
+    otherLayers.value = [];
+    return;
+  }
 
   const mappedLayers = nativeMap
     .getAllLayers()
-    .filter((l) => l.get("title"))
+    .filter((layer) => layer.get("title"))
     .map(transformLayer);
 
-  // We filter out baserlayers from here, as they are now managed by baseLayersStore
-  // Now we only want vector/other layers here.
-
-  vectorLayers.value = mappedLayers.filter(
+  otherLayers.value = mappedLayers.filter(
     ({ layer, layerType }) =>
       (layer instanceof VectorLayer ||
         layer instanceof LayerGroup ||
         layer instanceof ImageLayer) &&
       layerType !== "baselayer",
-  ) as LayerInfo<AnyVectorLayer>[];
+  );
 }
 
-const toggleLayer = (l: LayerInfo<any>) => {
-  l.visible = !l.visible;
-  l.layer.setOpacity(l.opacity);
-  l.layer.setVisible(l.visible);
-};
-
-function updateOpacity(l: LayerInfo<any>, opacity: number) {
-  if (l.layerType === "baselayer") {
-    baseLayersStore.setLayerOpacity(l.name, opacity);
+watchEffect(() => {
+  if (isMaplibreMode.value) {
+    activeScenario?.geo.layerItemsLayers.value;
   } else {
-    l.opacity = opacity;
-    l.layer.setOpacity(opacity);
+    geoStore.olMap;
   }
+  syncLayers();
+});
+
+function toggleLayer(layerInfo: PanelLayerInfo) {
+  layerInfo.visible = !layerInfo.visible;
+
+  if (layerInfo.kind === "openlayers") {
+    layerInfo.layer.setOpacity(layerInfo.opacity);
+    layerInfo.layer.setVisible(layerInfo.visible);
+    return;
+  }
+
+  activeScenario?.geo.updateLayer(layerInfo.layerId, { isHidden: !layerInfo.visible });
+}
+
+function updateOpacity(layerInfo: LayerInfo | PanelLayerInfo, opacity: number) {
+  if (layerInfo.layerType === "baselayer") {
+    if (isMaplibreMode.value) {
+      maplibreLayersStore.setLayerOpacity(layerInfo.name, opacity);
+    } else {
+      baseLayersStore.setLayerOpacity(layerInfo.name, opacity);
+    }
+    return;
+  }
+
+  if (layerInfo.kind === "openlayers") {
+    layerInfo.opacity = opacity;
+    layerInfo.layer.setOpacity(opacity);
+    return;
+  }
+
+  layerInfo.opacity = opacity;
+  activeScenario?.geo.updateLayer(layerInfo.layerId, { opacity });
 }
 </script>
 
@@ -151,7 +253,7 @@ function updateOpacity(l: LayerInfo<any>, opacity: number) {
 
     <div class="bg-card mt-4 overflow-hidden rounded-md shadow-sm">
       <ul class="divide-y">
-        <li v-for="layer in vectorLayers" :key="layer.id" class="px-6 py-4">
+        <li v-for="layer in otherLayers" :key="layer.id" class="px-6 py-4">
           <div class="flex items-center justify-between">
             <p class="flex-auto truncate text-sm">{{ layer.title }}</p>
             <div class="ml-2 flex shrink-0 items-center">

--- a/src/components/LayersPanel.vue
+++ b/src/components/LayersPanel.vue
@@ -34,17 +34,10 @@ export interface LayerInfo {
   description?: string;
   layerType?: LayerType | "baselayer" | "map-layer";
   supportsOpacity?: boolean;
+  kind?: "openlayers" | "scenario-layer";
+  nativeLayer?: unknown;
+  layerId?: FeatureId;
 }
-
-type PanelLayerInfo =
-  | (LayerInfo & {
-      kind: "openlayers";
-      layer: BaseLayer;
-    })
-  | (LayerInfo & {
-      kind: "scenario-layer";
-      layerId: FeatureId;
-    });
 
 const route = useRoute();
 const geoStore = useGeoStore();
@@ -53,7 +46,7 @@ const baseLayersStore = useBaseLayersStore();
 const maplibreLayersStore = useMaplibreLayersStore();
 const activeScenario = inject<TScenario | null>(activeScenarioKey, null);
 
-const otherLayers = ref<PanelLayerInfo[]>([]);
+const otherLayers = ref<LayerInfo[]>([]);
 const isMaplibreMode = computed(() => route.name === MAPLIBRE_ROUTE);
 
 const selectedBaseLayerId = computed(() => {
@@ -134,8 +127,8 @@ function setScenarioBaseMapId(baseMapId: string) {
   activeScenario.store.state.mapSettings.baseMapId = baseMapId;
 }
 
-function transformLayer(layer: BaseLayer): PanelLayerInfo {
-  const layerInfo: PanelLayerInfo = {
+function transformLayer(layer: BaseLayer): LayerInfo {
+  const layerInfo: LayerInfo = {
     kind: "openlayers",
     id: getUid(layer),
     title: layer.get("title") || layer.get("name"),
@@ -144,7 +137,7 @@ function transformLayer(layer: BaseLayer): PanelLayerInfo {
     visible: layer.getVisible(),
     zIndex: layer.getZIndex() || 0,
     opacity: layer.getOpacity(),
-    layer: markRaw(layer),
+    nativeLayer: markRaw(layer),
     subLayers: [],
   };
 
@@ -171,7 +164,6 @@ function syncLayers() {
         visible: !(layer.isHidden ?? false),
         zIndex: index,
         opacity: layer.opacity ?? 1,
-        layerType: layer.layerType,
       })) ?? [];
     return;
   }
@@ -188,10 +180,10 @@ function syncLayers() {
     .map(transformLayer);
 
   otherLayers.value = mappedLayers.filter(
-    ({ layer, layerType }) =>
-      (layer instanceof VectorLayer ||
-        layer instanceof LayerGroup ||
-        layer instanceof ImageLayer) &&
+    ({ nativeLayer, layerType }) =>
+      (nativeLayer instanceof VectorLayer ||
+        nativeLayer instanceof LayerGroup ||
+        nativeLayer instanceof ImageLayer) &&
       layerType !== "baselayer",
   );
 }
@@ -205,19 +197,21 @@ watchEffect(() => {
   syncLayers();
 });
 
-function toggleLayer(layerInfo: PanelLayerInfo) {
+function toggleLayer(layerInfo: LayerInfo) {
   layerInfo.visible = !layerInfo.visible;
 
-  if (layerInfo.kind === "openlayers") {
-    layerInfo.layer.setOpacity(layerInfo.opacity);
-    layerInfo.layer.setVisible(layerInfo.visible);
+  if (layerInfo.kind === "openlayers" && layerInfo.nativeLayer instanceof BaseLayer) {
+    layerInfo.nativeLayer.setOpacity(layerInfo.opacity);
+    layerInfo.nativeLayer.setVisible(layerInfo.visible);
     return;
   }
 
-  activeScenario?.geo.updateLayer(layerInfo.layerId, { isHidden: !layerInfo.visible });
+  if (layerInfo.layerId) {
+    activeScenario?.geo.updateLayer(layerInfo.layerId, { isHidden: !layerInfo.visible });
+  }
 }
 
-function updateOpacity(layerInfo: LayerInfo | PanelLayerInfo, opacity: number) {
+function updateOpacity(layerInfo: LayerInfo, opacity: number) {
   if (layerInfo.layerType === "baselayer") {
     if (isMaplibreMode.value) {
       maplibreLayersStore.setLayerOpacity(layerInfo.name, opacity);
@@ -227,14 +221,16 @@ function updateOpacity(layerInfo: LayerInfo | PanelLayerInfo, opacity: number) {
     return;
   }
 
-  if (layerInfo.kind === "openlayers") {
+  if (layerInfo.kind === "openlayers" && layerInfo.nativeLayer instanceof BaseLayer) {
     layerInfo.opacity = opacity;
-    layerInfo.layer.setOpacity(opacity);
+    layerInfo.nativeLayer.setOpacity(opacity);
     return;
   }
 
   layerInfo.opacity = opacity;
-  activeScenario?.geo.updateLayer(layerInfo.layerId, { opacity });
+  if (layerInfo.layerId) {
+    activeScenario?.geo.updateLayer(layerInfo.layerId, { opacity });
+  }
 }
 </script>
 

--- a/src/components/MapContextMenu.vue
+++ b/src/components/MapContextMenu.vue
@@ -230,18 +230,16 @@ function onAddPoint() {
 
   const newFeature: Omit<NGeometryLayerItem, "_pid"> = {
     kind: "geometry" as const,
-    type: "Feature",
     id: nanoid(),
-    meta: {
-      type: "Point",
-      name,
+    name,
+    geometryMeta: {
+      geometryKind: "Point",
     },
     geometry: {
       type: "Point",
       coordinates: dropPosition.value,
     },
     style: mainToolbarStore.currentDrawStyle ?? {},
-    properties: {},
   };
   geo.addFeature(newFeature, activeLayer.id);
 }
@@ -324,7 +322,7 @@ const baseMapId = computed({
               />
               <span
                 :class="[selectedFeatureIds.has(feature.id) ? 'font-semibold' : '']"
-                >{{ feature.meta.name }}</span
+                >{{ feature.name }}</span
               >
             </div>
           </ContextMenuItem>

--- a/src/components/MapHoverFeatureTooltip.vue
+++ b/src/components/MapHoverFeatureTooltip.vue
@@ -24,7 +24,7 @@ const rawHoveredFeatureName = computed(() => {
     const featureId = hoveredFeature?.getId?.();
     if (featureId === undefined || featureId === null) continue;
     const { layerItem: feature } = geo.getGeometryLayerItemById(featureId);
-    const name = feature?.meta?.name?.trim();
+    const name = feature?.name?.trim();
     if (name) return name;
   }
   return "";

--- a/src/components/ScenarioFeatureSelect.vue
+++ b/src/components/ScenarioFeatureSelect.vue
@@ -65,7 +65,9 @@ const selectedValue = defineModel<string | FeatureId>({
             :value="feature.id"
           >
             <component :is="getGeometryIcon(feature)" />
-            {{ feature.meta.name || feature.type || feature.geometry.type }}
+            {{
+              feature.name || feature.geometryMeta.geometryKind || feature.geometry.type
+            }}
           </SelectItem>
         </SelectGroup>
       </template>

--- a/src/components/ScenarioMapLogic.test.ts
+++ b/src/components/ScenarioMapLogic.test.ts
@@ -453,7 +453,7 @@ describe("ScenarioMapLogic", () => {
       geo: {
         everyVisibleUnit: ref([]),
         getGeometryLayerItemById: vi.fn(() => ({
-          layerItem: { meta: { name: "Bridge Alpha" } },
+          layerItem: { name: "Bridge Alpha" },
         })),
       },
       store: {
@@ -496,7 +496,7 @@ describe("ScenarioMapLogic", () => {
       geo: {
         everyVisibleUnit: ref([]),
         getGeometryLayerItemById: vi.fn(() => ({
-          layerItem: { meta: { name: "" } },
+          layerItem: { name: "" },
         })),
       },
       store: {
@@ -540,9 +540,8 @@ describe("ScenarioMapLogic", () => {
       geo: {
         everyVisibleUnit: ref([]),
         getGeometryLayerItemById: vi.fn((id: string) => {
-          if (id === "feature-empty") return { layerItem: { meta: { name: "" } } };
-          if (id === "feature-1")
-            return { layerItem: { meta: { name: "Bridge Alpha" } } };
+          if (id === "feature-empty") return { layerItem: { name: "" } };
+          if (id === "feature-1") return { layerItem: { name: "Bridge Alpha" } };
           return { layerItem: undefined };
         }),
       },

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,6 +1,6 @@
 import type { ScenarioVersion } from "@/types/scenarioModels";
 
-export const SCENARIO_FILE_VERSION: ScenarioVersion = "3.1.0";
+export const SCENARIO_FILE_VERSION: ScenarioVersion = "3.2.0";
 export const LOCALSTORAGE_KEY = "orbat-scenario4";
 export const SHARE_HISTORY_LOCALSTORAGE_KEY = "orbat-share-history";
 

--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
@@ -65,7 +65,6 @@ function createScenario() {
             id: "feature-1",
             kind: "geometry",
             _pid: "layer-1",
-            type: "Feature",
             geometry: {
               type: "LineString",
               coordinates: [
@@ -73,9 +72,8 @@ function createScenario() {
                 [15, 25],
               ],
             },
-            properties: {},
-            meta: {
-              type: "LineString",
+            geometryMeta: {
+              geometryKind: "LineString",
             },
             style: {
               "arrow-end": "arrow",
@@ -159,7 +157,6 @@ describe("createMapLibreScenarioLayerController", () => {
             id: "feature-1",
             kind: "geometry",
             _pid: "layer-1",
-            type: "Feature",
             geometry: {
               type: "LineString",
               coordinates: [
@@ -167,9 +164,8 @@ describe("createMapLibreScenarioLayerController", () => {
                 [30, 40],
               ],
             },
-            properties: {},
-            meta: {
-              type: "LineString",
+            geometryMeta: {
+              geometryKind: "LineString",
             },
             style: {
               "arrow-end": "arrow",

--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
@@ -58,16 +58,13 @@ function normalizeMapLayerExtent(
 function toCurrentFeature(feature: NGeometryLayerItem): GeoJsonFeature | undefined {
   const geometry = feature._state?.geometry ?? feature.geometry;
   if (!geometry) return;
-  if (feature.geometryMeta.radius && geometry.type === "Point") {
-    return turfCircle(
-      geometry.coordinates as Position,
-      feature.geometryMeta.radius / 1000,
-      {
-        steps: 48,
-        units: "kilometers",
-        properties: feature.userData ?? {},
-      },
-    ) as GeoJsonFeature;
+  const radius = feature.geometryMeta.radius;
+  if (typeof radius === "number" && geometry.type === "Point") {
+    return turfCircle(geometry.coordinates as Position, radius / 1000, {
+      steps: 48,
+      units: "kilometers",
+      properties: feature.userData ?? {},
+    }) as GeoJsonFeature;
   }
   return {
     type: "Feature",

--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
@@ -58,18 +58,22 @@ function normalizeMapLayerExtent(
 function toCurrentFeature(feature: NGeometryLayerItem): GeoJsonFeature | undefined {
   const geometry = feature._state?.geometry ?? feature.geometry;
   if (!geometry) return;
-  if (feature.meta.radius && geometry.type === "Point") {
-    return turfCircle(geometry.coordinates as Position, feature.meta.radius / 1000, {
-      steps: 48,
-      units: "kilometers",
-      properties: feature.properties ?? {},
-    }) as GeoJsonFeature;
+  if (feature.geometryMeta.radius && geometry.type === "Point") {
+    return turfCircle(
+      geometry.coordinates as Position,
+      feature.geometryMeta.radius / 1000,
+      {
+        steps: 48,
+        units: "kilometers",
+        properties: feature.userData ?? {},
+      },
+    ) as GeoJsonFeature;
   }
   return {
     type: "Feature",
     id: feature.id,
     geometry,
-    properties: feature.properties ?? {},
+    properties: feature.userData ?? {},
   };
 }
 

--- a/src/geo/engines/openlayers/olScenarioLayerController.ts
+++ b/src/geo/engines/openlayers/olScenarioLayerController.ts
@@ -652,10 +652,16 @@ export function useOlScenarioLayerController(olMap: OLMap): ScenarioLayerControl
   function zoomToFeatures(featureIds: FeatureId[]) {
     const scenario = activeScenario;
     if (!scenario) return;
+    const items = featureIds
+      .map((featureId) => scenario.geo.getLayerItemById(featureId).layerItem)
+      .filter(isNGeometryLayerItem);
     const collection = featureCollection(
-      featureIds
-        .map((featureId) => scenario.geo.getLayerItemById(featureId).layerItem)
-        .filter(isNGeometryLayerItem),
+      items.map((item) => ({
+        type: "Feature" as const,
+        id: item.id,
+        geometry: item._state?.geometry ?? item.geometry,
+        properties: {},
+      })),
     );
     if (!collection.features.length) return;
     const bboxFeature = new GeoJSON().readFeature(turfEnvelope(collection), {

--- a/src/geo/featureStyles.ts
+++ b/src/geo/featureStyles.ts
@@ -61,7 +61,8 @@ export function useFeatureStyles(geo: TGeo) {
     const scenarioFeature = layerItem;
 
     const {
-      meta: { name: label, _zIndex },
+      name: label,
+      _zIndex,
       style: {
         showLabel = false,
         limitVisibility,
@@ -75,7 +76,7 @@ export function useFeatureStyles(geo: TGeo) {
     if (!cachedStyle) {
       const baseStyle = createSimpleStyle(scenarioFeature.style || {}) || defaultStyle;
       // @ts-ignore
-      feature.set("_zIndex", scenarioFeature.meta._zIndex, true);
+      feature.set("_zIndex", scenarioFeature._zIndex, true);
 
       // Create arrow styles if applicable
       const geometry = feature.getGeometry();

--- a/src/importexport/export/geojsonConverter.ts
+++ b/src/importexport/export/geojsonConverter.ts
@@ -10,6 +10,7 @@ import {
   type GeometryLayerItem,
   type NScenarioLayerItem,
   isNGeometryLayerItem,
+  toGeometryLayerItemGeoJsonProperties,
 } from "@/types/scenarioLayerItems";
 
 export function useGeoJsonConverter(scenario: TScenario) {
@@ -48,14 +49,13 @@ export function useGeoJsonConverter(scenario: TScenario) {
           isNGeometryLayerItem(layerItem),
         )
         .map((f) => {
-          const { id, geometry, properties, meta } = f;
+          const { id, geometry } = f;
+          const properties = toGeometryLayerItemGeoJsonProperties(f);
           return {
             type: "Feature",
             id: options.includeId ? id : undefined,
             properties: {
               id: includeIdInProperties ? id : undefined,
-              name: meta.name,
-              description: meta.description,
               ...properties,
             },
             geometry,

--- a/src/modules/maplibreview/MaplibreContextMenu.test.ts
+++ b/src/modules/maplibreview/MaplibreContextMenu.test.ts
@@ -205,9 +205,7 @@ describe("MaplibreContextMenu", () => {
   function mountMenu(props?: Record<string, unknown>) {
     const feature = {
       id: "feature-1",
-      meta: {
-        name: "Feature 1",
-      },
+      name: "Feature 1",
     };
     const scenario = {
       store: {

--- a/src/modules/maplibreview/MaplibreContextMenu.vue
+++ b/src/modules/maplibreview/MaplibreContextMenu.vue
@@ -257,18 +257,16 @@ function onAddPoint() {
 
   const newFeature: Omit<NGeometryLayerItem, "_pid"> = {
     kind: "geometry" as const,
-    type: "Feature",
     id: nanoid(),
-    meta: {
-      type: "Point",
-      name,
+    name,
+    geometryMeta: {
+      geometryKind: "Point",
     },
     geometry: {
       type: "Point",
       coordinates: dropPosition.value,
     },
     style: mainToolbarStore.currentDrawStyle ?? {},
-    properties: {},
   };
   geo.addFeature(newFeature, activeLayer.id);
 }
@@ -382,7 +380,7 @@ function onContextMenu(event: MouseEvent) {
                 class="text-muted-foreground mr-1 h-5 w-5"
               />
               <span :class="[selectedFeatureIds.has(feature.id) ? 'font-semibold' : '']">
-                {{ feature.meta.name }}
+                {{ feature.name }}
               </span>
             </div>
           </ContextMenuItem>

--- a/src/modules/maplibreview/ScenarioEditorMaplibre.vue
+++ b/src/modules/maplibreview/ScenarioEditorMaplibre.vue
@@ -93,7 +93,16 @@ provide(activeFeatureSelectInteractionKey, featureSelectStub);
 const geoStore = useGeoStore();
 const maplibreLayersStore = useMaplibreLayersStore();
 const mapSettingsStore = useMapSettingsStore();
-const maplibreBaseMapId = ref(MAPLIBRE_VECTOR_BASEMAP_ID);
+const maplibreBaseMapId = computed({
+  get: () =>
+    resolveMaplibreBasemap(state.mapSettings.baseMapId, maplibreLayersStore.layers).id,
+  set: (value: string) => {
+    activeScenario.store.update((draft) => {
+      draft.mapSettings.baseMapId = value;
+    });
+    mapSettingsStore.baseLayerName = value;
+  },
+});
 
 const effectiveProjection = computed<MapProjection>(() =>
   state.mapSettings.maxExtent ? "mercator" : mapSettingsStore.mapProjection,

--- a/src/modules/maplibreview/maplibreScenarioFeatures.test.ts
+++ b/src/modules/maplibreview/maplibreScenarioFeatures.test.ts
@@ -14,14 +14,12 @@ describe("buildScenarioFeatureRenderPlan", () => {
             id: "circle-1",
             kind: "geometry",
             _pid: "layer-1",
-            type: "Feature",
             geometry: {
               type: "Point",
               coordinates: [10, 20],
             },
-            properties: {},
-            meta: {
-              type: "Circle",
+            geometryMeta: {
+              geometryKind: "Circle",
               radius: 1500,
             },
             style: {},
@@ -49,16 +47,13 @@ describe("buildScenarioFeatureRenderPlan", () => {
             id: "point-1",
             kind: "geometry",
             _pid: "layer-2",
-            type: "Feature",
             geometry: {
               type: "Point",
               coordinates: [10, 20],
             },
-            properties: { name: "Alpha" },
-            meta: {
-              type: "Point",
-              name: "Alpha",
-            },
+            userData: { name: "Alpha" },
+            geometryMeta: { geometryKind: "Point" },
+            name: "Alpha",
             style: {
               showLabel: true,
               "marker-symbol": "square",
@@ -69,7 +64,6 @@ describe("buildScenarioFeatureRenderPlan", () => {
             id: "line-1",
             kind: "geometry",
             _pid: "layer-2",
-            type: "Feature",
             geometry: {
               type: "LineString",
               coordinates: [
@@ -77,10 +71,7 @@ describe("buildScenarioFeatureRenderPlan", () => {
                 [15, 25],
               ],
             },
-            properties: {},
-            meta: {
-              type: "LineString",
-            },
+            geometryMeta: { geometryKind: "LineString" },
             style: {
               "arrow-end": "arrow",
               "stroke-style": "dashed",
@@ -91,15 +82,11 @@ describe("buildScenarioFeatureRenderPlan", () => {
             kind: "geometry",
             _pid: "layer-2",
             _hidden: true,
-            type: "Feature",
             geometry: {
               type: "Point",
               coordinates: [0, 0],
             },
-            properties: {},
-            meta: {
-              type: "Point",
-            },
+            geometryMeta: { geometryKind: "Point" },
             style: {},
           },
         ],
@@ -163,7 +150,6 @@ describe("buildScenarioFeatureRenderPlan", () => {
             id: "line-2",
             kind: "geometry",
             _pid: "layer-3",
-            type: "Feature",
             geometry: {
               type: "LineString",
               coordinates: [
@@ -172,10 +158,7 @@ describe("buildScenarioFeatureRenderPlan", () => {
                 [1, 1],
               ],
             },
-            properties: {},
-            meta: {
-              type: "LineString",
-            },
+            geometryMeta: { geometryKind: "LineString" },
             style: {
               "arrow-start": "arrow",
               "arrow-end": "arrow",
@@ -215,7 +198,6 @@ describe("buildScenarioFeatureRenderPlan", () => {
             id: "line-3",
             kind: "geometry",
             _pid: "layer-4",
-            type: "Feature",
             geometry: {
               type: "LineString",
               coordinates: [
@@ -223,10 +205,7 @@ describe("buildScenarioFeatureRenderPlan", () => {
                 [0, 1],
               ],
             },
-            properties: {},
-            meta: {
-              type: "LineString",
-            },
+            geometryMeta: { geometryKind: "LineString" },
             style: {
               "arrow-end": "bar",
               "stroke-width": 10,
@@ -266,7 +245,6 @@ describe("buildScenarioFeatureRenderPlan", () => {
             id: "line-4",
             kind: "geometry",
             _pid: "layer-5",
-            type: "Feature",
             geometry: {
               type: "LineString",
               coordinates: [
@@ -274,10 +252,7 @@ describe("buildScenarioFeatureRenderPlan", () => {
                 [1, 0],
               ],
             },
-            properties: {},
-            meta: {
-              type: "LineString",
-            },
+            geometryMeta: { geometryKind: "LineString" },
             style: {
               "arrow-end": "arrow",
               "stroke-width": 4,
@@ -316,7 +291,6 @@ describe("buildScenarioFeatureRenderPlan", () => {
             id: "line-5",
             kind: "geometry",
             _pid: "layer-6",
-            type: "Feature",
             geometry: {
               type: "LineString",
               coordinates: [
@@ -324,10 +298,7 @@ describe("buildScenarioFeatureRenderPlan", () => {
                 [1, 1],
               ],
             },
-            properties: {},
-            meta: {
-              type: "LineString",
-            },
+            geometryMeta: { geometryKind: "LineString" },
             style: {
               "arrow-end": "arrow-hand-drawn",
             },

--- a/src/modules/maplibreview/maplibreScenarioFeatures.ts
+++ b/src/modules/maplibreview/maplibreScenarioFeatures.ts
@@ -30,7 +30,10 @@ import type {
   FullScenarioLayerItemsLayer,
   NGeometryLayerItem,
 } from "@/types/scenarioLayerItems";
-import { isNGeometryLayerItem } from "@/types/scenarioLayerItems";
+import {
+  getGeometryLayerItemLabelText,
+  isNGeometryLayerItem,
+} from "@/types/scenarioLayerItems";
 import { hashObject } from "@/utils";
 import type { ArrowType } from "@/geo/simplestyle";
 
@@ -143,7 +146,7 @@ function toRgbaColor(
 }
 
 function getLabelText(feature: NGeometryLayerItem) {
-  return feature.meta.name || feature.properties?.title || feature.properties?.name || "";
+  return getGeometryLayerItemLabelText(feature);
 }
 
 function getCurrentGeometry(feature: NGeometryLayerItem) {
@@ -268,11 +271,15 @@ function getTextVisibilityGroup(style: StyleLike, layerId: string) {
 
 function convertCircleFeature(feature: NGeometryLayerItem) {
   const geometry = getCurrentGeometry(feature);
-  if (!feature.meta.radius || geometry.type !== "Point") return geometry;
-  return turfCircle(geometry.coordinates as Position, feature.meta.radius / 1000, {
-    steps: 48,
-    units: "kilometers",
-  }).geometry;
+  if (!feature.geometryMeta.radius || geometry.type !== "Point") return geometry;
+  return turfCircle(
+    geometry.coordinates as Position,
+    feature.geometryMeta.radius / 1000,
+    {
+      steps: 48,
+      units: "kilometers",
+    },
+  ).geometry;
 }
 
 function flattenGeometry(
@@ -424,7 +431,7 @@ function buildFeatureData(
           geometryKind,
           renderGroup: renderGroup.id,
           selected: selectedFeatureIds.has(item.id),
-          zIndex: item.meta._zIndex ?? index,
+          zIndex: item._zIndex ?? index,
           strokeColor,
           strokeWidth,
           strokeStyle: style["stroke-style"] || "solid",
@@ -455,7 +462,7 @@ function buildFeatureData(
               layerId,
               labelGroup: labelGroup.id,
               selected: selectedFeatureIds.has(item.id),
-              zIndex: item.meta._zIndex ?? index,
+              zIndex: item._zIndex ?? index,
               textField: labelText,
               textColor: "#333333",
               textHaloColor: "#FBFCFB",
@@ -501,7 +508,7 @@ function buildFeatureData(
             layerId,
             arrowGroup: group.id,
             selected: selectedFeatureIds.has(item.id),
-            zIndex: item.meta._zIndex ?? 0,
+            zIndex: item._zIndex ?? 0,
             arrowImageId: imageId,
             iconAnchor: group.iconAnchor,
             iconScale: arrowIconScale,
@@ -536,7 +543,7 @@ function buildFeatureData(
             layerId,
             arrowGroup: group.id,
             selected: selectedFeatureIds.has(item.id),
-            zIndex: item.meta._zIndex ?? 0,
+            zIndex: item._zIndex ?? 0,
             arrowImageId: imageId,
             iconAnchor: group.iconAnchor,
             iconScale: arrowIconScale,

--- a/src/modules/maplibreview/maplibreScenarioFeatures.ts
+++ b/src/modules/maplibreview/maplibreScenarioFeatures.ts
@@ -271,7 +271,8 @@ function getTextVisibilityGroup(style: StyleLike, layerId: string) {
 
 function convertCircleFeature(feature: NGeometryLayerItem) {
   const geometry = getCurrentGeometry(feature);
-  if (!feature.geometryMeta.radius || geometry.type !== "Point") return geometry;
+  if (feature.geometryMeta.radius === undefined || geometry.type !== "Point")
+    return geometry;
   return turfCircle(
     geometry.coordinates as Position,
     feature.geometryMeta.radius / 1000,

--- a/src/modules/scenarioeditor/EditMetaForm.vue
+++ b/src/modules/scenarioeditor/EditMetaForm.vue
@@ -52,7 +52,7 @@ const form = ref<Partial<ItemMetaForm>>({
 const isScenarioFeatureType = (
   item: NUnit | NGeometryLayerItem | NScenarioEvent,
 ): item is NGeometryLayerItem => {
-  return "type" in item && item.type == "Feature";
+  return "kind" in item && item.kind === "geometry";
 };
 
 const isScenarioEventType = (
@@ -79,9 +79,9 @@ watch(
     if (!item) return;
     if (isScenarioFeatureType(item)) {
       form.value = {
-        name: item?.meta?.name ?? "",
-        description: item?.meta?.description ?? "",
-        externalUrl: item?.meta?.externalUrl ?? "",
+        name: item?.name ?? "",
+        description: item?.description ?? "",
+        externalUrl: item?.externalUrl ?? "",
       };
     } else if (isUnitType(item)) {
       form.value = {

--- a/src/modules/scenarioeditor/FeatureTransformations.vue
+++ b/src/modules/scenarioeditor/FeatureTransformations.vue
@@ -100,11 +100,11 @@ function createScenarioFeatureFromGeoJSON(
 ): NGeometryLayerItem {
   return {
     kind: "geometry",
-    type: "Feature",
     id: nanoid(),
-    properties: feature.properties ?? {},
+    userData: (feature.properties as Record<string, unknown> | undefined) ?? {},
     geometry: feature.geometry,
-    meta: { type: feature.geometry.type, name: "New Feature" },
+    geometryMeta: { geometryKind: feature.geometry.type },
+    name: "New Feature",
     style: {},
     _pid: layerId,
   };
@@ -182,9 +182,9 @@ function onSubmit(updateMode = false) {
 
     const activeFeatureName = isUnitMode
       ? (activeFeature as NUnit).name
-      : (activeFeature as NGeometryLayerItem).meta.name;
+      : (activeFeature as NGeometryLayerItem).name;
     const featureName = isMultiMode.value ? "FeatureCollection" : activeFeatureName;
-    scenarioFeature.meta.name = `${featureName} (${filteredTrans[0].transform})`;
+    scenarioFeature.name = `${featureName} (${filteredTrans[0].transform})`;
     scn.geo.addFeature(scenarioFeature, layerId!);
   }
   previewLayer.getSource()?.clear();

--- a/src/modules/scenarioeditor/MapEditorDrawToolbar.vue
+++ b/src/modules/scenarioeditor/MapEditorDrawToolbar.vue
@@ -77,8 +77,8 @@ function updateFeatureGeometryFromOlFeature(olFeature: Feature, updateState = fa
   const { layerItem: feature, layer } = geo.getGeometryLayerItemById(id) || {};
   if (!(feature && layer)) return;
   const dataUpdate = {
-    meta: { ...feature.meta, ...t.meta },
-    properties: { ...feature.properties, ...t.properties },
+    geometryMeta: { ...feature.geometryMeta, ...t.geometryMeta },
+    userData: { ...(feature.userData ?? {}), ...(t.userData ?? {}) },
     geometry: t.geometry,
   };
   if (updateState) {
@@ -100,10 +100,10 @@ function addOlFeature(olFeature: Feature, olLayer: AnyVectorLayer) {
 
   const _zIndex = Math.max(
     scenarioLayer.items.length,
-    (lastFeatureInLayer?.meta._zIndex || 0) + 1,
+    (lastFeatureInLayer?._zIndex || 0) + 1,
   );
-  scenarioFeature.meta.name = `${scenarioFeature.meta.type} ${_zIndex + 1}`;
-  scenarioFeature.meta._zIndex = _zIndex;
+  scenarioFeature.name = `${scenarioFeature.geometryMeta.geometryKind} ${_zIndex + 1}`;
+  scenarioFeature._zIndex = _zIndex;
   scenarioFeature.style = currentDrawStyle.value ?? {};
 
   olFeature.set("_zIndex", _zIndex);

--- a/src/modules/scenarioeditor/ScenarioEditor.test.ts
+++ b/src/modules/scenarioeditor/ScenarioEditor.test.ts
@@ -160,7 +160,10 @@ describe("ScenarioEditor", () => {
       routes,
     });
 
-    await router.push({ name: MAP_EDIT_MODE_ROUTE, params: { scenarioId: "scenario-1" } });
+    await router.push({
+      name: MAP_EDIT_MODE_ROUTE,
+      params: { scenarioId: "scenario-1" },
+    });
     await router.isReady();
 
     mount(ScenarioEditor, {
@@ -212,7 +215,10 @@ describe("ScenarioEditor", () => {
       routes,
     });
 
-    await router.push({ name: MAP_EDIT_MODE_ROUTE, params: { scenarioId: "scenario-1" } });
+    await router.push({
+      name: MAP_EDIT_MODE_ROUTE,
+      params: { scenarioId: "scenario-1" },
+    });
     await router.isReady();
 
     mount(ScenarioEditor, {
@@ -247,7 +253,10 @@ describe("ScenarioEditor", () => {
 
     await router.push({ name: MAPLIBRE_ROUTE, params: { scenarioId: "scenario-1" } });
     await flushPromises();
-    await router.push({ name: MAP_EDIT_MODE_ROUTE, params: { scenarioId: "scenario-1" } });
+    await router.push({
+      name: MAP_EDIT_MODE_ROUTE,
+      params: { scenarioId: "scenario-1" },
+    });
     await flushPromises();
     await router.push({ name: MAPLIBRE_ROUTE, params: { scenarioId: "scenario-1" } });
     await flushPromises();

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.test.ts
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.test.ts
@@ -27,16 +27,14 @@ describe("ScenarioFeatureDetails", () => {
       id: "feature-1",
       kind: "geometry",
       _pid: "layer-1",
-      type: "Feature",
       geometry: {
         type: "Point",
         coordinates: [10, 20],
       },
-      properties: {},
-      meta: {
-        type: "Point",
-        name: "Alpha",
+      geometryMeta: {
+        geometryKind: "Point",
       },
+      name: "Alpha",
       style: {},
     };
 

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
@@ -11,7 +11,6 @@ import { injectStrict } from "@/utils";
 import { activeScenarioKey, activeScenarioMapEngineKey } from "@/components/injects";
 import { computed, defineAsyncComponent, ref, watch } from "vue";
 import { getGeometryIcon } from "@/modules/scenarioeditor/featureLayerUtils";
-import { type ScenarioFeatureMeta } from "@/types/scenarioGeoModels";
 import { useDebounceFn } from "@vueuse/core";
 import ScenarioFeatureMarkerSettings from "@/modules/scenarioeditor/ScenarioFeatureMarkerSettings.vue";
 import ScenarioFeatureStrokeSettings from "@/modules/scenarioeditor/ScenarioFeatureStrokeSettings.vue";
@@ -77,9 +76,7 @@ const feature = computed(() => {
 
 const featureName = ref("DD");
 const featureDescription = ref();
-const hDescription = computed(() =>
-  renderMarkdown(feature.value?.meta.description || ""),
-);
+const hDescription = computed(() => renderMarkdown(feature.value?.description || ""));
 
 const isEditMode = ref(false);
 
@@ -110,15 +107,15 @@ function showStylePanel() {
 }
 
 watch(
-  () => feature.value?.meta.name,
+  () => feature.value?.name,
   (v) => {
     featureName.value = v ?? "";
-    featureDescription.value = feature.value?.meta.description ?? "";
+    featureDescription.value = feature.value?.description ?? "";
   },
   { immediate: true },
 );
 
-const geometryType = computed(() => feature.value?.meta.type);
+const geometryType = computed(() => feature.value?.geometryMeta.geometryKind);
 const hasStroke = computed(() => geometryType.value !== "Point");
 const hasArrows = computed(() => geometryType.value === "LineString");
 const hasFill = computed(
@@ -165,7 +162,7 @@ const media = computed(() => {
 });
 
 function updateValue(value: string) {
-  feature.value && geo.updateFeature(feature.value?.id, { meta: { name: value } });
+  feature.value && geo.updateFeature(feature.value?.id, { name: value });
 }
 
 const debouncedResetMap = useDebounceFn(
@@ -192,8 +189,10 @@ function doUpdateFeature(data: GeometryLayerItemUpdate) {
   debouncedResetMap();
 }
 
-function doMetaUpdate(data: Partial<ScenarioFeatureMeta>) {
-  if (data) doUpdateFeature({ meta: data });
+function doMetaUpdate(
+  data: Pick<GeometryLayerItemUpdate, "name" | "description" | "externalUrl">,
+) {
+  if (data) doUpdateFeature(data);
   isEditMode.value = false;
 }
 

--- a/src/modules/scenarioeditor/ScenarioFeatureLayer.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureLayer.vue
@@ -105,7 +105,7 @@ const defaultLayerMenuItems: MenuItemData<ScenarioLayerAction>[] = [
 ];
 
 function toggleFeatureVisibility(feature: NGeometryLayerItem) {
-  geo.updateFeature(feature.id, { meta: { isHidden: !feature.meta.isHidden } });
+  geo.updateFeature(feature.id, { isHidden: !feature.isHidden });
 }
 
 function toggleFeatureLayerVisibility(layer: NScenarioLayer) {

--- a/src/modules/scenarioeditor/ScenarioFeatureListItem.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureListItem.vue
@@ -132,7 +132,7 @@ onUnmounted(() => {
         class="group-hover:text-accent-foreground text-foreground ml-2 text-left text-sm"
         :class="{ 'font-bold': active, 'opacity-50': hidden }"
       >
-        {{ feature.meta.name || feature.type || feature.geometry.type }}
+        {{ feature.name || feature.geometryMeta.geometryKind || feature.geometry.type }}
       </span>
     </button>
     <div class="relative flex items-center">
@@ -142,12 +142,12 @@ onUnmounted(() => {
         class="text-muted-foreground hover:text-foreground mr-1 opacity-0 group-focus-within:opacity-100 group-hover:opacity-100"
         title="Toggle visibility"
       >
-        <IconEyeOff v-if="feature.meta.isHidden" class="size-5" />
+        <IconEyeOff v-if="feature.isHidden" class="size-5" />
         <IconEye v-else class="size-5" />
       </button>
 
       <IconClockOutline
-        v-if="feature.meta.visibleFromT || feature.meta.visibleUntilT"
+        v-if="feature.visibleFromT || feature.visibleUntilT"
         class="text-muted-foreground h-5 w-5"
       />
       <DotsMenu

--- a/src/modules/scenarioeditor/featureLayerUtils.items.test.ts
+++ b/src/modules/scenarioeditor/featureLayerUtils.items.test.ts
@@ -7,11 +7,12 @@ import type { AnnotationLayerItem, GeometryLayerItem } from "@/types/scenarioLay
 
 const geometryItem: GeometryLayerItem = {
   kind: "geometry",
-  type: "Feature",
   id: "feature-1",
   geometry: { type: "Point", coordinates: [10, 60] },
-  properties: { status: "active" },
-  meta: { type: "Point", name: "HQ", description: "Headquarters" },
+  geometryMeta: { geometryKind: "Point" },
+  name: "HQ",
+  description: "Headquarters",
+  userData: { status: "active" },
   style: { showLabel: true },
 };
 

--- a/src/modules/scenarioeditor/featureLayerUtils.ts
+++ b/src/modules/scenarioeditor/featureLayerUtils.ts
@@ -156,12 +156,13 @@ export function layerItemsToGeoJsonString(
               description: f.meta.description,
               ...f.properties,
             };
+      const radius = getGeometryRadius(f);
       if (
         getGeometryKind(f) === "Circle" &&
-        getGeometryRadius(f) &&
+        radius !== undefined &&
         f.geometry.type === "Point"
       ) {
-        const poly = turfCircle(f.geometry.coordinates, getGeometryRadius(f)!, {
+        const poly = turfCircle(f.geometry.coordinates, radius, {
           units: "meters",
         });
         return { ...poly, id: f.id, properties };
@@ -225,14 +226,15 @@ export function projectGeometryLayerItemToOlFeature(
   } else {
     feature.meta._zIndex = index;
   }
-  if (getGeometryRadius(feature) && feature.geometry.type === "Point") {
+  const radius = getGeometryRadius(feature);
+  if (radius !== undefined && feature.geometry.type === "Point") {
     const newRadius = convertRadius(
       {
         type: "Feature",
         geometry: feature.geometry,
         properties: {},
       } as GeoJsonFeature<Point>,
-      getGeometryRadius(feature)!,
+      radius,
     );
     const circle = new Circle(
       fromLonLat(feature.geometry.coordinates as number[]),

--- a/src/modules/scenarioeditor/featureLayerUtils.ts
+++ b/src/modules/scenarioeditor/featureLayerUtils.ts
@@ -45,6 +45,7 @@ import type { GeometryLayerItem, ScenarioLayerItem } from "@/types/scenarioLayer
 import {
   isGeometryLayerItemLike,
   isNGeometryLayerItem,
+  toGeometryLayerItemGeoJsonProperties,
 } from "@/types/scenarioLayerItems";
 import { useScenarioFeatureSelection } from "@/modules/scenarioeditor/useScenarioFeatureSelection";
 import { useSelectionActions } from "@/composables/selectionActions";
@@ -89,6 +90,24 @@ const geometryIconMap: any = {
 
 type GeometryFeatureLike = GeometryLayerItem | NGeometryLayerItem | ScenarioFeature;
 
+function getGeometryKind(item: GeometryFeatureLike): string {
+  return "geometryMeta" in item ? item.geometryMeta.geometryKind : item.meta.type;
+}
+
+function getGeometryRadius(item: GeometryFeatureLike): number | undefined {
+  return "geometryMeta" in item ? item.geometryMeta.radius : item.meta.radius;
+}
+
+function getGeometryUserData(
+  item: GeometryFeatureLike,
+): Record<string, unknown> | undefined {
+  if ("userData" in item) return item.userData;
+  return (
+    ((item as ScenarioFeature).properties as Record<string, unknown> | undefined) ??
+    undefined
+  );
+}
+
 function isGeometryFeatureLike(
   item: ScenarioLayerItem | NGeometryLayerItem | ScenarioFeature,
 ): item is GeometryFeatureLike {
@@ -99,7 +118,7 @@ function getItemIconKey(
   item?: ScenarioFeature | NGeometryLayerItem | ScenarioLayerItem,
 ): string | undefined {
   if (!item) return undefined;
-  if (isGeometryLayerItemLike(item)) return item.meta.type;
+  if (isGeometryLayerItemLike(item)) return getGeometryKind(item as GeometryFeatureLike);
   return "kind" in item ? item.kind : undefined;
 }
 
@@ -129,13 +148,20 @@ export function layerItemsToGeoJsonString(
 ) {
   const fc = featureCollection(
     items.filter(isGeometryFeatureLike).map((f) => {
-      const properties = {
-        name: f.meta.name,
-        description: f.meta.description,
-        ...f.properties,
-      };
-      if (f.meta.type === "Circle" && f.meta.radius && f.geometry.type === "Point") {
-        const poly = turfCircle(f.geometry.coordinates, f.meta.radius, {
+      const properties =
+        "geometryMeta" in f
+          ? toGeometryLayerItemGeoJsonProperties(f)
+          : {
+              name: f.meta.name,
+              description: f.meta.description,
+              ...f.properties,
+            };
+      if (
+        getGeometryKind(f) === "Circle" &&
+        getGeometryRadius(f) &&
+        f.geometry.type === "Point"
+      ) {
+        const poly = turfCircle(f.geometry.coordinates, getGeometryRadius(f)!, {
           units: "meters",
         });
         return { ...poly, id: f.id, properties };
@@ -194,11 +220,19 @@ export function projectGeometryLayerItemToOlFeature(
     };
   }
 
-  feature.meta._zIndex = index;
-  if (feature.meta?.radius && feature.geometry.type === "Point") {
+  if ("geometryMeta" in feature) {
+    feature._zIndex = index;
+  } else {
+    feature.meta._zIndex = index;
+  }
+  if (getGeometryRadius(feature) && feature.geometry.type === "Point") {
     const newRadius = convertRadius(
-      feature as GeoJsonFeature<Point>,
-      feature.meta.radius,
+      {
+        type: "Feature",
+        geometry: feature.geometry,
+        properties: {},
+      } as GeoJsonFeature<Point>,
+      getGeometryRadius(feature)!,
     );
     const circle = new Circle(
       fromLonLat(feature.geometry.coordinates as number[]),
@@ -206,16 +240,27 @@ export function projectGeometryLayerItemToOlFeature(
     );
     const f = new Feature({
       geometry: circle,
-      ...feature.properties,
+      ...(getGeometryUserData(feature) ?? {}),
     });
     f.setId(feature.id);
     return f;
   }
 
-  return gjson.readFeature(feature, {
-    featureProjection,
-    dataProjection: "EPSG:4326",
-  }) as Feature;
+  return gjson.readFeature(
+    {
+      type: "Feature",
+      id: feature.id,
+      geometry: feature.geometry,
+      properties:
+        "geometryMeta" in feature
+          ? toGeometryLayerItemGeoJsonProperties(feature)
+          : (feature.properties ?? {}),
+    },
+    {
+      featureProjection,
+      dataProjection: "EPSG:4326",
+    },
+  ) as Feature;
 }
 
 export function createScenarioLayerItemFeatures(
@@ -362,7 +407,15 @@ export function useFeatureLayerUtils(
 
   function zoomToFeatures(featureIds: FeatureId[]) {
     const c = featureCollection(
-      featureIds.map((fid) => state.layerItemMap[fid]).filter(isNGeometryLayerItem),
+      featureIds
+        .map((fid) => state.layerItemMap[fid])
+        .filter(isNGeometryLayerItem)
+        .map((item) => ({
+          type: "Feature" as const,
+          id: item.id,
+          geometry: item._state?.geometry ?? item.geometry,
+          properties: {},
+        })),
     );
     const bb = new GeoJSON().readFeature(turfEnvelope(c), {
       featureProjection: "EPSG:3857",

--- a/src/modules/scenarioeditor/scenarioFeatureLayers.ts
+++ b/src/modules/scenarioeditor/scenarioFeatureLayers.ts
@@ -2,7 +2,7 @@ import OLMap from "ol/Map";
 import { injectStrict, nanoid } from "@/utils";
 import { activeFeatureStylesKey, activeScenarioKey } from "@/components/injects";
 import type { ScenarioFeatureLayerEvent } from "@/scenariostore/geo";
-import type { FeatureId, ScenarioFeatureMeta } from "@/types/scenarioGeoModels";
+import type { FeatureId } from "@/types/scenarioGeoModels";
 import type { NGeometryLayerItem, ScenarioLayerUpdate } from "@/types/internalModels";
 import { type ProjectionLike, toLonLat } from "ol/proj";
 import VectorLayer from "ol/layer/Vector";
@@ -263,18 +263,16 @@ export function convertOlFeatureToScenarioFeature(olFeature: Feature): GeometryL
     const { geometry, properties = {} } = olFeature.getProperties();
     const center = circle.getCenter();
     const r = addCoordinate([...center], [0, circle.getRadius()]);
-    const meta: ScenarioFeatureMeta = {
-      type: "Circle",
-      radius: getLength(new LineString([center, r])),
-    };
 
     return {
       kind: "geometry",
-      type: "Feature",
       id: String(olFeature.getId() || nanoid()),
       geometry: point(toLonLat(circle.getCenter())).geometry,
-      properties,
-      meta,
+      geometryMeta: {
+        geometryKind: "Circle",
+        radius: getLength(new LineString([center, r])),
+      },
+      userData: properties,
       style: {},
     };
   }
@@ -285,11 +283,10 @@ export function convertOlFeatureToScenarioFeature(olFeature: Feature): GeometryL
 
   return {
     kind: "geometry",
-    type: gj.type,
     id: String(gj.id ?? nanoid()),
     geometry: gj.geometry,
-    properties: gj.properties ?? {},
+    userData: gj.properties ?? {},
     style: {},
-    meta: { type: gj.geometry.type },
+    geometryMeta: { geometryKind: gj.geometry.type },
   };
 }

--- a/src/scenariostore/geo.ts
+++ b/src/scenariostore/geo.ts
@@ -126,8 +126,8 @@ function getReferenceLayerFromMap(
 }
 
 function updateGeometryItemHidden(feature: NGeometryLayerItem, currentTime: number) {
-  const visibleFromT = feature.visibleFromT || Number.MIN_SAFE_INTEGER;
-  const visibleUntilT = feature.visibleUntilT || Number.MAX_SAFE_INTEGER;
+  const visibleFromT = feature.visibleFromT ?? Number.MIN_SAFE_INTEGER;
+  const visibleUntilT = feature.visibleUntilT ?? Number.MAX_SAFE_INTEGER;
   const timeHidden = currentTime <= visibleFromT || currentTime >= visibleUntilT;
   feature._hidden = timeHidden || !!feature.isHidden;
 }

--- a/src/scenariostore/geo.ts
+++ b/src/scenariostore/geo.ts
@@ -132,6 +132,20 @@ function updateGeometryItemHidden(feature: NGeometryLayerItem, currentTime: numb
   feature._hidden = timeHidden || !!feature.isHidden;
 }
 
+function mergeGeometryUserData(
+  current: Record<string, unknown> | undefined,
+  next: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  const merged = {
+    ...(current ?? {}),
+    ...(next ?? {}),
+  };
+  Object.keys(merged).forEach((key) => {
+    if (merged[key] === undefined) delete merged[key];
+  });
+  return Object.keys(merged).length ? merged : undefined;
+}
+
 export function useGeo(store: NewScenarioStore) {
   const { state, update } = store;
   const mapLayerEvent = createEventHook<ScenarioMapLayerEvent>();
@@ -629,10 +643,7 @@ export function useGeo(store: NewScenarioStore) {
           if (state) feature.state = state;
           if (media) feature.media = media;
           if (userData) {
-            feature.userData = {
-              ...(feature.userData ?? {}),
-              ...userData,
-            };
+            feature.userData = mergeGeometryUserData(feature.userData, userData);
           }
           if (name !== undefined) feature.name = name;
           if (description !== undefined) feature.description = description;
@@ -659,18 +670,10 @@ export function useGeo(store: NewScenarioStore) {
       Object.assign(layerItem.geometryMeta, data.geometryMeta ?? {});
       if (data.geometry) Object.assign(layerItem.geometry, data.geometry);
       if (data.userData) {
-        layerItem.userData = {
-          ...(layerItem.userData ?? {}),
-          ...data.userData,
-        };
+        layerItem.userData = mergeGeometryUserData(layerItem.userData, data.userData);
       }
-      Object.assign(layerItem, {
-        ...data,
-        style: layerItem.style,
-        geometryMeta: layerItem.geometryMeta,
-        geometry: layerItem.geometry,
-        userData: layerItem.userData,
-      });
+      const { geometry, geometryMeta, style, userData, ...topLevelData } = data;
+      Object.assign(layerItem, topLevelData);
       updateGeometryItemHidden(layerItem, state.currentTime);
     }
     if (data.state) {

--- a/src/scenariostore/geo.ts
+++ b/src/scenariostore/geo.ts
@@ -125,6 +125,13 @@ function getReferenceLayerFromMap(
   return isScenarioReferenceLayer(layer) ? (layer as NScenarioReferenceLayer) : undefined;
 }
 
+function updateGeometryItemHidden(feature: NGeometryLayerItem, currentTime: number) {
+  const visibleFromT = feature.visibleFromT || Number.MIN_SAFE_INTEGER;
+  const visibleUntilT = feature.visibleUntilT || Number.MAX_SAFE_INTEGER;
+  const timeHidden = currentTime <= visibleFromT || currentTime >= visibleUntilT;
+  feature._hidden = timeHidden || !!feature.isHidden;
+}
+
 export function useGeo(store: NewScenarioStore) {
   const { state, update } = store;
   const mapLayerEvent = createEventHook<ScenarioMapLayerEvent>();
@@ -334,7 +341,7 @@ export function useGeo(store: NewScenarioStore) {
         layer.items.forEach((fid, i) => {
           const feature = getGeometryLayerItemFromMap(s.layerItemMap, fid);
           if (!feature) return;
-          if (feature.meta._zIndex !== i) feature.meta._zIndex = i;
+          if (feature._zIndex !== i) feature._zIndex = i;
         });
       },
       { label: "moveFeature", value: featureId },
@@ -597,23 +604,48 @@ export function useGeo(store: NewScenarioStore) {
         (s) => {
           const feature = getGeometryLayerItemFromMap(s.layerItemMap, featureId);
           if (!feature) return;
-          const { properties = {}, geometry, media, style = {}, meta = {}, state } = data;
+          const {
+            geometry,
+            geometryMeta = {},
+            media,
+            style = {},
+            state,
+            userData,
+            name,
+            description,
+            externalUrl,
+            locked,
+            isHidden,
+            visibleFromT,
+            visibleUntilT,
+            _zIndex,
+            _hidden,
+            _state,
+          } = data;
           Object.assign(feature.style, style);
-          Object.assign(feature.meta, meta);
-          feature.properties
-            ? Object.assign(feature.properties, properties)
-            : (feature.properties = properties);
-          Object.assign(feature.geometry, geometry);
+          Object.assign(feature.geometryMeta, geometryMeta);
+          if (geometry) Object.assign(feature.geometry, geometry);
 
           if (state) feature.state = state;
           if (media) feature.media = media;
+          if (userData) {
+            feature.userData = {
+              ...(feature.userData ?? {}),
+              ...userData,
+            };
+          }
+          if (name !== undefined) feature.name = name;
+          if (description !== undefined) feature.description = description;
+          if (externalUrl !== undefined) feature.externalUrl = externalUrl;
+          if (locked !== undefined) feature.locked = locked;
+          if (isHidden !== undefined) feature.isHidden = isHidden;
+          if (visibleFromT !== undefined) feature.visibleFromT = visibleFromT;
+          if (visibleUntilT !== undefined) feature.visibleUntilT = visibleUntilT;
+          if (_zIndex !== undefined) feature._zIndex = _zIndex;
+          if (_hidden !== undefined) feature._hidden = _hidden;
+          if (_state !== undefined) feature._state = _state;
 
-          const visibleFromT = feature.meta.visibleFromT || Number.MIN_SAFE_INTEGER;
-          const visibleUntilT = feature.meta.visibleUntilT || Number.MAX_SAFE_INTEGER;
-          const timeHidden =
-            s.currentTime <= visibleFromT || s.currentTime >= visibleUntilT;
-
-          feature._hidden = timeHidden || feature.meta.isHidden;
+          updateGeometryItemHidden(feature, s.currentTime);
         },
         {
           label: isGeometry ? "updateFeatureGeometry" : "updateFeature",
@@ -623,7 +655,23 @@ export function useGeo(store: NewScenarioStore) {
     } else {
       const layerItem = getGeometryLayerItemFromMap(state.layerItemMap, featureId);
       if (!layerItem) return;
-      Object.assign(layerItem, data);
+      Object.assign(layerItem.style, data.style ?? {});
+      Object.assign(layerItem.geometryMeta, data.geometryMeta ?? {});
+      if (data.geometry) Object.assign(layerItem.geometry, data.geometry);
+      if (data.userData) {
+        layerItem.userData = {
+          ...(layerItem.userData ?? {}),
+          ...data.userData,
+        };
+      }
+      Object.assign(layerItem, {
+        ...data,
+        style: layerItem.style,
+        geometryMeta: layerItem.geometryMeta,
+        geometry: layerItem.geometry,
+        userData: layerItem.userData,
+      });
+      updateGeometryItemHidden(layerItem, state.currentTime);
     }
     if (data.state) {
       updateFeatureState(featureId);
@@ -701,12 +749,12 @@ export function useGeo(store: NewScenarioStore) {
           };
         }
         const feature = layerItem;
-        const { meta, id } = feature;
+        const { id } = feature;
         return {
           id,
-          type: meta.type,
-          name: meta.name || "",
-          description: meta.description,
+          type: feature.geometryMeta.geometryKind,
+          name: feature.name || "",
+          description: feature.description,
           _pid: layer.id,
         };
       });

--- a/src/scenariostore/io.test.ts
+++ b/src/scenariostore/io.test.ts
@@ -65,7 +65,7 @@ describe("Scenario IO", () => {
   it("creates empty scenarios with items[] layers", () => {
     const scenario = createEmptyScenario();
 
-    expect(scenario.version).toBe("3.1.0");
+    expect(scenario.version).toBe("3.2.0");
     expect(getOverlayLayers(scenario)[0]).toHaveProperty("items");
     expect(getOverlayLayers(scenario)[0]).not.toHaveProperty("features");
     expect((getOverlayLayers(scenario)[0] as any).items).toEqual([]);
@@ -209,12 +209,27 @@ describe("Scenario IO", () => {
     const { serializeToObject } = useScenarioIO(storeRef);
     const serialized = serializeToObject();
 
-    expect(serialized.version).toBe("3.1.0");
+    expect(serialized.version).toBe("3.2.0");
     expect(getOverlayLayers(serialized)[0]).not.toHaveProperty("features");
     expect(getOverlayLayers(serialized)[0].items).toEqual([
       {
-        ...feature,
         kind: "geometry",
+        id: "feature-1",
+        geometry: { type: "Point", coordinates: [10, 60] },
+        geometryMeta: { geometryKind: "Point" },
+        name: "HQ",
+        description: "Feature description",
+        externalUrl: undefined,
+        locked: undefined,
+        isHidden: undefined,
+        visibleFromT: undefined,
+        visibleUntilT: undefined,
+        media: undefined,
+        userData: undefined,
+        _zIndex: undefined,
+        _hidden: undefined,
+        _state: undefined,
+        style: { showLabel: true, title: "HQ" },
         state: [
           {
             id: "state-1",
@@ -245,11 +260,10 @@ describe("Scenario IO", () => {
           items: [
             {
               kind: "geometry",
-              type: "Feature",
               id: "feature-1",
               geometry: { type: "Point", coordinates: [10, 60] },
-              properties: {},
-              meta: { type: "Point", name: "HQ" },
+              geometryMeta: { geometryKind: "Point" },
+              name: "HQ",
               style: {},
             },
           ],

--- a/src/scenariostore/newScenarioStore.ts
+++ b/src/scenariostore/newScenarioStore.ts
@@ -482,11 +482,8 @@ export function prepareScenario(newScenario: Scenario | LoadableScenario): Scena
             id: s.id || nanoid(),
           }),
         }));
-
-        tmp.meta = mapVisibility(tmp.meta);
-        tmp.properties = tmp.properties ?? {};
         layerItemMap[item.id] = {
-          ...tmp,
+          ...mapVisibility(tmp),
           _pid: layer.id,
         } as NGeometryLayerItem;
       });

--- a/src/scenariostore/time.ts
+++ b/src/scenariostore/time.ts
@@ -204,8 +204,8 @@ export function useScenarioTime(store: NewScenarioStore) {
         isScenarioOverlayLayer,
       ) as import("@/types/scenarioStackLayers").NScenarioOverlayLayer[]
     ).forEach((layer) => {
-      const visibleFromT = layer.visibleFromT || Number.MIN_SAFE_INTEGER;
-      const visibleUntilT = layer.visibleUntilT || Number.MAX_SAFE_INTEGER;
+      const visibleFromT = layer.visibleFromT ?? Number.MIN_SAFE_INTEGER;
+      const visibleUntilT = layer.visibleUntilT ?? Number.MAX_SAFE_INTEGER;
       const oldHidden = layer._hidden;
       layer._hidden = timestamp <= visibleFromT || timestamp >= visibleUntilT;
       if (oldHidden !== layer._hidden) {
@@ -214,8 +214,8 @@ export function useScenarioTime(store: NewScenarioStore) {
       layer.items.forEach((featureId) => {
         const feature = state.layerItemMap[featureId];
         if (!feature || !isNGeometryLayerItem(feature)) return;
-        const visibleFromT = feature.visibleFromT || Number.MIN_SAFE_INTEGER;
-        const visibleUntilT = feature.visibleUntilT || Number.MAX_SAFE_INTEGER;
+        const visibleFromT = feature.visibleFromT ?? Number.MIN_SAFE_INTEGER;
+        const visibleUntilT = feature.visibleUntilT ?? Number.MAX_SAFE_INTEGER;
         const oldHidden = feature._hidden;
         feature._hidden =
           timestamp <= visibleFromT || timestamp >= visibleUntilT || !!feature.isHidden;

--- a/src/scenariostore/time.ts
+++ b/src/scenariostore/time.ts
@@ -214,13 +214,11 @@ export function useScenarioTime(store: NewScenarioStore) {
       layer.items.forEach((featureId) => {
         const feature = state.layerItemMap[featureId];
         if (!feature || !isNGeometryLayerItem(feature)) return;
-        const visibleFromT = feature.meta.visibleFromT || Number.MIN_SAFE_INTEGER;
-        const visibleUntilT = feature.meta.visibleUntilT || Number.MAX_SAFE_INTEGER;
+        const visibleFromT = feature.visibleFromT || Number.MIN_SAFE_INTEGER;
+        const visibleUntilT = feature.visibleUntilT || Number.MAX_SAFE_INTEGER;
         const oldHidden = feature._hidden;
         feature._hidden =
-          timestamp <= visibleFromT ||
-          timestamp >= visibleUntilT ||
-          !!feature.meta.isHidden;
+          timestamp <= visibleFromT || timestamp >= visibleUntilT || !!feature.isHidden;
         if (oldHidden !== feature._hidden) {
           state.featureStateCounter++;
         }

--- a/src/scenariostore/upgrade.test.ts
+++ b/src/scenariostore/upgrade.test.ts
@@ -48,6 +48,38 @@ function createFeature(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function createExpectedGeometryItem(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "feature-1",
+    kind: "geometry",
+    geometry: { type: "Point", coordinates: [10, 60] },
+    geometryMeta: { geometryKind: "Point" },
+    name: "HQ",
+    description: "Feature description",
+    externalUrl: undefined,
+    locked: undefined,
+    isHidden: undefined,
+    visibleFromT: undefined,
+    visibleUntilT: undefined,
+    media: undefined,
+    style: { showLabel: true, title: "HQ" },
+    userData: undefined,
+    _zIndex: undefined,
+    _hidden: undefined,
+    _state: undefined,
+    state: [
+      {
+        id: "state-1",
+        t: "2025-01-01T01:00:00Z",
+        patch: {
+          geometry: { type: "Point", coordinates: [11, 61] },
+        },
+      },
+    ],
+    ...overrides,
+  };
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -61,21 +93,7 @@ describe("upgradeScenarioIfNecessary", () => {
 
     const upgraded = upgradeScenarioIfNecessary(scenario as any);
 
-    expect(getOverlayLayers(upgraded)[0].items).toEqual([
-      {
-        ...feature,
-        kind: "geometry",
-        state: [
-          {
-            id: "state-1",
-            t: "2025-01-01T01:00:00Z",
-            patch: {
-              geometry: { type: "Point", coordinates: [11, 61] },
-            },
-          },
-        ],
-      },
-    ]);
+    expect(getOverlayLayers(upgraded)[0].items).toEqual([createExpectedGeometryItem()]);
     expect(getOverlayLayers(upgraded)[0]).not.toHaveProperty("features");
   });
 
@@ -107,21 +125,7 @@ describe("upgradeScenarioIfNecessary", () => {
 
     const upgraded = upgradeScenarioIfNecessary(scenario as any);
 
-    expect(getOverlayLayers(upgraded)[0].items).toEqual([
-      {
-        ...feature,
-        kind: "geometry",
-        state: [
-          {
-            id: "state-1",
-            t: "2025-01-01T01:00:00Z",
-            patch: {
-              geometry: { type: "Point", coordinates: [11, 61] },
-            },
-          },
-        ],
-      },
-    ]);
+    expect(getOverlayLayers(upgraded)[0].items).toEqual([createExpectedGeometryItem()]);
     expect(getOverlayLayers(upgraded)[0]).not.toHaveProperty("features");
   });
 
@@ -164,21 +168,7 @@ describe("upgradeScenarioIfNecessary", () => {
 
     const upgraded = upgradeScenarioIfNecessary(scenario as any);
 
-    expect(getOverlayLayers(upgraded)[0].items).toEqual([
-      {
-        ...feature,
-        kind: "geometry",
-        state: [
-          {
-            id: "state-1",
-            t: "2025-01-01T01:00:00Z",
-            patch: {
-              geometry: { type: "Point", coordinates: [11, 61] },
-            },
-          },
-        ],
-      },
-    ]);
+    expect(getOverlayLayers(upgraded)[0].items).toEqual([createExpectedGeometryItem()]);
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0][0]).toContain('layer "Features" (layer-1)');
     expect(warnSpy.mock.calls[0][0]).toContain("annotation=1");
@@ -208,19 +198,11 @@ describe("upgradeScenarioIfNecessary", () => {
     const upgraded = upgradeScenarioIfNecessary(scenario as any);
 
     expect(getOverlayLayers(upgraded)[0].items).toEqual([
-      {
-        ...itemFeature,
-        kind: "geometry",
-        state: [
-          {
-            id: "state-1",
-            t: "2025-01-01T01:00:00Z",
-            patch: {
-              geometry: { type: "Point", coordinates: [11, 61] },
-            },
-          },
-        ],
-      },
+      createExpectedGeometryItem({
+        id: "item-feature",
+        name: "Items",
+        description: undefined,
+      }),
     ]);
   });
 
@@ -273,8 +255,8 @@ describe("upgradeScenarioIfNecessary", () => {
 
     expect(feature.kind).toBe("geometry");
     if (feature.kind !== "geometry") throw new Error("Expected geometry item");
-    expect(feature.meta).toMatchObject({
-      type: "Point",
+    expect(feature).toMatchObject({
+      geometryMeta: { geometryKind: "Point" },
       name: "Legacy item",
       description: "Before v0.30",
     });
@@ -286,6 +268,6 @@ describe("upgradeScenarioIfNecessary", () => {
       showLabel: true,
       title: "Legacy title",
     });
-    expect(feature.properties).toEqual({ foo: "bar" });
+    expect(feature.userData).toEqual({ foo: "bar" });
   });
 });

--- a/src/scenariostore/upgrade.ts
+++ b/src/scenariostore/upgrade.ts
@@ -222,6 +222,9 @@ function canonicalizeOverlayLayer(
       kind: "overlay",
       items: features.map((feature) => {
         const { state, ...featureRest } = feature;
+        // Transitional stage: canonicalization keeps legacy feature-shaped data intact.
+        // The object is normalized to the real GeometryLayerItem shape by the
+        // versioned shared-base upgrade later in this pipeline.
         return {
           ...featureRest,
           id: String(feature.id),
@@ -240,6 +243,8 @@ function canonicalizeOverlayLayer(
   items.forEach((item) => {
     if (isGeometryLayerItem(item)) {
       const { kind: _kind, state, ...feature } = item;
+      // Transitional stage: canonicalization preserves the loaded shape here so
+      // pre-3.2 scenarios can still flow through the later shared-base upgrader.
       canonicalItems.push({
         ...feature,
         id: String(feature.id),
@@ -360,6 +365,8 @@ function upgradeLegacyFeatureProperties(scenario: Scenario): Scenario {
     const upgradedLayer = { ...layer };
     upgradedLayer.items = upgradedLayer.items.map((item) => {
       if (item.kind !== "geometry") return item;
+      // This migration intentionally operates on the legacy pre-shared-base
+      // geometry shape before the final 3.2.0 normalization step runs.
       const upgradedFeature = { ...(item as any) } as any;
       const {
         visibleFromT,

--- a/src/scenariostore/upgrade.ts
+++ b/src/scenariostore/upgrade.ts
@@ -2,13 +2,16 @@ import type { Scenario } from "@/types/scenarioModels";
 import { compare as compareVersions } from "compare-versions";
 import type {
   ScenarioFeature,
-  ScenarioFeatureMeta,
   ScenarioLayer,
   ScenarioMapLayer,
+  ScenarioFeatureMeta,
+  ScenarioFeatureType,
 } from "@/types/scenarioGeoModels";
+import type { GeoJsonProperties } from "geojson";
 import { type SimpleStyleSpec } from "@/geo/simplestyle";
 import type {
   AnnotationLayerItem,
+  GeometryLayerMeta,
   GeometryLayerItem,
   LoadableGeometryLayerItemState,
   MeasurementLayerItem,
@@ -22,9 +25,28 @@ import type {
   ScenarioStackLayer,
 } from "@/types/scenarioStackLayers";
 
-export type LoadableGeometryLayerItem = Omit<ScenarioFeature, "state"> & {
+export type LoadableGeometryLayerItem = {
+  id: string | number;
   kind: "geometry";
+  geometry: ScenarioFeature["geometry"];
+  style?: Partial<SimpleStyleSpec>;
   state?: LoadableGeometryLayerItemState[];
+  type?: "Feature";
+  properties?: GeoJsonProperties;
+  meta?: Partial<ScenarioFeatureMeta>;
+  geometryMeta?: Partial<GeometryLayerMeta>;
+  name?: string;
+  description?: string;
+  externalUrl?: string;
+  locked?: boolean;
+  isHidden?: boolean;
+  visibleFromT?: number | string;
+  visibleUntilT?: number | string;
+  media?: GeometryLayerItem["media"];
+  userData?: Record<string, unknown>;
+  _zIndex?: number;
+  _hidden?: boolean;
+  _state?: GeometryLayerItem["_state"];
 };
 type UnsupportedLayerItem =
   | AnnotationLayerItem
@@ -64,6 +86,126 @@ function canonicalizeGeometryStateEntries(
   return states?.map((state) => normalizeGeometryLayerItemState(state));
 }
 
+function inferGeometryKind(
+  geometry: GeometryLayerItem["geometry"] | undefined,
+  legacyKind: unknown,
+): ScenarioFeatureType {
+  if (legacyKind === "Circle") return "Circle";
+  const geometryType = geometry?.type;
+  if (
+    geometryType === "Point" ||
+    geometryType === "LineString" ||
+    geometryType === "Polygon" ||
+    geometryType === "MultiPoint" ||
+    geometryType === "MultiLineString" ||
+    geometryType === "MultiPolygon" ||
+    geometryType === "GeometryCollection"
+  ) {
+    return geometryType;
+  }
+  return "Point";
+}
+
+const RESERVED_LEGACY_PROPERTY_KEYS = new Set([
+  "visibleFromT",
+  "visibleUntilT",
+  "type",
+  "name",
+  "description",
+  "externalUrl",
+  "locked",
+  "isHidden",
+  "radius",
+  "_zIndex",
+  "fill-opacity",
+  "fill",
+  "showLabel",
+  "stroke-opacity",
+  "stroke",
+  "marker-color",
+  "marker-size",
+  "marker-symbol",
+  "stroke-width",
+  "stroke-style",
+  "title",
+  "text-placement",
+  "text-align",
+  "text-offset-x",
+  "text-offset-y",
+  "limitVisibility",
+  "minZoom",
+  "maxZoom",
+  "textMinZoom",
+  "textMaxZoom",
+  "arrow-start",
+  "arrow-end",
+]);
+
+function sanitizeLegacyProperties(
+  properties: GeoJsonProperties | undefined,
+): Record<string, unknown> {
+  const sanitized: Record<string, unknown> = {};
+  if (!properties || typeof properties !== "object") return sanitized;
+  Object.entries(properties).forEach(([key, value]) => {
+    if (RESERVED_LEGACY_PROPERTY_KEYS.has(key) || value === undefined) return;
+    sanitized[key] = value;
+  });
+  return sanitized;
+}
+
+function normalizeGeometryUserData(
+  item: LoadableGeometryLayerItem,
+): Record<string, unknown> | undefined {
+  const next = {
+    ...sanitizeLegacyProperties(item.properties),
+    ...(item.userData ?? {}),
+  };
+  Object.keys(next).forEach((key) => {
+    if (RESERVED_LEGACY_PROPERTY_KEYS.has(key) || next[key] === undefined) {
+      delete next[key];
+    }
+  });
+  return Object.keys(next).length ? next : undefined;
+}
+
+function upgradeGeometryItemToSharedBase(
+  item: LoadableGeometryLayerItem,
+): GeometryLayerItem {
+  const legacyMeta = item.meta ?? {};
+  const geometryMeta: GeometryLayerMeta = {
+    geometryKind: inferGeometryKind(
+      item.geometry,
+      item.geometryMeta?.geometryKind ?? legacyMeta.type,
+    ),
+    ...(item.geometryMeta?.radius !== undefined
+      ? { radius: item.geometryMeta.radius }
+      : legacyMeta.radius !== undefined
+        ? { radius: legacyMeta.radius }
+        : {}),
+  };
+
+  return {
+    id: String(item.id),
+    kind: "geometry",
+    geometry: item.geometry,
+    geometryMeta,
+    style: item.style ?? {},
+    state: canonicalizeGeometryStateEntries(item.state),
+    name: item.name ?? legacyMeta.name,
+    description: item.description ?? legacyMeta.description,
+    externalUrl: item.externalUrl ?? legacyMeta.externalUrl,
+    locked: item.locked ?? legacyMeta.locked,
+    isHidden: item.isHidden ?? legacyMeta.isHidden,
+    visibleFromT: (item.visibleFromT ?? legacyMeta.visibleFromT) as number | undefined,
+    visibleUntilT: (item.visibleUntilT ?? legacyMeta.visibleUntilT) as number | undefined,
+    media: item.media,
+    userData: normalizeGeometryUserData(item),
+    _zIndex: item._zIndex ?? legacyMeta._zIndex,
+    _hidden: item._hidden,
+    _state: item._state,
+  };
+}
+
 function canonicalizeOverlayLayer(
   layer: LoadableOverlayLayer,
   scenarioId?: string,
@@ -85,7 +227,7 @@ function canonicalizeOverlayLayer(
           id: String(feature.id),
           kind: "geometry",
           state: canonicalizeGeometryStateEntries(state),
-        };
+        } as unknown as GeometryLayerItem;
       }),
     };
   }
@@ -103,7 +245,7 @@ function canonicalizeOverlayLayer(
         id: String(feature.id),
         kind: "geometry",
         state: canonicalizeGeometryStateEntries(state),
-      } satisfies GeometryLayerItem);
+      } as unknown as GeometryLayerItem);
       return;
     }
 
@@ -218,7 +360,7 @@ function upgradeLegacyFeatureProperties(scenario: Scenario): Scenario {
     const upgradedLayer = { ...layer };
     upgradedLayer.items = upgradedLayer.items.map((item) => {
       if (item.kind !== "geometry") return item;
-      const upgradedFeature = { ...item };
+      const upgradedFeature = { ...(item as any) } as any;
       const {
         visibleFromT,
         visibleUntilT,
@@ -296,14 +438,33 @@ function upgradeLegacyFeatureProperties(scenario: Scenario): Scenario {
   return upgradedScenario;
 }
 
+function upgradeGeometryLayerItemsToSharedBase(scenario: Scenario): Scenario {
+  const upgradedScenario = { ...scenario };
+  upgradedScenario.layerStack = upgradedScenario.layerStack.map((layer) => {
+    if (layer.kind !== "overlay") return layer;
+    return {
+      ...layer,
+      items: layer.items.map((item) =>
+        item.kind === "geometry"
+          ? upgradeGeometryItemToSharedBase(item as LoadableGeometryLayerItem)
+          : item,
+      ),
+    };
+  });
+  return upgradedScenario;
+}
+
 export function upgradeScenarioIfNecessary(
   scenario: LoadableScenario | Scenario,
 ): Scenario {
-  const canonicalScenario = canonicalizeScenarioLayerStack(scenario as LoadableScenario);
+  let canonicalScenario = canonicalizeScenarioLayerStack(scenario as LoadableScenario);
 
   if (compareVersions(canonicalScenario.version, "0.30.0", "<")) {
     console.log("Found outdated scenario version, upgrading from", scenario.version);
-    return upgradeLegacyFeatureProperties(canonicalScenario);
+    canonicalScenario = upgradeLegacyFeatureProperties(canonicalScenario);
+  }
+  if (compareVersions(canonicalScenario.version, "3.2.0", "<")) {
+    canonicalScenario = upgradeGeometryLayerItemsToSharedBase(canonicalScenario);
   }
   return canonicalScenario;
 }

--- a/src/stores/maplibreLayersStore.ts
+++ b/src/stores/maplibreLayersStore.ts
@@ -47,9 +47,16 @@ export const useMaplibreLayersStore = defineStore("maplibreLayers", () => {
     }
   }
 
+  function setLayerOpacity(name: string, opacity: number) {
+    layers.value = layers.value.map((layer) =>
+      layer.name === name ? { ...layer, opacity } : layer,
+    );
+  }
+
   return {
     layers,
     isInitialized,
     initialize,
+    setLayerOpacity,
   };
 });

--- a/src/types/scenarioLayerItems.ts
+++ b/src/types/scenarioLayerItems.ts
@@ -255,6 +255,8 @@ export function isGeometryLayerItemLike(item: unknown): item is GeometryLayerIte
     return candidate.kind === "geometry";
   }
   // Transitional fallback for legacy feature-shaped data loaded before kind tagging.
+  // TODO: Remove the legacy `meta` branch once all geometry items enter through
+  // the shared-base upgrade pipeline.
   // Remove this once all call sites operate on canonical ScenarioLayerItem objects only.
   return (
     candidate.type === "Feature" &&

--- a/src/types/scenarioLayerItems.ts
+++ b/src/types/scenarioLayerItems.ts
@@ -9,7 +9,7 @@ import type {
 import type {
   LayerId,
   Position,
-  ScenarioFeatureMeta,
+  ScenarioFeatureType,
   ScenarioLayer,
   VisibilityInfo,
 } from "@/types/scenarioGeoModels";
@@ -68,11 +68,16 @@ export interface ScenarioLayerItemBase extends Partial<VisibilityInfo> {
   locked?: boolean;
   isHidden?: boolean;
   media?: Media[];
+  userData?: Record<string, unknown>;
+}
+
+export interface GeometryLayerMeta {
+  geometryKind: ScenarioFeatureType;
+  radius?: number;
 }
 
 export interface GeometryLayerItemStatePatch {
   geometry?: Geometry;
-  properties?: GeoJsonProperties;
 }
 
 export interface GeometryLayerItemState extends Partial<ScenarioEventDescription> {
@@ -87,7 +92,6 @@ export type LoadableGeometryLayerItemState =
       id: string;
       t: ScenarioTime;
       geometry?: Geometry;
-      properties?: GeoJsonProperties;
     });
 
 export interface CurrentGeometryLayerItemState
@@ -95,16 +99,13 @@ export interface CurrentGeometryLayerItemState
   type?: CurrentStateType;
 }
 
-export interface GeometryLayerItem {
+export interface GeometryLayerItem extends ScenarioLayerItemBase {
   kind: "geometry";
-  type: "Feature";
-  id: LayerItemId;
   geometry: Geometry;
-  properties: GeoJsonProperties;
-  meta: ScenarioFeatureMeta;
+  geometryMeta: GeometryLayerMeta;
   style: Partial<SimpleStyleSpec>;
   state?: GeometryLayerItemState[];
-  media?: Media[];
+  _zIndex?: number;
   _hidden?: boolean;
   _state?: CurrentGeometryLayerItemState | null;
 }
@@ -255,7 +256,11 @@ export function isGeometryLayerItemLike(item: unknown): item is GeometryLayerIte
   }
   // Transitional fallback for legacy feature-shaped data loaded before kind tagging.
   // Remove this once all call sites operate on canonical ScenarioLayerItem objects only.
-  return candidate.type === "Feature" && !!candidate.geometry && !!candidate.meta;
+  return (
+    candidate.type === "Feature" &&
+    !!candidate.geometry &&
+    ("geometryMeta" in candidate || "meta" in candidate)
+  );
 }
 
 export function isNGeometryLayerItem(
@@ -274,12 +279,11 @@ export function normalizeGeometryLayerItemState(
     LoadableGeometryLayerItemState,
     GeometryLayerItemState
   >;
-  const { geometry, properties, ...rest } = legacyState;
+  const { geometry, ...rest } = legacyState;
   return {
     ...rest,
     patch: {
       ...(geometry !== undefined ? { geometry } : {}),
-      ...(properties !== undefined ? { properties } : {}),
     },
   };
 }
@@ -313,10 +317,9 @@ export interface NScenarioLayerItemsLayer extends Omit<ScenarioLayerItemsLayer, 
 }
 
 export interface GeometryLayerItemUpdate extends Partial<
-  Omit<NGeometryLayerItem, "id" | "meta" | "kind">
+  Omit<NGeometryLayerItem, "id" | "geometryMeta" | "kind">
 > {
-  meta?: Partial<ScenarioFeatureMeta>;
-  _hidden?: boolean;
+  geometryMeta?: Partial<GeometryLayerMeta>;
 }
 
 export interface FullScenarioLayerItemsLayer extends Omit<
@@ -324,4 +327,92 @@ export interface FullScenarioLayerItemsLayer extends Omit<
   "items"
 > {
   items: NScenarioLayerItem[];
+}
+
+const RESERVED_GEOMETRY_ITEM_USERDATA_KEYS = new Set([
+  "type",
+  "radius",
+  "name",
+  "description",
+  "externalUrl",
+  "locked",
+  "isHidden",
+  "visibleFromT",
+  "visibleUntilT",
+  "_zIndex",
+  "fill",
+  "fill-opacity",
+  "stroke",
+  "stroke-opacity",
+  "stroke-width",
+  "stroke-style",
+  "marker-color",
+  "marker-size",
+  "marker-symbol",
+  "showLabel",
+  "title",
+  "text-placement",
+  "text-align",
+  "text-offset-x",
+  "text-offset-y",
+  "limitVisibility",
+  "minZoom",
+  "maxZoom",
+  "textMinZoom",
+  "textMaxZoom",
+  "arrow-start",
+  "arrow-end",
+]);
+
+export function getGeometryLayerItemLabelText(
+  item: Pick<GeometryLayerItem, "name" | "userData">,
+): string {
+  const title = item.userData?.title;
+  const userName = item.userData?.name;
+  return (
+    item.name ||
+    (typeof title === "string" ? title : undefined) ||
+    (typeof userName === "string" ? userName : undefined) ||
+    ""
+  );
+}
+
+export function toGeometryLayerItemGeoJsonProperties(
+  item: Pick<
+    GeometryLayerItem,
+    | "name"
+    | "description"
+    | "externalUrl"
+    | "locked"
+    | "isHidden"
+    | "visibleFromT"
+    | "visibleUntilT"
+    | "style"
+    | "userData"
+    | "geometryMeta"
+    | "_zIndex"
+  >,
+): GeoJsonProperties {
+  const properties: Record<string, unknown> = {
+    ...(item.geometryMeta.geometryKind ? { type: item.geometryMeta.geometryKind } : {}),
+    ...(item.geometryMeta.radius !== undefined
+      ? { radius: item.geometryMeta.radius }
+      : {}),
+    ...(item.name !== undefined ? { name: item.name } : {}),
+    ...(item.description !== undefined ? { description: item.description } : {}),
+    ...(item.externalUrl !== undefined ? { externalUrl: item.externalUrl } : {}),
+    ...(item.locked !== undefined ? { locked: item.locked } : {}),
+    ...(item.isHidden !== undefined ? { isHidden: item.isHidden } : {}),
+    ...(item.visibleFromT !== undefined ? { visibleFromT: item.visibleFromT } : {}),
+    ...(item.visibleUntilT !== undefined ? { visibleUntilT: item.visibleUntilT } : {}),
+    ...(item._zIndex !== undefined ? { _zIndex: item._zIndex } : {}),
+    ...(item.style ?? {}),
+  };
+
+  Object.entries(item.userData ?? {}).forEach(([key, value]) => {
+    if (RESERVED_GEOMETRY_ITEM_USERDATA_KEYS.has(key) || value === undefined) return;
+    properties[key] = value;
+  });
+
+  return properties;
 }

--- a/src/types/scenarioModels.ts
+++ b/src/types/scenarioModels.ts
@@ -268,6 +268,7 @@ export interface ScenarioInfo {
 
 export type SymbologyStandard = "2525" | "app6";
 export type ScenarioVersion =
+  | "3.2.0"
   | "3.1.0"
   | "3.0.0"
   | "2.8.0"


### PR DESCRIPTION
## Summary
- move geometry features to the layer stack schema with top-level naming and metadata
- update MapLibre and OpenLayers scenario layer handling, feature styling, import/export, and editor UI to match the new model
- upgrade existing scenario data, including `falkland82`, and refresh related tests

## Testing
- Not run (not requested)