### PR TITLE
Load MapLibre basemaps from dedicated config file

### DIFF
--- a/public/config/maplibreConfig.json
+++ b/public/config/maplibreConfig.json
@@ -1,0 +1,82 @@
+[
+  {
+    "name": "openFreeMapPositron",
+    "title": "OpenFreeMap Positron",
+    "sourceType": "style",
+    "styleUrl": "https://tiles.openfreemap.org/styles/positron"
+  },
+  {
+    "name": "openFreeMapLiberty",
+    "title": "OpenFreeMap Liberty",
+    "sourceType": "style",
+    "styleUrl": "https://tiles.openfreemap.org/styles/liberty"
+  },
+  {
+    "name": "openFreeMapBright",
+    "title": "OpenFreeMap Bright",
+    "sourceType": "style",
+    "styleUrl": "https://tiles.openfreemap.org/styles/bright"
+  },
+  {
+    "name": "versaTilesEclipse",
+    "title": "VersaTiles Eclipse (dark)",
+    "sourceType": "style",
+    "styleUrl": "https://tiles.versatiles.org/assets/styles/eclipse/style.json"
+  },
+  {
+    "name": "osm",
+    "title": "OSM",
+    "sourceType": "raster",
+    "tiles": ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+    "tileSize": 256,
+    "attribution": "© <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors"
+  },
+  {
+    "name": "osm-de",
+    "title": "OSM (DE)",
+    "sourceType": "raster",
+    "tiles": ["https://tile.openstreetmap.de/{z}/{x}/{y}.png"],
+    "tileSize": 256,
+    "attribution": "© <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors"
+  },
+  {
+    "name": "grayBasemap",
+    "title": "Gray Basemap",
+    "sourceType": "raster",
+    "tiles": [
+      "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Light_Gray_Base/MapServer/tile/{z}/{y}/{x}"
+    ],
+    "tileSize": 256,
+    "attribution": "Tiles © <a href=\"https://services.arcgisonline.com/ArcGIS/rest/services/World_Light_Gray_Base/MapServer\">ArcGIS</a>"
+  },
+  {
+    "name": "openTopoMap",
+    "title": "Open topo map",
+    "sourceType": "raster",
+    "tiles": ["https://a.tile.opentopomap.org/{z}/{x}/{y}.png"],
+    "tileSize": 256,
+    "maxZoom": 14,
+    "attribution": "Map data: © <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors, <a href=\"http://viewfinderpanoramas.org\">SRTM</a> | Map style: © <a href=\"https://opentopomap.org\">OpenTopoMap</a> (<a href=\"https://creativecommons.org/licenses/by-sa/3.0/\">CC-BY-SA</a>)"
+  },
+  {
+    "name": "esriWorldImagery",
+    "title": "ESRI World imagery",
+    "sourceType": "raster",
+    "tiles": [
+      "https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+    ],
+    "tileSize": 256,
+    "attribution": "Tiles © Esri — Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community"
+  },
+  {
+    "name": "kartverketTopo4",
+    "title": "Topographic Map Norway",
+    "sourceType": "raster",
+    "tiles": [
+      "https://cache.kartverket.no/v1/wmts/1.0.0/topo/default/webmercator/{z}/{y}/{x}.png"
+    ],
+    "tileSize": 256,
+    "bounds": [2, 57, 33, 72],
+    "attribution": "<a href=\"http://www.kartverket.no/\">Kartverket</a>"
+  }
+]

--- a/src/geo/maplibreLayerConfigTypes.ts
+++ b/src/geo/maplibreLayerConfigTypes.ts
@@ -9,8 +9,8 @@ import type { StyleSpecification } from "maplibre-gl";
 interface BaseMlLayerConfig {
   /** Unique identifier. Used as the basemap id in the UI and as the MapLibre source id. */
   name: string;
-  /** Display name shown in the basemap picker. */
-  title: string;
+  /** Display name shown in the basemap picker. Falls back to `name` when omitted. */
+  title?: string;
   minZoom?: number;
   maxZoom?: number;
   /** Applied as raster-opacity for raster sources; ignored for style sources. */

--- a/src/geo/maplibreLayerConfigTypes.ts
+++ b/src/geo/maplibreLayerConfigTypes.ts
@@ -1,0 +1,40 @@
+/**
+ * Types for MapLibre basemap configuration loaded from /config/maplibreConfig.json.
+ *
+ * Kept separate from layerConfigTypes.ts (which is OpenLayers-typed) so MapLibre-native
+ * source options don't have to coexist with OL source option types.
+ */
+import type { StyleSpecification } from "maplibre-gl";
+
+interface BaseMlLayerConfig {
+  /** Unique identifier. Used as the basemap id in the UI and as the MapLibre source id. */
+  name: string;
+  /** Display name shown in the basemap picker. */
+  title: string;
+  minZoom?: number;
+  maxZoom?: number;
+  /** Applied as raster-opacity for raster sources; ignored for style sources. */
+  opacity?: number;
+  attribution?: string;
+  /** Tile coverage bounds [minLon, minLat, maxLon, maxLat] in WGS84. */
+  bounds?: [number, number, number, number];
+}
+
+export interface MlStyleLayerConfig extends BaseMlLayerConfig {
+  sourceType: "style";
+  /** URL to a MapLibre style JSON. Mutually exclusive with `style`. */
+  styleUrl?: string;
+  /** Inline style specification. Mutually exclusive with `styleUrl`. */
+  style?: StyleSpecification;
+}
+
+export interface MlRasterLayerConfig extends BaseMlLayerConfig {
+  sourceType: "raster";
+  tiles: string[];
+  tileSize?: number;
+  scheme?: "xyz" | "tms";
+}
+
+export type MlLayerConfig = MlStyleLayerConfig | MlRasterLayerConfig;
+
+export type MlLayerConfigFile = MlLayerConfig[];

--- a/src/modules/maplibreview/MaplibreContextMenu.test.ts
+++ b/src/modules/maplibreview/MaplibreContextMenu.test.ts
@@ -9,7 +9,7 @@ import {
   searchActionsKey,
 } from "@/components/injects";
 import MaplibreContextMenu from "@/modules/maplibreview/MaplibreContextMenu.vue";
-import { useBaseLayersStore } from "@/stores/baseLayersStore";
+import { useMaplibreLayersStore } from "@/stores/maplibreLayersStore";
 import { MAPLIBRE_VECTOR_BASEMAP_ID } from "@/modules/maplibreview/maplibreBasemaps";
 import { usePlaybackStore } from "@/stores/playbackStore";
 import { useUiStore } from "@/stores/uiStore";
@@ -282,27 +282,23 @@ describe("MaplibreContextMenu", () => {
   }
 
   it("updates the bound maplibre basemap when a basemap is selected", async () => {
-    const baseLayersStore = useBaseLayersStore();
+    const maplibreLayersStore = useMaplibreLayersStore();
     const selectedBasemap = ref(MAPLIBRE_VECTOR_BASEMAP_ID);
 
-    baseLayersStore.layers = [
+    maplibreLayersStore.layers = [
       {
-        title: "OSM",
         name: "osm",
-        layerSourceType: "osm",
-        sourceOptions: { crossOrigin: "anonymous" },
-        layerType: "baselayer",
-        opacity: 1,
+        title: "OSM",
+        sourceType: "raster",
+        tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
       },
       {
-        title: "Imagery",
         name: "imagery",
-        layerSourceType: "xyz",
-        sourceOptions: { url: "https://tiles.example.com/{z}/{x}/{y}.png" },
-        layerType: "baselayer",
-        opacity: 1,
+        title: "Imagery",
+        sourceType: "raster",
+        tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],
       },
-    ] as any;
+    ];
 
     const { wrapper } = mountMenu({
       baseMapId: selectedBasemap.value,

--- a/src/modules/maplibreview/MaplibreContextMenu.vue
+++ b/src/modules/maplibreview/MaplibreContextMenu.vue
@@ -25,7 +25,7 @@ import {
 } from "@iconify-prerendered/vue-mdi";
 import type { Position } from "geojson";
 import type { Map as MlMap } from "maplibre-gl";
-import { useBaseLayersStore } from "@/stores/baseLayersStore";
+import { useMaplibreLayersStore } from "@/stores/maplibreLayersStore";
 import { computed, ref } from "vue";
 import { breakpointsTailwind, useBreakpoints, useClipboard } from "@vueuse/core";
 import {
@@ -59,7 +59,7 @@ import { useMainToolbarStore } from "@/stores/mainToolbarStore.ts";
 import UnitSymbol from "@/components/UnitSymbol.vue";
 import { useRecordingStore } from "@/stores/recordingStore";
 
-const baseLayersStore = useBaseLayersStore();
+const maplibreLayersStore = useMaplibreLayersStore();
 const {
   store,
   unitActions,
@@ -87,7 +87,7 @@ const baseMapId = defineModel<string>("baseMapId", {
 });
 
 const basemapOptions = computed(() =>
-  getSupportedMaplibreBasemaps(baseLayersStore.layers),
+  getSupportedMaplibreBasemaps(maplibreLayersStore.layers),
 );
 const breakpoints = useBreakpoints(breakpointsTailwind);
 const isMobile = breakpoints.smallerOrEqual("md");

--- a/src/modules/maplibreview/ScenarioEditorMaplibre.test.ts
+++ b/src/modules/maplibreview/ScenarioEditorMaplibre.test.ts
@@ -9,7 +9,7 @@ import { activeScenarioKey } from "@/components/injects";
 const bindScenario = vi.fn();
 const cleanupScenarioBinding = vi.fn();
 const setMapAdapter = vi.fn();
-const initializeBaseLayers = vi.fn();
+const initializeMaplibreLayers = vi.fn();
 
 vi.mock("@/geo/mapLibreMapAdapter", () => ({
   MapLibreMapAdapter: class MockMapLibreMapAdapter {
@@ -43,10 +43,10 @@ vi.mock("@/geo/engines/maplibre/mapLibreScenarioLayerController", () => ({
   })),
 }));
 
-vi.mock("@/stores/baseLayersStore", () => ({
-  useBaseLayersStore: () => ({
+vi.mock("@/stores/maplibreLayersStore", () => ({
+  useMaplibreLayersStore: () => ({
     layers: [],
-    initialize: initializeBaseLayers,
+    initialize: initializeMaplibreLayers,
   }),
 }));
 
@@ -122,7 +122,7 @@ describe("ScenarioEditorMaplibre", () => {
     bindScenario.mockReturnValue(cleanupScenarioBinding);
     cleanupScenarioBinding.mockReset();
     setMapAdapter.mockReset();
-    initializeBaseLayers.mockReset();
+    initializeMaplibreLayers.mockReset();
   });
 
   it("cleans up the scenario binding when the maplibre view unmounts", () => {

--- a/src/modules/maplibreview/ScenarioEditorMaplibre.vue
+++ b/src/modules/maplibreview/ScenarioEditorMaplibre.vue
@@ -23,7 +23,7 @@ import { injectStrict } from "@/utils";
 import { MapLibreMapAdapter } from "@/geo/mapLibreMapAdapter";
 import type { ScenarioMapEngine } from "@/geo/contracts/scenarioMapEngine";
 import { createMapLibreScenarioLayerController } from "@/geo/engines/maplibre/mapLibreScenarioLayerController";
-import { useBaseLayersStore } from "@/stores/baseLayersStore";
+import { useMaplibreLayersStore } from "@/stores/maplibreLayersStore";
 import { useGeoStore } from "@/stores/geoStore";
 import { useMapSettingsStore, type MapProjection } from "@/stores/mapSettingsStore";
 import {
@@ -87,7 +87,7 @@ provide(activeNativeMapKey, nativeMapStub);
 provide(activeFeatureSelectInteractionKey, featureSelectStub);
 
 const geoStore = useGeoStore();
-const baseLayersStore = useBaseLayersStore();
+const maplibreLayersStore = useMaplibreLayersStore();
 const mapSettingsStore = useMapSettingsStore();
 const maplibreBaseMapId = ref(MAPLIBRE_VECTOR_BASEMAP_ID);
 
@@ -101,7 +101,7 @@ function onProjectionUpdate(projection: MapProjection) {
   }
 }
 const activeMaplibreBasemap = computed(() =>
-  resolveMaplibreBasemap(maplibreBaseMapId.value, baseLayersStore.layers),
+  resolveMaplibreBasemap(maplibreBaseMapId.value, maplibreLayersStore.layers),
 );
 
 function onMapReady(mapInstance: MlMap) {
@@ -249,7 +249,7 @@ const mgrsPrecisionLabel = computed(() => {
 });
 
 onMounted(() => {
-  void baseLayersStore.initialize();
+  void maplibreLayersStore.initialize();
 });
 
 function disposeMaplibreBinding() {

--- a/src/modules/maplibreview/maplibreBasemaps.test.ts
+++ b/src/modules/maplibreview/maplibreBasemaps.test.ts
@@ -32,6 +32,11 @@ const layers: MlLayerConfig[] = [
     title: "Broken",
     sourceType: "style",
   },
+  {
+    name: "name-only",
+    sourceType: "raster",
+    tiles: ["https://tiles.example.com/name-only/{z}/{x}/{y}.png"],
+  },
 ];
 
 describe("maplibreBasemaps", () => {
@@ -42,8 +47,15 @@ describe("maplibreBasemaps", () => {
       MAPLIBRE_VECTOR_BASEMAP_ID,
       "osm",
       "imagery",
+      "name-only",
       NO_BASEMAP_ID,
     ]);
+  });
+
+  it("falls back to the layer name when title is missing", () => {
+    const options = getSupportedMaplibreBasemaps(layers);
+    const nameOnly = options.find((o) => o.id === "name-only");
+    expect(nameOnly?.title).toBe("name-only");
   });
 
   it("passes through a style URL unchanged for style sources", () => {

--- a/src/modules/maplibreview/maplibreBasemaps.test.ts
+++ b/src/modules/maplibreview/maplibreBasemaps.test.ts
@@ -1,78 +1,81 @@
 import { describe, expect, it } from "vitest";
 import {
-  MAPLIBRE_BRIGHT_BASEMAP_ID,
-  MAPLIBRE_DARK_BASEMAP_ID,
-  MAPLIBRE_LIBERTY_BASEMAP_ID,
   MAPLIBRE_VECTOR_BASEMAP_ID,
   NO_BASEMAP_ID,
   getSupportedMaplibreBasemaps,
   resolveMaplibreBasemap,
 } from "@/modules/maplibreview/maplibreBasemaps";
-import type { StoredLayerConfig } from "@/stores/baseLayersStore";
+import type { MlLayerConfig } from "@/geo/maplibreLayerConfigTypes";
 
-const layers: StoredLayerConfig[] = [
+const layers: MlLayerConfig[] = [
   {
-    title: "OSM",
-    name: "osm",
-    layerSourceType: "osm",
-    sourceOptions: {
-      crossOrigin: "anonymous",
-    },
-    layerType: "baselayer",
-    opacity: 1,
+    name: MAPLIBRE_VECTOR_BASEMAP_ID,
+    title: "OpenFreeMap Positron",
+    sourceType: "style",
+    styleUrl: "https://tiles.openfreemap.org/styles/positron",
   },
   {
-    title: "Imagery",
+    name: "osm",
+    title: "OSM",
+    sourceType: "raster",
+    tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+  },
+  {
     name: "imagery",
-    layerSourceType: "xyz",
-    sourceOptions: {
-      url: "https://tiles.example.com/{z}/{x}/{y}.png",
-    },
-    layerType: "baselayer",
+    title: "Imagery",
+    sourceType: "raster",
+    tiles: ["https://tiles.example.com/{z}/{x}/{y}.png"],
     opacity: 0.6,
   },
   {
-    title: "Unsupported",
-    name: "unsupported",
-    layerSourceType: "wms" as any,
-    sourceOptions: {},
-    layerType: "baselayer",
-    opacity: 1,
+    name: "broken-style",
+    title: "Broken",
+    sourceType: "style",
   },
 ];
 
 describe("maplibreBasemaps", () => {
-  it("returns the vector option, supported raster basemaps, and no basemap", () => {
+  it("returns the configured basemaps plus the no-basemap option", () => {
     const options = getSupportedMaplibreBasemaps(layers);
 
     expect(options.map((option) => option.id)).toEqual([
       MAPLIBRE_VECTOR_BASEMAP_ID,
-      MAPLIBRE_LIBERTY_BASEMAP_ID,
-      MAPLIBRE_BRIGHT_BASEMAP_ID,
-      MAPLIBRE_DARK_BASEMAP_ID,
       "osm",
       "imagery",
       NO_BASEMAP_ID,
     ]);
-    expect(options[4].style).toMatchObject({
+  });
+
+  it("passes through a style URL unchanged for style sources", () => {
+    const [positron] = getSupportedMaplibreBasemaps(layers);
+    expect(positron.style).toBe("https://tiles.openfreemap.org/styles/positron");
+  });
+
+  it("synthesizes a raster StyleSpecification for raster sources", () => {
+    const options = getSupportedMaplibreBasemaps(layers);
+    const osm = options.find((o) => o.id === "osm");
+    expect(osm?.style).toMatchObject({
       version: 8,
       sources: {
-        osm: {
-          type: "raster",
-        },
+        osm: { type: "raster" },
       },
     });
-    expect(options[5].style).toMatchObject({
+
+    const imagery = options.find((o) => o.id === "imagery");
+    expect(imagery?.style).toMatchObject({
       layers: [
         {
           source: "imagery",
-          paint: {
-            "raster-opacity": 0.6,
-          },
+          paint: { "raster-opacity": 0.6 },
         },
       ],
     });
-    expect(options[6].style).toMatchObject({
+  });
+
+  it("emits an empty style for the no-basemap option", () => {
+    const options = getSupportedMaplibreBasemaps(layers);
+    const none = options.find((o) => o.id === NO_BASEMAP_ID);
+    expect(none?.style).toMatchObject({
       version: 8,
       sources: {},
       layers: [],
@@ -81,7 +84,6 @@ describe("maplibreBasemaps", () => {
 
   it("falls back to the vector maplibre basemap when the requested id is unavailable", () => {
     const option = resolveMaplibreBasemap("missing-id", layers);
-
     expect(option.id).toBe(MAPLIBRE_VECTOR_BASEMAP_ID);
   });
 });

--- a/src/modules/maplibreview/maplibreBasemaps.ts
+++ b/src/modules/maplibreview/maplibreBasemaps.ts
@@ -1,16 +1,16 @@
 import type { StyleSpecification } from "maplibre-gl";
+import type {
+  MlLayerConfig,
+  MlRasterLayerConfig,
+  MlStyleLayerConfig,
+} from "@/geo/maplibreLayerConfigTypes";
 
 export const MAPLIBRE_VECTOR_BASEMAP_ID = "openFreeMapPositron";
 export const MAPLIBRE_LIBERTY_BASEMAP_ID = "openFreeMapLiberty";
 export const MAPLIBRE_BRIGHT_BASEMAP_ID = "openFreeMapBright";
 export const MAPLIBRE_DARK_BASEMAP_ID = "versaTilesEclipse";
 export const NO_BASEMAP_ID = "None";
-const OSM_TILE_URL = "https://tile.openstreetmap.org/{z}/{x}/{y}.png";
-const OPEN_FREE_MAP_POSITRON_STYLE_URL = "https://tiles.openfreemap.org/styles/positron";
-const OPEN_FREE_MAP_LIBERTY_STYLE_URL = "https://tiles.openfreemap.org/styles/liberty";
-const OPEN_FREE_MAP_BRIGHT_STYLE_URL = "https://tiles.openfreemap.org/styles/bright";
-const VERSATILES_ECLIPSE_STYLE_URL =
-  "https://tiles.versatiles.org/assets/styles/eclipse/style.json";
+
 const DEFAULT_GLYPHS_URL = "https://demotiles.maplibre.org/font/{fontstack}/{range}.pbf";
 
 export type MaplibreBasemapStyle = string | StyleSpecification;
@@ -18,45 +18,23 @@ export type MaplibreBasemapStyle = string | StyleSpecification;
 export interface MaplibreBasemapOption {
   id: string;
   title: string;
-  isShared: boolean;
   style: MaplibreBasemapStyle;
 }
 
-interface MaplibreBasemapLayer {
-  name: string;
-  title: string;
-  opacity: number;
-  layerSourceType?: "osm" | "xyz";
-  sourceOptions?: {
-    url?: string;
-    attributions?: unknown;
-    maxZoom?: number;
-  };
-}
-
-function toMapLibreAttribution(value: unknown): string | undefined {
-  if (typeof value === "string") return value;
-  if (Array.isArray(value)) {
-    const parts = value.filter((part): part is string => typeof part === "string");
-    return parts.length > 0 ? parts.join(" | ") : undefined;
-  }
-  return undefined;
-}
-
-function createRasterStyle(
-  layer: MaplibreBasemapLayer,
-  tiles: string[],
-): StyleSpecification {
+function createRasterStyle(layer: MlRasterLayerConfig): StyleSpecification {
   return {
     version: 8,
     glyphs: DEFAULT_GLYPHS_URL,
     sources: {
       [layer.name]: {
         type: "raster",
-        tiles,
-        tileSize: 256,
-        attribution: toMapLibreAttribution(layer.sourceOptions?.attributions),
-        maxzoom: layer.sourceOptions?.maxZoom,
+        tiles: layer.tiles,
+        tileSize: layer.tileSize ?? 256,
+        attribution: layer.attribution,
+        maxzoom: layer.maxZoom,
+        minzoom: layer.minZoom,
+        scheme: layer.scheme,
+        bounds: layer.bounds,
       },
     },
     layers: [
@@ -81,62 +59,38 @@ function createEmptyStyle(): StyleSpecification {
   };
 }
 
-function getTileUrls(layer: MaplibreBasemapLayer): string[] | null {
-  if (layer.layerSourceType === "osm") {
-    return [layer.sourceOptions?.url || OSM_TILE_URL];
-  }
-  if (layer.layerSourceType === "xyz" && layer.sourceOptions?.url) {
-    return [layer.sourceOptions.url];
-  }
+function resolveStyleSource(layer: MlStyleLayerConfig): MaplibreBasemapStyle | null {
+  if (layer.styleUrl) return layer.styleUrl;
+  if (layer.style) return layer.style;
   return null;
 }
 
+function configToBasemapOption(layer: MlLayerConfig): MaplibreBasemapOption | null {
+  switch (layer.sourceType) {
+    case "style": {
+      const style = resolveStyleSource(layer);
+      if (!style) return null;
+      return { id: layer.name, title: layer.title, style };
+    }
+    case "raster": {
+      if (!layer.tiles || layer.tiles.length === 0) return null;
+      return { id: layer.name, title: layer.title, style: createRasterStyle(layer) };
+    }
+  }
+}
+
 export function getSupportedMaplibreBasemaps(
-  layers: readonly MaplibreBasemapLayer[],
+  layers: MlLayerConfig[],
 ): MaplibreBasemapOption[] {
-  const options: MaplibreBasemapOption[] = [
-    {
-      id: MAPLIBRE_VECTOR_BASEMAP_ID,
-      title: "OpenFreeMap Positron",
-      isShared: false,
-      style: OPEN_FREE_MAP_POSITRON_STYLE_URL,
-    },
-    {
-      id: MAPLIBRE_LIBERTY_BASEMAP_ID,
-      title: "OpenFreeMap Liberty",
-      isShared: false,
-      style: OPEN_FREE_MAP_LIBERTY_STYLE_URL,
-    },
-    {
-      id: MAPLIBRE_BRIGHT_BASEMAP_ID,
-      title: "OpenFreeMap Bright",
-      isShared: false,
-      style: OPEN_FREE_MAP_BRIGHT_STYLE_URL,
-    },
-    {
-      id: MAPLIBRE_DARK_BASEMAP_ID,
-      title: "VersaTiles Eclipse (dark)",
-      isShared: false,
-      style: VERSATILES_ECLIPSE_STYLE_URL,
-    },
-  ];
-
+  const options: MaplibreBasemapOption[] = [];
   for (const layer of layers) {
-    const tiles = getTileUrls(layer);
-    if (!tiles) continue;
-
-    options.push({
-      id: layer.name,
-      title: layer.title,
-      isShared: true,
-      style: createRasterStyle(layer, tiles),
-    });
+    const option = configToBasemapOption(layer);
+    if (option) options.push(option);
   }
 
   options.push({
     id: NO_BASEMAP_ID,
     title: "No base map",
-    isShared: true,
     style: createEmptyStyle(),
   });
 
@@ -145,7 +99,7 @@ export function getSupportedMaplibreBasemaps(
 
 export function resolveMaplibreBasemap(
   basemapId: string | undefined,
-  layers: readonly MaplibreBasemapLayer[],
+  layers: MlLayerConfig[],
 ): MaplibreBasemapOption {
   const options = getSupportedMaplibreBasemaps(layers);
   return (

--- a/src/modules/maplibreview/maplibreBasemaps.ts
+++ b/src/modules/maplibreview/maplibreBasemaps.ts
@@ -21,6 +21,10 @@ export interface MaplibreBasemapOption {
   style: MaplibreBasemapStyle;
 }
 
+function resolveBasemapTitle(layer: MlLayerConfig): string {
+  return layer.title || layer.name;
+}
+
 function createRasterStyle(layer: MlRasterLayerConfig): StyleSpecification {
   return {
     version: 8,
@@ -70,11 +74,15 @@ function configToBasemapOption(layer: MlLayerConfig): MaplibreBasemapOption | nu
     case "style": {
       const style = resolveStyleSource(layer);
       if (!style) return null;
-      return { id: layer.name, title: layer.title, style };
+      return { id: layer.name, title: resolveBasemapTitle(layer), style };
     }
     case "raster": {
       if (!layer.tiles || layer.tiles.length === 0) return null;
-      return { id: layer.name, title: layer.title, style: createRasterStyle(layer) };
+      return {
+        id: layer.name,
+        title: resolveBasemapTitle(layer),
+        style: createRasterStyle(layer),
+      };
     }
   }
 }

--- a/src/stores/maplibreLayersStore.ts
+++ b/src/stores/maplibreLayersStore.ts
@@ -1,0 +1,55 @@
+import { defineStore } from "pinia";
+import { ref, shallowRef } from "vue";
+import type { MlLayerConfig, MlLayerConfigFile } from "@/geo/maplibreLayerConfigTypes";
+
+const FALLBACK_LAYERS: MlLayerConfig[] = [
+  {
+    name: "openFreeMapPositron",
+    title: "OpenFreeMap Positron",
+    sourceType: "style",
+    styleUrl: "https://tiles.openfreemap.org/styles/positron",
+  },
+  {
+    name: "openFreeMapLiberty",
+    title: "OpenFreeMap Liberty",
+    sourceType: "style",
+    styleUrl: "https://tiles.openfreemap.org/styles/liberty",
+  },
+  {
+    name: "openFreeMapBright",
+    title: "OpenFreeMap Bright",
+    sourceType: "style",
+    styleUrl: "https://tiles.openfreemap.org/styles/bright",
+  },
+  {
+    name: "versaTilesEclipse",
+    title: "VersaTiles Eclipse (dark)",
+    sourceType: "style",
+    styleUrl: "https://tiles.versatiles.org/assets/styles/eclipse/style.json",
+  },
+];
+
+export const useMaplibreLayersStore = defineStore("maplibreLayers", () => {
+  const layers = shallowRef<MlLayerConfig[]>([]);
+  const isInitialized = ref(false);
+
+  async function initialize() {
+    if (isInitialized.value) return;
+    try {
+      const res = await fetch("/config/maplibreConfig.json");
+      const config = (await res.json()) as MlLayerConfigFile;
+      layers.value = config && config.length > 0 ? config : FALLBACK_LAYERS;
+    } catch (e) {
+      console.error("Failed to fetch maplibreConfig.json", e);
+      layers.value = FALLBACK_LAYERS;
+    } finally {
+      isInitialized.value = true;
+    }
+  }
+
+  return {
+    layers,
+    isInitialized,
+    initialize,
+  };
+});


### PR DESCRIPTION
## Summary

- Split MapLibre basemap configuration out of the OpenLayers-typed `mapConfig.json` into a new `public/config/maplibreConfig.json` with MapLibre-native types (style URLs, raster tiles, bounds).
- Added `src/geo/maplibreLayerConfigTypes.ts` (discriminated union on `sourceType`: `style` | `raster`) and a dedicated `useMaplibreLayersStore` Pinia store that fetches the new config with a hard-coded fallback.
- Rewrote `maplibreBasemaps.ts` as a dispatcher over the config. The four prior hard-coded vector styles (OpenFreeMap Positron/Liberty/Bright, VersaTiles Eclipse) now ship as data, and all six OL raster layers (OSM, OSM DE, Gray Basemap, OpenTopoMap, ESRI World Imagery, Kartverket Topo Norway) are mirrored with attributions preserved. Kartverket keeps its Norway-only tile bounds via a new `bounds` field.

## Notes

- Basemap ids are unchanged, so any stored `maplibreBaseMapId` selection continues to resolve.
- `vector` and `raster-dem` source types are intentionally deferred until there is a UI consumer.
- `layers` in the store uses `shallowRef` because MapLibre's `StyleSpecification` blows up TSC when transitively unwrapped by Pinia's deep reactivity.