### PR TITLE
Enable GeoJSON overlay support for map engines

### DIFF
--- a/src/composables/geoMapLocation.test.ts
+++ b/src/composables/geoMapLocation.test.ts
@@ -105,6 +105,8 @@ function createFakeMapAdapter(initialCursor = ""): FakeMapAdapter {
     getNativeMap() {
       return undefined;
     },
+    addGeoJsonOverlay() {},
+    removeGeoJsonOverlay() {},
     emit(event: MapEventType, payload?: { coordinate?: [number, number] }) {
       const mapEvent = {
         coordinate: payload?.coordinate,

--- a/src/geo/contracts/mapAdapter.ts
+++ b/src/geo/contracts/mapAdapter.ts
@@ -1,5 +1,5 @@
 import type { AllGeoJSON } from "@turf/helpers";
-import type { Position } from "geojson";
+import type { GeoJSON, Position } from "geojson";
 
 export interface FitOptions {
   maxZoom?: number;
@@ -17,6 +17,20 @@ export interface ViewConstraints {
   extent?: [number, number, number, number] | null;
   minZoom?: number | null;
   maxZoom?: number | null;
+}
+
+export interface GeoJsonOverlayStyle {
+  strokeColor?: string;
+  strokeWidth?: number;
+  strokeLineDash?: number[];
+  fillColor?: string;
+  circleRadius?: number;
+  circleFillColor?: string;
+  circleStrokeColor?: string;
+}
+
+export interface GeoJsonOverlayOptions {
+  style?: GeoJsonOverlayStyle;
 }
 
 export type MapEventType = "moveend" | "click" | "pointermove" | "singleclick";
@@ -56,6 +70,14 @@ export interface MapAdapter {
   // Map events
   on(event: MapEventType, handler: MapEventHandler): () => void;
   once(event: MapEventType, handler: MapEventHandler): () => void;
+
+  // Transient GeoJSON overlays for shared editor UI such as previews.
+  addGeoJsonOverlay(
+    id: string,
+    geojson: GeoJSON | null | undefined,
+    options?: GeoJsonOverlayOptions,
+  ): void;
+  removeGeoJsonOverlay(id: string): void;
 
   // Escape hatch for incremental migration — returns the underlying
   // library-specific map object. Callers using this are still coupled

--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
@@ -258,7 +258,7 @@ export function createMapLibreScenarioLayerController(
       panToFeature: true,
       zoomToScenarioLayer: true,
       zoomToMapLayer: true,
-      featureTransform: false,
+      featureTransform: true,
       mapLayerTransform: false,
       mapLayerExtent: true,
     },

--- a/src/geo/engines/openlayers/olMapAdapter.test.ts
+++ b/src/geo/engines/openlayers/olMapAdapter.test.ts
@@ -1,6 +1,19 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
 import { OlMapAdapter } from "@/geo/engines/openlayers/olMapAdapter";
+import VectorLayer from "ol/layer/Vector";
+
+Object.defineProperty(HTMLCanvasElement.prototype, "getContext", {
+  configurable: true,
+  value: vi.fn(() => ({
+    fillStyle: "",
+    clearRect: vi.fn(),
+    fillRect: vi.fn(),
+    getImageData: vi.fn(() => ({
+      data: new Uint8ClampedArray([255, 0, 0, 255]),
+    })),
+  })),
+});
 
 function createMockView(overrides: Record<string, any> = {}) {
   return {
@@ -23,6 +36,9 @@ function createMockMap(viewOverrides: Record<string, any> = {}) {
     getView: vi.fn(() => view),
     setView: vi.fn(),
     updateSize: vi.fn(),
+    render: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
     on: vi.fn(),
     once: vi.fn(),
     getSize: vi.fn(() => [800, 600]),
@@ -90,6 +106,26 @@ describe("OlMapAdapter", () => {
       adapter.setViewConstraints({ minZoom: 5 });
 
       expect(olMap.setView).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("geojson overlays", () => {
+    it("creates and removes a managed overlay layer", () => {
+      const { olMap } = createMockMap();
+      const adapter = new OlMapAdapter(olMap as any);
+      const setMapSpy = vi.spyOn(VectorLayer.prototype, "setMap");
+
+      adapter.addGeoJsonOverlay("preview", {
+        type: "FeatureCollection",
+        features: [],
+      });
+
+      expect(setMapSpy).toHaveBeenCalledWith(olMap);
+
+      adapter.removeGeoJsonOverlay("preview");
+
+      expect(setMapSpy).toHaveBeenCalledWith(null);
+      setMapSpy.mockRestore();
     });
   });
 });

--- a/src/geo/engines/openlayers/olMapAdapter.ts
+++ b/src/geo/engines/openlayers/olMapAdapter.ts
@@ -1,16 +1,19 @@
 import type OLMap from "ol/Map";
 import { fromLonLat, toLonLat, transformExtent } from "ol/proj";
 import type { AllGeoJSON } from "@turf/helpers";
-import type { Position } from "geojson";
-import GeoJSON from "ol/format/GeoJSON";
+import type { GeoJSON as GeoJsonObject, Position } from "geojson";
+import GeoJSONFormat from "ol/format/GeoJSON";
 import Feature from "ol/Feature";
 import SimpleGeometry from "ol/geom/SimpleGeometry";
+import VectorLayer from "ol/layer/Vector";
+import VectorSource from "ol/source/Vector";
 import turfEnvelope from "@turf/envelope";
 import { unByKey } from "ol/Observable";
 import View from "ol/View";
 import type {
   AnimateOptions,
   FitOptions,
+  GeoJsonOverlayOptions,
   MapAdapter,
   MapEventHandler,
   MapEventType,
@@ -19,6 +22,7 @@ import type {
 
 export class OlMapAdapter implements MapAdapter {
   private _viewConstraints: ViewConstraints = {};
+  private readonly geoJsonOverlayLayers = new Map<string, VectorLayer<VectorSource>>();
 
   constructor(private olMap: OLMap) {}
 
@@ -43,7 +47,7 @@ export class OlMapAdapter implements MapAdapter {
 
   fitGeometry(geojson: AllGeoJSON, options: FitOptions = {}): void {
     const { duration = 900, maxZoom = 15, padding } = options;
-    const bb = new GeoJSON().readFeature(turfEnvelope(geojson), {
+    const bb = new GeoJSONFormat().readFeature(turfEnvelope(geojson), {
       featureProjection: this.projection,
       dataProjection: "EPSG:4326",
     }) as Feature;
@@ -172,7 +176,63 @@ export class OlMapAdapter implements MapAdapter {
     return () => unByKey(key);
   }
 
+  addGeoJsonOverlay(
+    id: string,
+    geojson: GeoJsonObject | null | undefined,
+    options: GeoJsonOverlayOptions = {},
+  ): void {
+    const layer = this.getOrCreateGeoJsonOverlayLayer(id, options);
+    layer.getSource()?.clear();
+    if (!geojson) return;
+    layer.getSource()?.addFeatures(
+      new GeoJSONFormat().readFeatures(geojson, {
+        featureProjection: this.projection,
+        dataProjection: "EPSG:4326",
+      }),
+    );
+  }
+
+  removeGeoJsonOverlay(id: string): void {
+    const layer = this.geoJsonOverlayLayers.get(id);
+    if (!layer) return;
+    layer.setMap(null);
+    this.geoJsonOverlayLayers.delete(id);
+  }
+
   getNativeMap(): OLMap {
     return this.olMap;
   }
+
+  private getOrCreateGeoJsonOverlayLayer(
+    id: string,
+    options: GeoJsonOverlayOptions,
+  ): VectorLayer<VectorSource> {
+    const existingLayer = this.geoJsonOverlayLayers.get(id);
+    if (existingLayer) {
+      existingLayer.setStyle(createOlGeoJsonOverlayStyle(options));
+      return existingLayer;
+    }
+
+    const layer = new VectorLayer({
+      source: new VectorSource(),
+      style: createOlGeoJsonOverlayStyle(options),
+    });
+    layer.setMap(this.olMap);
+    this.geoJsonOverlayLayers.set(id, layer);
+    return layer;
+  }
+}
+
+function createOlGeoJsonOverlayStyle(options: GeoJsonOverlayOptions = {}) {
+  const style = options.style ?? {};
+  return {
+    "stroke-color": style.strokeColor ?? "red",
+    "stroke-width": style.strokeWidth ?? 3,
+    "stroke-line-dash": style.strokeLineDash ?? [10, 10],
+    "fill-color": style.fillColor ?? "rgba(188,35,65,0.2)",
+    "circle-radius": style.circleRadius ?? 5,
+    "circle-fill-color": style.circleFillColor ?? "red",
+    "circle-stroke-color": style.circleStrokeColor ?? "red",
+    "circle-stroke-width": 1,
+  };
 }

--- a/src/geo/mapLibreMapAdapter.test.ts
+++ b/src/geo/mapLibreMapAdapter.test.ts
@@ -4,6 +4,8 @@ import { MapLibreMapAdapter } from "@/geo/mapLibreMapAdapter";
 
 function createMockMap() {
   const listeners = new Map<string, (event: any) => void>();
+  const sources = new Map<string, any>();
+  const layers = new Map<string, any>();
 
   const mlMap = {
     on: vi.fn((event: string, handler: (event: any) => void) => {
@@ -29,9 +31,27 @@ function createMockMap() {
     setMaxBounds: vi.fn(),
     setMinZoom: vi.fn(),
     setMaxZoom: vi.fn(),
+    addSource: vi.fn((id: string, spec: any) => {
+      const source = {
+        ...spec,
+        setData: vi.fn(),
+      };
+      sources.set(id, source);
+    }),
+    getSource: vi.fn((id: string) => sources.get(id)),
+    removeSource: vi.fn((id: string) => {
+      sources.delete(id);
+    }),
+    addLayer: vi.fn((spec: any) => {
+      layers.set(spec.id, spec);
+    }),
+    getLayer: vi.fn((id: string) => layers.get(id)),
+    removeLayer: vi.fn((id: string) => {
+      layers.delete(id);
+    }),
   };
 
-  return { mlMap, listeners };
+  return { mlMap, listeners, sources, layers };
 }
 
 describe("MapLibreMapAdapter", () => {
@@ -112,6 +132,109 @@ describe("MapLibreMapAdapter", () => {
 
       expect(mlMap.setMinZoom).toHaveBeenCalledWith(3);
       expect(mlMap.setMaxZoom).toHaveBeenCalledWith(18);
+    });
+  });
+
+  describe("geojson overlays", () => {
+    it("creates a source and preview layers and writes overlay data", () => {
+      const { mlMap, sources, layers } = createMockMap();
+      const adapter = new MapLibreMapAdapter(mlMap as any);
+      const geojson = {
+        type: "FeatureCollection" as const,
+        features: [],
+      };
+
+      adapter.addGeoJsonOverlay("preview", geojson, {
+        style: { strokeColor: "#ff0000" },
+      });
+
+      expect(mlMap.addSource).toHaveBeenCalledWith(
+        "geojson-overlay-source-preview",
+        expect.objectContaining({ type: "geojson" }),
+      );
+      expect(mlMap.addLayer).toHaveBeenCalledTimes(3);
+      expect(layers.has("geojson-overlay-fill-preview")).toBe(true);
+      expect(layers.has("geojson-overlay-line-preview")).toBe(true);
+      expect(layers.has("geojson-overlay-circle-preview")).toBe(true);
+      expect(sources.get("geojson-overlay-source-preview").setData).toHaveBeenCalledWith(
+        geojson,
+      );
+    });
+
+    it("omits line-dasharray when the computed dash pattern is undefined", () => {
+      const { mlMap, layers } = createMockMap();
+      const adapter = new MapLibreMapAdapter(mlMap as any);
+
+      adapter.addGeoJsonOverlay(
+        "preview",
+        {
+          type: "FeatureCollection",
+          features: [],
+        },
+        {
+          style: {
+            strokeWidth: 0,
+            strokeLineDash: [],
+          },
+        },
+      );
+
+      expect(layers.get("geojson-overlay-line-preview").paint).not.toHaveProperty(
+        "line-dasharray",
+      );
+    });
+
+    it("removes overlay layers and source", () => {
+      const { mlMap, sources, layers } = createMockMap();
+      const adapter = new MapLibreMapAdapter(mlMap as any);
+
+      adapter.addGeoJsonOverlay("preview", {
+        type: "FeatureCollection",
+        features: [],
+      });
+      adapter.removeGeoJsonOverlay("preview");
+
+      expect(mlMap.removeLayer).toHaveBeenCalledWith("geojson-overlay-circle-preview");
+      expect(mlMap.removeLayer).toHaveBeenCalledWith("geojson-overlay-line-preview");
+      expect(mlMap.removeLayer).toHaveBeenCalledWith("geojson-overlay-fill-preview");
+      expect(mlMap.removeSource).toHaveBeenCalledWith("geojson-overlay-source-preview");
+      expect(sources.size).toBe(0);
+      expect(layers.size).toBe(0);
+    });
+
+    it("rebuilds overlays after a style reload", () => {
+      const { mlMap, listeners, sources, layers } = createMockMap();
+      const adapter = new MapLibreMapAdapter(mlMap as any);
+      const geojson = {
+        type: "FeatureCollection" as const,
+        features: [],
+      };
+
+      adapter.addGeoJsonOverlay("preview", geojson);
+      sources.clear();
+      layers.clear();
+
+      listeners.get("style.load")?.({});
+
+      expect(mlMap.addSource).toHaveBeenCalledTimes(2);
+      expect(mlMap.addLayer).toHaveBeenCalledTimes(6);
+      expect(sources.get("geojson-overlay-source-preview").setData).toHaveBeenCalledWith(
+        geojson,
+      );
+    });
+
+    it("tolerates overlay cleanup after the native map is gone", () => {
+      const { mlMap } = createMockMap();
+      const adapter = new MapLibreMapAdapter(mlMap as any);
+
+      adapter.addGeoJsonOverlay("preview", {
+        type: "FeatureCollection",
+        features: [],
+      });
+
+      (adapter as any).mlMap = undefined;
+
+      expect(() => adapter.removeGeoJsonOverlay("preview")).not.toThrow();
     });
   });
 });

--- a/src/geo/mapLibreMapAdapter.ts
+++ b/src/geo/mapLibreMapAdapter.ts
@@ -1,10 +1,18 @@
-import type { Map as MlMap, MapMouseEvent } from "maplibre-gl";
+import type { GeoJSON, Position } from "geojson";
+import type {
+  CircleLayerSpecification,
+  FillLayerSpecification,
+  GeoJSONSource,
+  LineLayerSpecification,
+  Map as MlMap,
+  MapMouseEvent,
+} from "maplibre-gl";
 import type { AllGeoJSON } from "@turf/helpers";
-import type { Position } from "geojson";
 import turfBbox from "@turf/bbox";
 import type {
   AnimateOptions,
   FitOptions,
+  GeoJsonOverlayOptions,
   MapAdapter,
   MapEventHandler,
   MapEventType,
@@ -34,8 +42,14 @@ function toMapEventPayload(e: MapMouseEvent) {
 
 export class MapLibreMapAdapter implements MapAdapter {
   private _viewConstraints: ViewConstraints = {};
+  private readonly geoJsonOverlays = new Map<
+    string,
+    { geojson: GeoJSON | null; options: GeoJsonOverlayOptions }
+  >();
 
-  constructor(private mlMap: MlMap) {}
+  constructor(private mlMap: MlMap) {
+    this.mlMap.on("style.load", this.handleStyleLoad);
+  }
 
   animateView(options: AnimateOptions): void {
     this.mlMap.flyTo({
@@ -158,7 +172,148 @@ export class MapLibreMapAdapter implements MapAdapter {
     };
   }
 
+  addGeoJsonOverlay(
+    id: string,
+    geojson: GeoJSON | null | undefined,
+    options: GeoJsonOverlayOptions = {},
+  ): void {
+    const normalizedGeoJson = geojson ?? null;
+    this.geoJsonOverlays.set(id, { geojson: normalizedGeoJson, options });
+    this.ensureGeoJsonOverlay(id, options);
+    const source = this.mlMap.getSource(this.getGeoJsonOverlaySourceId(id)) as
+      | GeoJSONSource
+      | undefined;
+    source?.setData(
+      normalizedGeoJson ?? {
+        type: "FeatureCollection",
+        features: [],
+      },
+    );
+  }
+
+  removeGeoJsonOverlay(id: string): void {
+    this.geoJsonOverlays.delete(id);
+    this.removeGeoJsonOverlayFromMap(id);
+  }
+
   getNativeMap(): MlMap {
     return this.mlMap;
   }
+
+  private readonly handleStyleLoad = () => {
+    for (const [id, overlay] of this.geoJsonOverlays.entries()) {
+      this.ensureGeoJsonOverlay(id, overlay.options);
+      const source = this.mlMap.getSource(this.getGeoJsonOverlaySourceId(id)) as
+        | GeoJSONSource
+        | undefined;
+      source?.setData(
+        overlay.geojson ?? {
+          type: "FeatureCollection",
+          features: [],
+        },
+      );
+    }
+  };
+
+  private ensureGeoJsonOverlay(id: string, options: GeoJsonOverlayOptions) {
+    const sourceId = this.getGeoJsonOverlaySourceId(id);
+    if (!this.mlMap.getSource(sourceId)) {
+      this.mlMap.addSource(sourceId, {
+        type: "geojson",
+        data: {
+          type: "FeatureCollection",
+          features: [],
+        },
+      });
+    }
+
+    const fillLayerId = this.getGeoJsonOverlayLayerId(id, "fill");
+    const lineLayerId = this.getGeoJsonOverlayLayerId(id, "line");
+    const circleLayerId = this.getGeoJsonOverlayLayerId(id, "circle");
+    const style = options.style ?? {};
+    const lineDashArray = toMapLibreLineDashArray(
+      style.strokeLineDash ?? [10, 10],
+      style.strokeWidth ?? 3,
+    );
+
+    this.upsertLayer(fillLayerId, {
+      id: fillLayerId,
+      type: "fill",
+      source: sourceId,
+      paint: {
+        "fill-color": style.fillColor ?? "rgba(188,35,65,0.2)",
+      },
+    } satisfies FillLayerSpecification);
+
+    this.upsertLayer(lineLayerId, {
+      id: lineLayerId,
+      type: "line",
+      source: sourceId,
+      paint: {
+        "line-color": style.strokeColor ?? "red",
+        "line-width": style.strokeWidth ?? 3,
+        ...(lineDashArray ? { "line-dasharray": lineDashArray } : {}),
+      },
+    } satisfies LineLayerSpecification);
+
+    this.upsertLayer(circleLayerId, {
+      id: circleLayerId,
+      type: "circle",
+      source: sourceId,
+      paint: {
+        "circle-radius": style.circleRadius ?? 5,
+        "circle-color": style.circleFillColor ?? "red",
+        "circle-stroke-color": style.circleStrokeColor ?? "red",
+        "circle-stroke-width": 1,
+      },
+    } satisfies CircleLayerSpecification);
+  }
+
+  private upsertLayer(
+    id: string,
+    spec: FillLayerSpecification | LineLayerSpecification | CircleLayerSpecification,
+  ) {
+    if (this.mlMap.getLayer(id)) {
+      this.mlMap.removeLayer(id);
+    }
+    this.mlMap.addLayer(spec as any);
+  }
+
+  private removeGeoJsonOverlayFromMap(id: string) {
+    const map = this.mlMap;
+    if (
+      !map ||
+      typeof map.getLayer !== "function" ||
+      typeof map.getSource !== "function"
+    ) {
+      return;
+    }
+
+    const fillLayerId = this.getGeoJsonOverlayLayerId(id, "fill");
+    const lineLayerId = this.getGeoJsonOverlayLayerId(id, "line");
+    const circleLayerId = this.getGeoJsonOverlayLayerId(id, "circle");
+    for (const layerId of [circleLayerId, lineLayerId, fillLayerId]) {
+      if (map.getLayer(layerId)) {
+        map.removeLayer(layerId);
+      }
+    }
+
+    const sourceId = this.getGeoJsonOverlaySourceId(id);
+    if (map.getSource(sourceId)) {
+      map.removeSource(sourceId);
+    }
+  }
+
+  private getGeoJsonOverlaySourceId(id: string) {
+    return `geojson-overlay-source-${id}`;
+  }
+
+  private getGeoJsonOverlayLayerId(id: string, kind: "fill" | "line" | "circle") {
+    return `geojson-overlay-${kind}-${id}`;
+  }
+}
+
+function toMapLibreLineDashArray(lineDash: number[], lineWidth: number) {
+  if (!lineDash.length || lineWidth <= 0) return undefined;
+  return lineDash.map((segment) => segment / lineWidth);
 }

--- a/src/modules/scenarioeditor/FeatureTransformations.test.ts
+++ b/src/modules/scenarioeditor/FeatureTransformations.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { nextTick, reactive, ref, shallowRef } from "vue";
+import FeatureTransformations from "@/modules/scenarioeditor/FeatureTransformations.vue";
+import {
+  activeLayerKey,
+  activeScenarioKey,
+  activeScenarioMapEngineKey,
+} from "@/components/injects";
+import { useSelectedItems } from "@/stores/selectedStore";
+
+describe("FeatureTransformations", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    useSelectedItems().clear();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders preview through the shared map adapter and cleans it up on unmount", async () => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const selected = useSelectedItems();
+    selected.selectedUnitIds.value.add("unit-1");
+
+    const addGeoJsonOverlay = vi.fn();
+    const removeGeoJsonOverlay = vi.fn();
+    const state = reactive({
+      currentTime: 1000,
+      unitStateCounter: 0,
+    });
+
+    const wrapper = mount(FeatureTransformations, {
+      props: { unitMode: true },
+      global: {
+        plugins: [pinia],
+        provide: {
+          [activeScenarioKey as symbol]: {
+            helpers: {
+              getUnitById: (id: string) =>
+                id === "unit-1" ? { id, name: "Unit 1", location: [10, 20] } : undefined,
+            },
+            geo: {
+              addFeature: vi.fn(),
+              updateFeature: vi.fn(),
+              addFeatureStateGeometry: vi.fn(),
+              getGeometryLayerItemById: vi.fn(),
+            },
+            time: {
+              scenarioTime: ref(1000),
+            },
+            store: {
+              state,
+            },
+          },
+          [activeLayerKey as symbol]: ref("layer-1"),
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            map: {
+              addGeoJsonOverlay,
+              removeGeoJsonOverlay,
+            },
+          }),
+        },
+        stubs: {
+          Tabs: { template: "<div><slot /></div>" },
+          TabsList: { template: "<div><slot /></div>" },
+          TabsTrigger: { template: "<button><slot /></button>" },
+          TabsContent: { template: "<div><slot /></div>" },
+          TransformForm: { template: "<div />" },
+          Button: { template: "<button><slot /></button>" },
+          BaseButton: { template: "<button><slot /></button>" },
+          InputCheckbox: { template: "<label />" },
+          ScenarioFeatureSelect: { template: "<div />" },
+          Label: { template: "<label><slot /></label>" },
+        },
+      },
+    });
+
+    state.currentTime += 1;
+    await nextTick();
+    vi.runAllTimers();
+    await nextTick();
+
+    expect(addGeoJsonOverlay).toHaveBeenCalledTimes(1);
+    expect(addGeoJsonOverlay).toHaveBeenCalledWith(
+      expect.stringContaining("transform-preview-"),
+      expect.any(Object),
+      expect.objectContaining({
+        style: expect.objectContaining({
+          strokeColor: "red",
+        }),
+      }),
+    );
+
+    wrapper.unmount();
+
+    expect(removeGeoJsonOverlay).toHaveBeenCalledWith(
+      expect.stringContaining("transform-preview-"),
+    );
+  });
+
+  it("does not deep-traverse map adapter internals when the map contains Set state", async () => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const selected = useSelectedItems();
+    selected.selectedFeatureIds.value.add("feature-1");
+
+    const addGeoJsonOverlay = vi.fn();
+    const removeGeoJsonOverlay = vi.fn();
+    const state = reactive({
+      currentTime: 1000,
+      unitStateCounter: 0,
+    });
+
+    const wrapper = mount(FeatureTransformations, {
+      global: {
+        plugins: [pinia],
+        provide: {
+          [activeScenarioKey as symbol]: {
+            helpers: {
+              getUnitById: vi.fn(),
+            },
+            geo: {
+              addFeature: vi.fn(),
+              updateFeature: vi.fn(),
+              addFeatureStateGeometry: vi.fn(),
+              getGeometryLayerItemById: vi.fn(() => ({
+                layerItem: {
+                  id: "feature-1",
+                  name: "Feature 1",
+                  geometry: {
+                    type: "Point",
+                    coordinates: [10, 20],
+                  },
+                },
+              })),
+            },
+            time: {
+              scenarioTime: ref(1000),
+            },
+            store: {
+              state,
+            },
+          },
+          [activeLayerKey as symbol]: ref("layer-1"),
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            map: {
+              internalSet: new Set(["x"]),
+              internalMap: new Map([["a", 1]]),
+              addGeoJsonOverlay,
+              removeGeoJsonOverlay,
+            },
+          }),
+        },
+        stubs: {
+          Tabs: { template: "<div><slot /></div>" },
+          TabsList: { template: "<div><slot /></div>" },
+          TabsTrigger: { template: "<button><slot /></button>" },
+          TabsContent: { template: "<div><slot /></div>" },
+          TransformForm: { template: "<div />" },
+          Button: { template: "<button><slot /></button>" },
+          BaseButton: { template: "<button><slot /></button>" },
+          InputCheckbox: { template: "<label />" },
+          ScenarioFeatureSelect: { template: "<div />" },
+          Label: { template: "<label><slot /></label>" },
+        },
+      },
+    });
+
+    state.currentTime += 1;
+    await nextTick();
+    vi.runAllTimers();
+    await nextTick();
+
+    expect(addGeoJsonOverlay).toHaveBeenCalledTimes(1);
+
+    wrapper.unmount();
+  });
+});

--- a/src/modules/scenarioeditor/FeatureTransformations.vue
+++ b/src/modules/scenarioeditor/FeatureTransformations.vue
@@ -7,16 +7,13 @@ import BaseButton from "@/components/BaseButton.vue";
 import { injectStrict, nanoid } from "@/utils";
 import {
   activeLayerKey,
-  activeNativeMapKey,
   activeScenarioKey,
+  activeScenarioMapEngineKey,
 } from "@/components/injects";
 import type { FeatureId } from "@/types/scenarioGeoModels";
 import type { NGeometryLayerItem, NUnit } from "@/types/internalModels";
 import type { Feature } from "geojson";
 import { useDebounceFn } from "@vueuse/core";
-import VectorLayer from "ol/layer/Vector";
-import VectorSource from "ol/source/Vector";
-import { drawGeoJsonLayer } from "@/composables/openlayersHelpers";
 import { useTransformSettingsStore } from "@/stores/transformStore";
 import { storeToRefs } from "pinia";
 import InputCheckbox from "@/components/InputCheckbox.vue";
@@ -40,9 +37,9 @@ const isUnitMode = props.unitMode;
 
 const scn = injectStrict(activeScenarioKey);
 const activeLayerId = injectStrict(activeLayerKey);
-
-const olMapRef = injectStrict(activeNativeMapKey);
+const scenarioMapEngineRef = injectStrict(activeScenarioMapEngineKey);
 const fmt = useTimeFormatStore();
+const previewOverlayId = `transform-preview-${nanoid()}`;
 
 const formattedTime = computed(() =>
   fmt.scenarioFormatter.format(+scn.time.scenarioTime.value),
@@ -67,29 +64,31 @@ const { showPreview, transformations, updateActiveFeature, updateAtTime } = stor
 
 const toggleRedraw = ref(true);
 const addActiveLayer = ref(activeLayerId.value!);
-
-const previewLayer = new VectorLayer({
-  source: new VectorSource({}),
-  style: {
-    "stroke-color": "red",
-    "stroke-width": 3,
-    "stroke-line-dash": [10, 10],
-    "fill-color": "rgba(188,35,65,0.2)",
-    "circle-radius": 5,
-    "circle-fill-color": "red",
-    "circle-stroke-color": "red",
-  },
-});
-
-olMapRef.value.addLayer(previewLayer);
+let previewMap = scenarioMapEngineRef.value?.map;
 
 const calculatePreview = useDebounceFn(
-  (features: NGeometryLayerItem[] | NUnit[], ops: TransformationOperation[]) => {
+  (
+    features: NGeometryLayerItem[] | NUnit[],
+    ops: TransformationOperation[],
+    map = scenarioMapEngineRef.value?.map,
+  ) => {
+    if (!map) return;
     const geometry = isUnitMode
       ? doUnitTransformations(features as NUnit[], ops)
       : doScenarioFeatureTransformation(features as NGeometryLayerItem[], ops);
 
-    drawGeoJsonLayer(previewLayer, geometry);
+    previewMap = map;
+    map.addGeoJsonOverlay(previewOverlayId, geometry, {
+      style: {
+        strokeColor: "red",
+        strokeWidth: 3,
+        strokeLineDash: [10, 10],
+        fillColor: "rgba(188,35,65,0.2)",
+        circleRadius: 5,
+        circleFillColor: "red",
+        circleStrokeColor: "red",
+      },
+    });
   },
   200,
 );
@@ -123,6 +122,21 @@ if (!props.unitMode) {
   );
 }
 
+function updatePreview() {
+  if (showPreview.value && transformations.value && selectedItems.value.length) {
+    const currentItems = props.unitMode
+      ? (selectedItems.value as NUnit[])
+      : (selectedItems.value.filter(Boolean) as NGeometryLayerItem[]);
+    calculatePreview(
+      currentItems,
+      transformations.value.filter((v) => !!v),
+      scenarioMapEngineRef.value?.map,
+    );
+  } else {
+    clearPreview();
+  }
+}
+
 watch(
   [
     transformations,
@@ -131,20 +145,16 @@ watch(
     () => scn.store.state.unitStateCounter,
     () => scn.store.state.currentTime,
   ],
-  () => {
-    if (showPreview.value && transformations.value) {
-      const currentItems = props.unitMode
-        ? (selectedItems.value as NUnit[])
-        : (selectedItems.value.filter(Boolean) as NGeometryLayerItem[]);
-      calculatePreview(
-        currentItems,
-        transformations.value.filter((v) => !!v),
-      );
-    } else {
-      previewLayer.getSource()?.clear();
-    }
-  },
+  updatePreview,
   { deep: true },
+);
+
+watch(
+  () => scenarioMapEngineRef.value?.map,
+  () => {
+    clearPreview();
+    updatePreview();
+  },
 );
 
 function onSubmit(updateMode = false) {
@@ -187,13 +197,10 @@ function onSubmit(updateMode = false) {
     scenarioFeature.name = `${featureName} (${filteredTrans[0].transform})`;
     scn.geo.addFeature(scenarioFeature, layerId!);
   }
-  previewLayer.getSource()?.clear();
+  clearPreview();
 }
 
-onUnmounted(() => {
-  previewLayer.getSource()?.clear();
-  olMapRef.value.removeLayer(previewLayer);
-});
+onUnmounted(() => clearPreview());
 
 function addTransformation() {
   transformations.value.push(createDefaultTransformationOperation());
@@ -201,6 +208,15 @@ function addTransformation() {
 
 function deleteTransformation(index: number) {
   transformations.value.splice(index, 1);
+}
+
+function clearPreview() {
+  const currentMap = scenarioMapEngineRef.value?.map;
+  previewMap?.removeGeoJsonOverlay(previewOverlayId);
+  if (currentMap && currentMap !== previewMap) {
+    currentMap.removeGeoJsonOverlay(previewOverlayId);
+  }
+  previewMap = currentMap;
 }
 </script>
 <template>

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.test.ts
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.test.ts
@@ -101,4 +101,76 @@ describe("ScenarioFeatureDetails", () => {
       style: { "marker-symbol": "square" },
     });
   });
+
+  it("shows the transform tab when the active map engine supports feature transforms", () => {
+    const feature = {
+      id: "feature-1",
+      kind: "geometry",
+      _pid: "layer-1",
+      geometry: {
+        type: "Point",
+        coordinates: [10, 20],
+      },
+      geometryMeta: {
+        geometryKind: "Point",
+      },
+      name: "Alpha",
+      style: {},
+    };
+
+    const wrapper = mount(ScenarioFeatureDetails, {
+      props: {
+        selectedIds: new Set(["feature-1"]),
+      },
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeScenarioKey as symbol]: {
+            geo: {
+              getGeometryLayerItemById: vi.fn(() => ({ layerItem: feature })),
+              updateFeature: vi.fn(),
+            },
+            store: {
+              groupUpdate: (callback: () => void) => callback(),
+            },
+          },
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            layers: {
+              capabilities: {
+                featureTransform: true,
+              },
+            },
+            suspendFeatureSelection: vi.fn(),
+            resumeFeatureSelection: vi.fn(),
+          } as any),
+        },
+        stubs: {
+          GlobalEvents: true,
+          EditableLabel: true,
+          IconButton: true,
+          ItemMedia: true,
+          ScenarioFeatureDropdownMenu: true,
+          ScenarioFeatureState: true,
+          EditMetaForm: true,
+          EditMediaForm: true,
+          FeatureTransformations: true,
+          PanelDataGrid: { template: "<div><slot /></div>" },
+          ScrollTabs: {
+            props: ["items"],
+            template: "<div><slot /></div>",
+          },
+          TabsContent: { template: "<div><slot /></div>" },
+          Button: { template: "<button><slot /></button>" },
+          ScenarioFeatureVisibilitySettings: true,
+          ScenarioFeatureStrokeSettings: true,
+          ScenarioFeatureArrowSettings: true,
+          ScenarioFeatureFillSettings: true,
+          ScenarioFeatureTextSettings: true,
+          ScenarioFeatureMarkerSettings: true,
+        },
+      },
+    });
+
+    expect(wrapper.find("feature-transformations-stub").exists()).toBe(true);
+  });
 });


### PR DESCRIPTION
- Add transient GeoJSON overlay functionality with configurable styles for previews and temporary UI layers.
- Implement `setGeoJsonOverlay` and `removeGeoJsonOverlay` methods in `MapLibreMapAdapter` and `OlMapAdapter`.
- Refactor `FeatureTransformations` to use the new GeoJSON overlay APIs for transformation previews.
- Update tests for map adapters and overlays to cover new behaviors and ensure compatibility.
