### PR TITLE
Add box select interaction in MapLibre mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Added a sort direction control to the stored scenario browser dropdown, with an icon indicating ascending or descending order.
 - Added a recording control dropdown to the navbar.
 - Added recovery drafts for scenario editing, along with "Revert to opened state" and "Revert to saved version" actions.
+- Added Ctrl/Cmd + drag box select for units in MapLibre mode.
 
 ### Changed
 

--- a/src/composables/useMaplibreBoxSelect.ts
+++ b/src/composables/useMaplibreBoxSelect.ts
@@ -1,0 +1,187 @@
+import type { GeoJSONSource, Map as MlMap } from "maplibre-gl";
+import bboxPolygon from "@turf/bbox-polygon";
+import type { EntityId } from "@/types/base";
+
+const BOX_SELECT_SOURCE = "__boxSelectSource";
+const BOX_SELECT_FILL = "__boxSelectFill";
+const BOX_SELECT_LINE = "__boxSelectLine";
+
+export interface MaplibreBoxSelectOptions<S> {
+  getUnitLayerIds: () => string[];
+  onBoxStart: () => void;
+  onBoxEnd: (unitIds: EntityId[]) => void;
+  isEnabled: () => boolean;
+  suspend: () => S;
+  restore: (suspended: S) => void;
+}
+
+export interface MaplibreBoxSelect {
+  cleanup: () => void;
+}
+
+/**
+ * Ctrl/Cmd + drag box-select for units on a MapLibre map. Mirrors the
+ * OpenLayers `DragBox({ condition: platformModifierKeyOnly })` behavior used by
+ * `useUnitSelectInteraction` in `src/composables/geoUnitLayers.ts`.
+ */
+export function useMaplibreBoxSelect<S>(
+  mlMap: MlMap,
+  options: MaplibreBoxSelectOptions<S>,
+): MaplibreBoxSelect {
+  const container = mlMap.getCanvasContainer();
+
+  type ActiveDrag = {
+    startPx: [number, number];
+    suspended: S;
+  };
+  let drag: ActiveDrag | null = null;
+
+  function getPixel(e: MouseEvent): [number, number] {
+    const rect = mlMap.getCanvas().getBoundingClientRect();
+    return [e.clientX - rect.left, e.clientY - rect.top];
+  }
+
+  function addPreviewLayers() {
+    if (!mlMap.getSource(BOX_SELECT_SOURCE)) {
+      mlMap.addSource(BOX_SELECT_SOURCE, {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      });
+    }
+    if (!mlMap.getLayer(BOX_SELECT_FILL)) {
+      mlMap.addLayer({
+        id: BOX_SELECT_FILL,
+        type: "fill",
+        source: BOX_SELECT_SOURCE,
+        paint: { "fill-color": "rgba(59, 130, 246, 0.15)" },
+      });
+    }
+    if (!mlMap.getLayer(BOX_SELECT_LINE)) {
+      mlMap.addLayer({
+        id: BOX_SELECT_LINE,
+        type: "line",
+        source: BOX_SELECT_SOURCE,
+        paint: {
+          "line-color": "#3b82f6",
+          "line-width": 2,
+          "line-dasharray": [4, 4],
+        },
+      });
+    }
+  }
+
+  function removePreviewLayers() {
+    if (mlMap.getLayer(BOX_SELECT_LINE)) mlMap.removeLayer(BOX_SELECT_LINE);
+    if (mlMap.getLayer(BOX_SELECT_FILL)) mlMap.removeLayer(BOX_SELECT_FILL);
+    if (mlMap.getSource(BOX_SELECT_SOURCE)) mlMap.removeSource(BOX_SELECT_SOURCE);
+  }
+
+  function updatePreview(currentPx: [number, number]) {
+    if (!drag) return;
+    const source = mlMap.getSource(BOX_SELECT_SOURCE) as GeoJSONSource | undefined;
+    if (!source) return;
+    const a = mlMap.unproject(drag.startPx);
+    const b = mlMap.unproject(currentPx);
+    const minLng = Math.min(a.lng, b.lng);
+    const maxLng = Math.max(a.lng, b.lng);
+    const minLat = Math.min(a.lat, b.lat);
+    const maxLat = Math.max(a.lat, b.lat);
+    source.setData(bboxPolygon([minLng, minLat, maxLng, maxLat]));
+  }
+
+  function onMove(e: MouseEvent) {
+    if (!drag) return;
+    updatePreview(getPixel(e));
+  }
+
+  function onUp(e: MouseEvent) {
+    if (!drag) return;
+    const startPx = drag.startPx;
+    const endPx = getPixel(e);
+    const minX = Math.min(startPx[0], endPx[0]);
+    const minY = Math.min(startPx[1], endPx[1]);
+    const maxX = Math.max(startPx[0], endPx[0]);
+    const maxY = Math.max(startPx[1], endPx[1]);
+
+    // Treat a zero-area box as a no-op (ends up as a plain click).
+    if (maxX - minX < 1 && maxY - minY < 1) {
+      finish();
+      return;
+    }
+
+    const features = mlMap.queryRenderedFeatures(
+      [
+        [minX, minY],
+        [maxX, maxY],
+      ],
+      { layers: options.getUnitLayerIds() },
+    );
+    const unitIds = new Set<EntityId>();
+    for (const f of features) {
+      const id = f.properties?.id;
+      if (typeof id === "string" && id) unitIds.add(id);
+    }
+    options.onBoxEnd([...unitIds]);
+    finish();
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === "Escape") cancel();
+  }
+
+  function detachWindowListeners() {
+    window.removeEventListener("mousemove", onMove, true);
+    window.removeEventListener("mouseup", onUp, true);
+    window.removeEventListener("keydown", onKey, true);
+  }
+
+  function teardown() {
+    if (!drag) return;
+    const suspended = drag.suspended;
+    drag = null;
+    detachWindowListeners();
+    removePreviewLayers();
+    options.restore(suspended);
+    mlMap.getCanvas().style.cursor = "";
+  }
+
+  function finish() {
+    teardown();
+  }
+
+  function cancel() {
+    teardown();
+  }
+
+  function onDown(e: MouseEvent) {
+    if (drag) return;
+    if (e.button !== 0) return;
+    if (!(e.ctrlKey || e.metaKey)) return;
+    if (!options.isEnabled()) return;
+
+    e.preventDefault();
+    e.stopPropagation();
+
+    options.onBoxStart();
+    drag = {
+      startPx: getPixel(e),
+      suspended: options.suspend(),
+    };
+    addPreviewLayers();
+    updatePreview(drag.startPx);
+    mlMap.getCanvas().style.cursor = "crosshair";
+
+    window.addEventListener("mousemove", onMove, true);
+    window.addEventListener("mouseup", onUp, true);
+    window.addEventListener("keydown", onKey, true);
+  }
+
+  container.addEventListener("mousedown", onDown, { capture: true });
+
+  return {
+    cleanup() {
+      container.removeEventListener("mousedown", onDown, { capture: true });
+      if (drag) teardown();
+    },
+  };
+}

--- a/src/modules/maplibreview/MlMapLogic.vue
+++ b/src/modules/maplibreview/MlMapLogic.vue
@@ -42,6 +42,7 @@ import { storeToRefs } from "pinia";
 import { useUnitSettingsStore } from "@/stores/geoStore";
 import { useRecordingStore } from "@/stores/recordingStore";
 import { useMaplibreRotateInteraction } from "@/modules/maplibreview/useMaplibreRotateInteraction";
+import { useMaplibreBoxSelect } from "@/composables/useMaplibreBoxSelect";
 import {
   useMapSettingsStore,
   type MapLibreUnitRotationMode,
@@ -95,6 +96,14 @@ const { mapLibreUnitRotationMode } = storeToRefs(mapSettings);
 const rotateInteraction = useMaplibreRotateInteraction(mlMap, activeScenario, {
   onPreview: (overrides) => addUnits(false, undefined, overrides),
   onPreviewEnd: () => addUnits(),
+});
+const boxSelect = useMaplibreBoxSelect(mlMap, {
+  getUnitLayerIds: () => [...unitLayerIds],
+  onBoxStart: () => clearSelectedItems(),
+  onBoxEnd: (ids) => ids.forEach((id) => selectedUnitIds.value.add(id)),
+  isEnabled: () => !moveUnitEnabled.value && !rotateUnitEnabled.value,
+  suspend: suspendMapDragInteractions,
+  restore: restoreMapDragInteractions,
 });
 const doNotFilterLayers = computed(() => uiStore.layersPanelActive);
 const recordingStore = useRecordingStore();
@@ -649,6 +658,7 @@ function addUnits(
 
 onUnmounted(() => {
   if (!mlMap) return;
+  boxSelect.cleanup();
   disposeUnitHistory();
   mlMap.off("styleimagemissing", styleImageMissing);
   mlMap.off("style.load", onStyleLoad);


### PR DESCRIPTION
## Summary

- Ctrl/Cmd + drag on the MapLibre canvas draws a dashed selection rectangle and adds every enclosed unit to the current selection, mirroring the existing OpenLayers `DragBox` behavior.
- Extracted into a new composable `useMaplibreBoxSelect` (`src/composables/useMaplibreBoxSelect.ts`) wired up from `MlMapLogic.vue`.
- Disabled while move-unit or rotate-unit modes are active. Escape cancels an in-progress drag. Shift+drag box-zoom and normal click / shift+click selection are unaffected.