### PR TITLE
Refactor details panel headers across scenario editor components

### DIFF
--- a/src/modules/scenarioeditor/DetailsPanelHeader.vue
+++ b/src/modules/scenarioeditor/DetailsPanelHeader.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import ItemMedia from "@/modules/scenarioeditor/ItemMedia.vue";
+import type { Media } from "@/types/scenarioModels";
+
+defineProps<{
+  media?: Media | null;
+  leadingAlign?: "start" | "center";
+  density?: "normal" | "compact";
+}>();
+</script>
+
+<template>
+  <header class="mb-3 flex flex-col gap-2">
+    <slot v-if="$slots.media" name="media" />
+    <ItemMedia v-else-if="media" :media="media" />
+    <div class="flex min-w-0 items-start justify-between gap-2">
+      <div
+        v-if="$slots.leading"
+        :class="[
+          'flex shrink-0 items-center',
+          leadingAlign === 'center' ? 'self-center' : 'mt-0.5',
+        ]"
+      >
+        <slot name="leading" />
+      </div>
+      <div :class="['min-w-0 flex-1', density === 'compact' ? '-mt-1.5 space-y-0' : '']">
+        <div class="min-w-0">
+          <slot name="title" />
+        </div>
+        <div
+          v-if="$slots.subtitle"
+          :class="[
+            'text-muted-foreground text-xs',
+            density === 'compact' ? '-mt-4 leading-5' : 'leading-5',
+          ]"
+        >
+          <slot name="subtitle" />
+        </div>
+        <div v-if="$slots.meta" class="text-muted-foreground text-sm leading-6">
+          <slot name="meta" />
+        </div>
+      </div>
+      <div v-if="$slots.trailing" class="flex shrink-0 items-center justify-end gap-1">
+        <slot name="trailing" />
+      </div>
+    </div>
+    <div v-if="$slots.summary" class="min-w-0">
+      <slot name="summary" />
+    </div>
+    <nav v-if="$slots.actions" class="flex min-w-0 items-center gap-2">
+      <slot name="actions" />
+    </nav>
+  </header>
+</template>

--- a/src/modules/scenarioeditor/MapEditorRouteContent.vue
+++ b/src/modules/scenarioeditor/MapEditorRouteContent.vue
@@ -31,6 +31,8 @@ import { useSelectedItems } from "@/stores/selectedStore";
 import { convertSpeedToMetric } from "@/utils/convert";
 import type { NUnit } from "@/types/internalModels";
 import type { SpeedUnitOfMeasure, UnitProperty } from "@/types/scenarioModels";
+import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue";
+import PanelTitle from "@/modules/scenarioeditor/PanelTitle.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -232,12 +234,14 @@ const showObstacleWarning = computed(
 
 <template>
   <div class="flex flex-col gap-3">
-    <div class="flex items-center justify-between gap-2">
-      <div class="flex items-center gap-2">
+    <DetailsPanelHeader leading-align="center">
+      <template #leading>
         <RouteIcon class="text-muted-foreground size-5" />
-        <p class="text-sm font-medium">Route</p>
-      </div>
-      <div class="flex min-w-14 items-center justify-end gap-2">
+      </template>
+      <template #title>
+        <PanelTitle>Route</PanelTitle>
+      </template>
+      <template #trailing>
         <span class="flex size-5 items-center justify-center">
           <Spinner v-if="routingStore.isBusy" class="text-muted-foreground size-4" />
           <TriangleAlertIcon
@@ -254,8 +258,8 @@ const showObstacleWarning = computed(
         >
           <CloseIcon class="size-5" />
         </MainToolbarButton>
-      </div>
-    </div>
+      </template>
+    </DetailsPanelHeader>
 
     <Tabs
       :model-value="routingStore.outcome ?? undefined"

--- a/src/modules/scenarioeditor/PanelTitle.vue
+++ b/src/modules/scenarioeditor/PanelTitle.vue
@@ -1,0 +1,5 @@
+<template>
+  <h2 class="text-foreground text-base leading-6 font-medium">
+    <slot />
+  </h2>
+</template>

--- a/src/modules/scenarioeditor/ScenarioEventDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioEventDetails.vue
@@ -9,7 +9,6 @@ import ScenarioEventDropdownMenu from "@/modules/scenarioeditor/ScenarioEventDro
 import { useTimeFormatStore } from "@/stores/timeFormatStore";
 import type { ScenarioEventAction } from "@/types/constants";
 import { useSelectedItems } from "@/stores/selectedStore";
-import ItemMedia from "@/modules/scenarioeditor/ItemMedia.vue";
 import ScrollTabs from "@/components/ScrollTabs.vue";
 import { TabsContent } from "@/components/ui/tabs";
 import EditMetaForm from "@/modules/scenarioeditor/EditMetaForm.vue";
@@ -18,6 +17,7 @@ import { useToggle } from "@vueuse/core";
 import type { MediaUpdate, ScenarioEventUpdate } from "@/types/internalModels";
 import DescriptionItem from "@/components/DescriptionItem.vue";
 import { renderMarkdown } from "@/composables/formatting";
+import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue";
 
 interface Props {
   eventId: EntityId;
@@ -123,14 +123,17 @@ const onFormSubmit = (eventUpdate: ScenarioEventUpdate) => {
 </script>
 <template>
   <div v-if="scenarioEvent" :key="scenarioEvent.id" class="p-1">
-    <ItemMedia v-if="media" :media="media" />
-    <header class="">
-      <EditableLabel v-model="title" @updateValue="updateTitle" />
-      <nav class="flex items-center justify-between">
-        <div class="text-sm font-medium">{{ formattedEventTime }}</div>
+    <DetailsPanelHeader :media="media">
+      <template #title>
+        <EditableLabel v-model="title" @updateValue="updateTitle" />
+      </template>
+      <template #meta>
+        {{ formattedEventTime }}
+      </template>
+      <template #trailing>
         <ScenarioEventDropdownMenu @action="onAction" />
-      </nav>
-    </header>
+      </template>
+    </DetailsPanelHeader>
     <div class="-mx-4">
       <ScrollTabs :items="tabList" v-model="selectedTab">
         <TabsContent value="0" class="mx-4 pt-4">

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
@@ -31,7 +31,6 @@ import EditMetaForm from "@/modules/scenarioeditor/EditMetaForm.vue";
 import EditMediaForm from "@/modules/scenarioeditor/EditMediaForm.vue";
 import type { GeometryLayerItemUpdate, MediaUpdate } from "@/types/internalModels";
 import type { UpdateOptions } from "@/scenariostore/geo";
-import ItemMedia from "@/modules/scenarioeditor/ItemMedia.vue";
 import { inputEventFilter } from "@/components/helpers";
 import ScenarioFeatureDropdownMenu from "@/modules/scenarioeditor/ScenarioFeatureDropdownMenu.vue";
 import type { ScenarioFeatureActions } from "@/types/constants";
@@ -45,6 +44,8 @@ import ScenarioFeaturesGeometryStats from "@/modules/scenarioeditor/ScenarioFeat
 import PanelDataGrid from "@/components/PanelDataGrid.vue";
 import { Button } from "@/components/ui/button";
 import type { NGeometryLayerItem } from "@/types/internalModels";
+import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue";
+import PanelTitle from "@/modules/scenarioeditor/PanelTitle.vue";
 
 interface Props {
   selectedIds: SelectedScenarioFeatures;
@@ -286,42 +287,43 @@ function onAction(action: ScenarioFeatureActions) {
 </script>
 <template>
   <div>
-    <ItemMedia v-if="media" :media="media" />
-    <header class="">
-      <div v-if="isMultiMode" class="mt-6 mb-2 flex items-center justify-between">
-        <p class="font-medium">{{ selectedFeatureIds.size }} features selected</p>
-        <Button variant="outline" type="button" size="sm" @click="clearSelection()">
+    <DetailsPanelHeader :media="media" leading-align="center">
+      <template v-if="feature" #leading>
+        <component :is="getGeometryIcon(feature)" class="text-muted-foreground size-6" />
+      </template>
+      <template #title>
+        <EditableLabel v-if="feature" v-model="featureName" @update-value="updateValue" />
+        <PanelTitle v-else-if="isMultiMode">
+          {{ selectedFeatureIds.size }} features selected
+        </PanelTitle>
+      </template>
+      <template #trailing>
+        <Button
+          v-if="isMultiMode"
+          variant="outline"
+          type="button"
+          size="sm"
+          @click="clearSelection()"
+        >
           Clear
         </Button>
-      </div>
-      <div v-if="feature" class="">
-        <EditableLabel v-model="featureName" @update-value="updateValue" />
-      </div>
-
-      <nav class="flex items-center justify-between">
-        <div class="flex items-center">
-          <component
-            :is="getGeometryIcon(feature!)"
-            class="text-muted-foreground mr-2 size-6"
-          />
-          <IconButton @click="doZoom()" title="Zoom to feature">
-            <ZoomIcon class="size-5" />
-          </IconButton>
-          <IconButton @click="showStylePanel()" title="Change feature style">
-            <StyleIcon class="size-5" />
-          </IconButton>
-          <IconButton title="Edit feature data" @click="toggleEditMode()">
-            <EditIcon class="size-5" />
-          </IconButton>
-          <IconButton title="Add/modify image" @click="toggleEditMediaMode()">
-            <ImageIcon class="size-5" />
-          </IconButton>
-        </div>
-        <div>
-          <ScenarioFeatureDropdownMenu @action="onAction" />
-        </div>
-      </nav>
-    </header>
+        <ScenarioFeatureDropdownMenu @action="onAction" />
+      </template>
+      <template #actions>
+        <IconButton @click="doZoom()" title="Zoom to feature">
+          <ZoomIcon class="size-5" />
+        </IconButton>
+        <IconButton @click="showStylePanel()" title="Change feature style">
+          <StyleIcon class="size-5" />
+        </IconButton>
+        <IconButton title="Edit feature data" @click="toggleEditMode()">
+          <EditIcon class="size-5" />
+        </IconButton>
+        <IconButton title="Add/modify image" @click="toggleEditMediaMode()">
+          <ImageIcon class="size-5" />
+        </IconButton>
+      </template>
+    </DetailsPanelHeader>
     <div class="-mx-4">
       <ScrollTabs :items="tabList" v-model="selectedTabString">
         <TabsContent value="0" class="mx-4">

--- a/src/modules/scenarioeditor/ScenarioInfoPanel.vue
+++ b/src/modules/scenarioeditor/ScenarioInfoPanel.vue
@@ -8,6 +8,7 @@ import ScenarioInfoDetails from "@/modules/scenarioeditor/ScenarioInfoDetails.vu
 import ScrollTabs from "@/components/ScrollTabs.vue";
 import { TabsContent } from "@/components/ui/tabs";
 import { useScenarioInfoPanelStore } from "@/stores/scenarioInfoPanelStore";
+import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue";
 
 const { store } = injectStrict(activeScenarioKey);
 const { state } = store;
@@ -39,13 +40,15 @@ function updateScenarioInfo(data: Partial<ScenarioInfo>) {
 </script>
 
 <template>
-  <div class="">
-    <header class="pr-4">
-      <EditableLabel
-        v-model="scenarioName"
-        @update-value="updateScenarioInfo({ name: $event })"
-      />
-    </header>
+  <div>
+    <DetailsPanelHeader>
+      <template #title>
+        <EditableLabel
+          v-model="scenarioName"
+          @update-value="updateScenarioInfo({ name: $event })"
+        />
+      </template>
+    </DetailsPanelHeader>
     <div class="-mx-4">
       <ScrollTabs :items="tabList" v-model="selectedTabString">
         <TabsContent value="0" class="mx-4 pt-4"

--- a/src/modules/scenarioeditor/ScenarioMapLayerDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioMapLayerDetails.vue
@@ -24,6 +24,7 @@ import { type LayerUpdateOptions } from "@/composables/geoMapLayers";
 import { useUiStore } from "@/stores/uiStore";
 import MapLayerMetaSettings from "@/modules/scenarioeditor/MapLayerMetaSettings.vue";
 import ScrollTabs from "@/components/ScrollTabs.vue";
+import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue";
 
 interface Props {
   layerId: FeatureId;
@@ -125,40 +126,44 @@ function toggleLayerVisibility() {
 </script>
 <template>
   <div v-if="mapLayer">
-    <header>
-      <EditableLabel v-model="layerName" @update-value="updateValue('name', $event)" />
-      <div class="flex">
-        <div class="flex flex-auto items-center">
-          <component
-            :is="getMapLayerIcon(mapLayer)"
-            class="text-muted-foreground mr-2 h-7 w-7"
-          />
-          <input
-            v-model.number="opacity"
-            type="range"
-            min="0"
-            max="1"
-            step="0.01"
-            class="transparent h-1 w-full cursor-pointer appearance-none rounded-lg border-transparent bg-red-800"
-          />
-          <span class="ml-2 w-8 shrink-0 text-sm">{{ opacityAsPercent }}%</span>
-        </div>
-        <div class="ml-2 flex shrink-0 items-center">
-          <IconButton
-            v-if="canZoomMapLayer"
-            @click="engineRef?.layers.zoomToMapLayer(layerId)"
-            title="Zoom to layer extent"
-          >
-            <ZoomIcon class="h-6 w-6" />
-          </IconButton>
-          <IconButton @click="toggleLayerVisibility()" title="Toggle visibility">
-            <IconEye v-if="isVisible" class="h-6 w-6" />
-            <IconEyeOff v-else class="h-6 w-6" />
-          </IconButton>
-          <DotsMenu :items="imageLayerMenuItems" @action="onImageLayerAction" />
-        </div>
-      </div>
-    </header>
+    <DetailsPanelHeader leading-align="center">
+      <template #leading>
+        <component
+          :is="getMapLayerIcon(mapLayer)"
+          class="text-muted-foreground h-7 w-7"
+        />
+      </template>
+      <template #title>
+        <EditableLabel v-model="layerName" @update-value="updateValue('name', $event)" />
+      </template>
+      <template #trailing>
+        <DotsMenu :items="imageLayerMenuItems" @action="onImageLayerAction" />
+      </template>
+      <template #actions>
+        <IconButton
+          v-if="canZoomMapLayer"
+          @click="engineRef?.layers.zoomToMapLayer(layerId)"
+          title="Zoom to layer extent"
+        >
+          <ZoomIcon class="size-5" />
+        </IconButton>
+        <IconButton @click="toggleLayerVisibility()" title="Toggle visibility">
+          <IconEye v-if="isVisible" class="size-5" />
+          <IconEyeOff v-else class="size-5" />
+        </IconButton>
+        <input
+          v-model.number="opacity"
+          type="range"
+          min="0"
+          max="1"
+          step="0.01"
+          class="transparent h-1 min-w-0 flex-1 cursor-pointer appearance-none rounded-lg border-transparent bg-red-800"
+        />
+        <span class="text-muted-foreground w-8 shrink-0 text-right text-sm">
+          {{ opacityAsPercent }}%
+        </span>
+      </template>
+    </DetailsPanelHeader>
     <div class="-mx-4">
       <ScrollTabs :items="tabList" v-model="selectedTabString">
         <TabsContent value="0" class="mx-4 pt-4"

--- a/src/modules/scenarioeditor/UnitDetails.vue
+++ b/src/modules/scenarioeditor/UnitDetails.vue
@@ -47,7 +47,6 @@ import DotsMenu from "@/components/DotsMenu.vue";
 import { type MenuItemData } from "@/components/types";
 import EditMediaForm from "@/modules/scenarioeditor/EditMediaForm.vue";
 import EditMetaForm from "@/modules/scenarioeditor/EditMetaForm.vue";
-import ItemMedia from "@/modules/scenarioeditor/ItemMedia.vue";
 import UnitDetailsProperties from "@/modules/scenarioeditor/UnitDetailsProperties.vue";
 import UnitDetailsSymbol from "@/modules/scenarioeditor/UnitDetailsSymbol.vue";
 import { Button } from "@/components/ui/button";
@@ -57,6 +56,8 @@ import UnitSymbol from "@/components/UnitSymbol.vue";
 import { CUSTOM_SYMBOL_PREFIX } from "@/config/constants.ts";
 import { Badge } from "@/components/ui/badge";
 import { useRecordingStore } from "@/stores/recordingStore";
+import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue";
+import PanelTitle from "@/modules/scenarioeditor/PanelTitle.vue";
 
 const FeatureTransformations = defineAsyncComponent(
   () => import("@/modules/scenarioeditor/FeatureTransformations.vue"),
@@ -404,12 +405,11 @@ function locateInOrbat() {
 </script>
 <template>
   <div v-if="unit" class="@container" :key="unit.id">
-    <ItemMedia v-if="media" :media="media" />
-    <header class="-mx-4 px-2 pt-2">
-      <div v-if="!isMultiMode" class="flex">
+    <DetailsPanelHeader :media="media" density="compact">
+      <template v-if="!isMultiMode" #leading>
         <button
           type="button"
-          class="mr-2 inline-flex w-16 justify-start"
+          class="inline-flex w-16 justify-start"
           @click="handleChangeSymbol()"
           ref="elRef"
         >
@@ -420,34 +420,41 @@ function locateInOrbat() {
             :options="combinedSymbolOptions"
           />
         </button>
-        <div class="-mt-1.5 flex-auto pr-4">
-          <EditableLabel
-            v-model="unitName"
-            @update-value="updateUnit(unitId, { name: $event })"
-            class="relative z-10 bg-transparent"
-            :disabled="isLocked"
-          />
-          <EditableLabel
-            class="relative -top-4"
-            v-model="shortName"
-            @update-value="updateUnit(unitId, { shortName: $event })"
-            text-class="text-sm text-muted-foreground"
-            :disabled="isLocked"
-          />
-        </div>
+      </template>
+      <template v-if="!isMultiMode" #title>
+        <EditableLabel
+          v-model="unitName"
+          @update-value="updateUnit(unitId, { name: $event })"
+          class="relative z-10 bg-transparent"
+          :disabled="isLocked"
+        />
+      </template>
+      <template v-else #title>
+        <PanelTitle> {{ selectedUnitIds.size }} units selected </PanelTitle>
+      </template>
+      <template v-if="!isMultiMode" #subtitle>
+        <EditableLabel
+          v-model="shortName"
+          @update-value="updateUnit(unitId, { shortName: $event })"
+          text-class="text-sm text-muted-foreground"
+          :disabled="isLocked"
+        />
+      </template>
+      <template #trailing>
         <IconLockOutline v-if="isLocked" class="text-muted-foreground size-5" />
-        <div v-if="unitStatus">
-          <Badge>{{ unitStatus }}</Badge>
-        </div>
-      </div>
-      <div v-else>
-        <div class="flex items-center justify-between">
-          <p class="font-medium">{{ selectedUnitIds.size }} units selected</p>
-          <Button type="button" size="sm" variant="outline" @click="clearSelection()"
-            >Clear
-          </Button>
-        </div>
-        <ul class="relative my-4 flex w-full flex-wrap gap-1 pb-4">
+        <Badge v-if="unitStatus">{{ unitStatus }}</Badge>
+        <Button
+          v-if="isMultiMode"
+          type="button"
+          size="sm"
+          variant="outline"
+          @click="clearSelection()"
+        >
+          Clear
+        </Button>
+      </template>
+      <template v-if="isMultiMode" #summary>
+        <ul class="relative mt-2 flex w-full flex-wrap gap-1 pb-4">
           <li v-for="sUnit in visibleSelectedUnits" class="relative flex">
             <UnitSymbol
               :sidc="sUnit.sidc"
@@ -467,9 +474,9 @@ function locateInOrbat() {
             </button>
           </li>
         </ul>
-      </div>
-      <nav class="-mt-2 mb-4 flex items-center justify-between">
-        <div class="flex items-center gap-0.5">
+      </template>
+      <template #actions>
+        <div class="flex min-w-0 flex-1 items-center gap-0.5">
           <IconButton title="Zoom to" @click="actionWrapper(UnitActions.Zoom)">
             <ZoomIcon class="size-5" />
           </IconButton>
@@ -513,11 +520,9 @@ function locateInOrbat() {
             v-model:active-item="uiStore.activeItem"
           />
         </div>
-        <div>
-          <DotsMenu :items="unitMenuItems" />
-        </div>
-      </nav>
-    </header>
+        <DotsMenu :items="unitMenuItems" />
+      </template>
+    </DetailsPanelHeader>
     <div class="-mx-4">
       <ScrollTabs :items="tabList" v-model="selectedTabString" class="">
         <TabsContent value="0" class="mx-4 pt-4">


### PR DESCRIPTION
- Replace ad-hoc header structures with the `DetailsPanelHeader` and `PanelTitle` components for consistent styling and layout.
- Update `MapEditorRouteContent`, `ScenarioFeatureDetails`, `ScenarioInfoPanel`, `ScenarioMapLayerDetails`, `ScenarioEventDetails`, and `UnitDetails` to use the new components.
- Remove redundant `ItemMedia` imports.
