### PR TITLE
Add GPX import support

### DIFF
--- a/src/components/ImportGeojsonStep.test.ts
+++ b/src/components/ImportGeojsonStep.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { defineComponent, nextTick } from "vue";
+import ImportGeojsonStep from "@/components/ImportGeojsonStep.vue";
+import { activeScenarioKey } from "@/components/injects";
+
+const InputRadioStub = defineComponent({
+  name: "InputRadio",
+  props: ["modelValue", "value"],
+  emits: ["update:modelValue"],
+  template:
+    "<button type='button' :data-value='value' @click='$emit(\"update:modelValue\", value)'><slot /></button>",
+});
+
+const DataGridStub = defineComponent({
+  name: "DataGrid",
+  props: ["data", "columns", "selected"],
+  emits: ["update:selected"],
+  template: "<div data-testid='data-grid' />",
+});
+
+const UnitTreeSelectStub = defineComponent({
+  name: "UnitTreeSelect",
+  props: ["modelValue", "units"],
+  emits: ["update:modelValue"],
+  template:
+    "<button type='button' data-testid='unit-tree-select' @click='$emit(\"update:modelValue\", \"group-unit\")'>{{ units.join(',') }}</button>",
+});
+
+function mountImportGeojsonStep() {
+  const addFeature = vi.fn();
+  const addUnitStateEntry = vi.fn();
+  const setCurrentTime = vi.fn();
+  const lineFeature = {
+    type: "Feature" as const,
+    properties: {
+      name: "Route",
+      coordinateProperties: {
+        times: ["2026-04-28T10:00:00Z", "2026-04-28T10:05:00Z"],
+      },
+    },
+    geometry: {
+      type: "LineString" as const,
+      coordinates: [
+        [10, 60],
+        [11, 61],
+      ],
+    },
+  };
+  const pointFeature = {
+    type: "Feature" as const,
+    properties: { name: "Point" },
+    geometry: {
+      type: "Point" as const,
+      coordinates: [10, 60],
+    },
+  };
+
+  const wrapper = mount(ImportGeojsonStep, {
+    props: {
+      data: {
+        type: "FeatureCollection",
+        features: [lineFeature, pointFeature],
+      },
+    },
+    global: {
+      provide: {
+        [activeScenarioKey as symbol]: {
+          unitActions: {
+            addUnitStateEntry,
+            addUnit: vi.fn(),
+            getCombinedSymbolOptions: vi.fn(() => ({})),
+            getUnitHierarchy: vi.fn(() => ({
+              side: { standardIdentity: "3" },
+            })),
+          },
+          store: {
+            state: {
+              currentTime: Date.parse("2026-04-28T10:00:00Z"),
+              unitMap: {
+                "unit-1": {
+                  id: "unit-1",
+                  name: "Alpha",
+                  sidc: "10031000000000000000",
+                  subUnits: ["unit-child"],
+                },
+                "unit-child": {
+                  id: "unit-child",
+                  name: "Alpha Child",
+                  sidc: "10031000000000000000",
+                  subUnits: [],
+                },
+                "group-unit": {
+                  id: "group-unit",
+                  name: "Group Unit",
+                  sidc: "10031000000000000000",
+                  subUnits: [],
+                },
+              },
+              sideMap: {
+                "side-1": {
+                  id: "side-1",
+                  name: "Blue",
+                  subUnits: ["unit-1"],
+                },
+              },
+              sideGroupMap: {
+                "group-1": {
+                  id: "group-1",
+                  name: "Group",
+                  _pid: "side-1",
+                  subUnits: ["group-unit"],
+                },
+              },
+            },
+            groupUpdate: (callback: () => void) => callback(),
+          },
+          geo: {
+            addFeature,
+            layerItemsLayers: {
+              value: [{ id: "layer-1", name: "Layer 1" }],
+            },
+          },
+          time: {
+            setCurrentTime,
+          },
+        },
+      },
+      stubs: {
+        ImportStepLayout: {
+          template: "<div><slot name='actions' /><slot name='sidebar' /><slot /></div>",
+        },
+        BaseButton: { template: "<button><slot /></button>" },
+        SimpleSelect: true,
+        SymbolCodeSelect: true,
+        UnitTreeSelect: UnitTreeSelectStub,
+        MRadioGroup: { template: "<div><slot /></div>" },
+        InputRadio: InputRadioStub,
+        DataGrid: DataGridStub,
+        AlertWarning: true,
+      },
+    },
+  });
+
+  return { wrapper, addFeature, addUnitStateEntry, setCurrentTime, lineFeature };
+}
+
+describe("ImportGeojsonStep", () => {
+  it("shows only line features in track assignment mode", async () => {
+    const { wrapper, lineFeature } = mountImportGeojsonStep();
+
+    await wrapper.get('[data-value="unit-tracks"]').trigger("click");
+
+    const dataGrid = wrapper.findComponent(DataGridStub);
+    expect(dataGrid.props("data")).toEqual([lineFeature]);
+  });
+
+  it("keeps selected line features and assigns their positions to the selected unit", async () => {
+    const { wrapper, addFeature, addUnitStateEntry, setCurrentTime, lineFeature } =
+      mountImportGeojsonStep();
+
+    await wrapper.get('[data-value="unit-tracks"]').trigger("click");
+    wrapper.findComponent(DataGridStub).vm.$emit("update:selected", [lineFeature]);
+    await nextTick();
+    await wrapper.get('[data-testid="unit-tree-select"]').trigger("click");
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Import")!
+      .trigger("click");
+
+    expect(addFeature).toHaveBeenCalledTimes(1);
+    expect(addUnitStateEntry).toHaveBeenCalledTimes(2);
+    expect(addUnitStateEntry).toHaveBeenNthCalledWith(
+      1,
+      "group-unit",
+      { t: Date.parse("2026-04-28T10:00:00Z"), location: [10, 60] },
+      true,
+    );
+    expect(addUnitStateEntry).toHaveBeenNthCalledWith(
+      2,
+      "group-unit",
+      { t: Date.parse("2026-04-28T10:05:00Z"), location: [11, 61] },
+      true,
+    );
+    expect(setCurrentTime).toHaveBeenCalledWith(Date.parse("2026-04-28T10:00:00Z"));
+  });
+});

--- a/src/components/ImportGeojsonStep.vue
+++ b/src/components/ImportGeojsonStep.vue
@@ -148,7 +148,7 @@ function findLikelySymbolColumn(columnNames: string[]) {
 const activeLayer = ref(existingLayers.value[0].value);
 const nameColumn = ref(findLikelyNameColumn([...propertyNames.value]));
 const symbolColumn = ref(findLikelySymbolColumn([...propertyNames.value]));
-const parentUnitId = ref(rootUnitItems.value[0]?.code as string);
+const parentUnitId = ref<string | undefined>(rootUnitItems.value[0]?.code as string | undefined);
 const { send } = useNotifications();
 
 async function onLoad() {
@@ -163,6 +163,7 @@ async function onLoad() {
 }
 
 function loadAsUnits() {
+  if (!parentUnitId.value) return;
   const { side } = unitActions.getUnitHierarchy(parentUnitId.value);
 
   const units: NUnit[] = selectedFeatures.value.map((f) => {
@@ -186,8 +187,9 @@ function loadAsUnits() {
       personnel: [],
     };
   });
+  const targetParentId = parentUnitId.value;
   scnStore.groupUpdate(() => {
-    units.forEach((unit) => unitActions.addUnit(unit, parentUnitId.value));
+    units.forEach((unit) => unitActions.addUnit(unit, targetParentId));
   });
 }
 

--- a/src/components/ImportGeojsonStep.vue
+++ b/src/components/ImportGeojsonStep.vue
@@ -5,6 +5,7 @@ import { activeScenarioKey } from "@/components/injects";
 import type { NUnit } from "@/types/internalModels";
 import type { Feature as GeoJSONFeature, FeatureCollection, Point } from "geojson";
 import SymbolCodeSelect from "@/components/SymbolCodeSelect.vue";
+import UnitTreeSelect from "@/components/UnitTreeSelect.vue";
 import { setCharAt } from "@/components/helpers";
 import { SID_INDEX } from "@/symbology/sidc";
 import { type SelectItem } from "@/components/types";
@@ -15,7 +16,7 @@ import DataGrid from "@/modules/grid/DataGrid.vue";
 import type { ColumnDef } from "@tanstack/vue-table";
 import MilitarySymbol from "@/components/MilitarySymbol.vue";
 import AlertWarning from "@/components/AlertWarning.vue";
-import { useRootUnits } from "@/composables/scenarioUtils.ts";
+import { useRootUnitIds, useRootUnits } from "@/composables/scenarioUtils.ts";
 import ImportStepLayout from "@/components/ImportStepLayout.vue";
 import BaseButton from "@/components/BaseButton.vue";
 import {
@@ -25,6 +26,11 @@ import {
   getGeoJSONPropertyNames,
   normalizeImportedName,
 } from "@/importexport/geojsonScenarioFeatures";
+import {
+  createUnitTrackStatesFromFeature,
+  isAssignableTrackFeature,
+} from "@/importexport/unitTrackAssignment";
+import { useNotifications } from "@/composables/notifications";
 
 interface Props {
   data: GeoJSONFeature | FeatureCollection;
@@ -33,14 +39,16 @@ interface Props {
 const props = defineProps<Props>();
 const emit = defineEmits(["cancel", "loaded"]);
 
-const { unitActions, store: scnStore, geo } = injectStrict(activeScenarioKey);
+const { unitActions, store: scnStore, geo, time } = injectStrict(activeScenarioKey);
 
-type GeoJsonImportMode = "units" | "features";
+type GeoJsonImportMode = "units" | "features" | "unit-tracks";
 
 const importMode = ref<GeoJsonImportMode>("features");
 const isFeatureMode = computed(() => importMode.value === "features");
+const isTrackAssignmentMode = computed(() => importMode.value === "unit-tracks");
 
 const selectedFeatures = ref<GeoJSONFeature[]>([]);
+const trackAssignmentUnitIds = ref<Record<string, string>>({});
 
 const propertyNames = computed(() => new Set(getGeoJSONPropertyNames(props.data)));
 
@@ -94,6 +102,7 @@ const computedColumns = computed((): (ColumnDef<GeoJSONFeature, unknown> | false
 });
 
 const { rootUnitItems, groupedRootUnitItems } = useRootUnits();
+const { rootUnitIds } = useRootUnitIds();
 
 const geoJSONFeatures = computed((): GeoJSONFeature[] => {
   // This is a hack to force the computed to re-run when we change column assignments
@@ -105,6 +114,10 @@ const geoJSONFeatures = computed((): GeoJSONFeature[] => {
 
 const geoJSONPointFeatures = computed(() => {
   return geoJSONFeatures.value.filter((f) => f.geometry?.type === "Point");
+});
+
+const geoJSONTrackFeatures = computed(() => {
+  return geoJSONFeatures.value.filter(isAssignableTrackFeature);
 });
 
 const existingLayers = computed((): SelectItem[] => {
@@ -135,11 +148,14 @@ function findLikelySymbolColumn(columnNames: string[]) {
 const activeLayer = ref(existingLayers.value[0].value);
 const nameColumn = ref(findLikelyNameColumn([...propertyNames.value]));
 const symbolColumn = ref(findLikelySymbolColumn([...propertyNames.value]));
-const parentUnitId = ref(rootUnitItems.value[0].code as string);
+const parentUnitId = ref(rootUnitItems.value[0]?.code as string);
+const { send } = useNotifications();
 
 async function onLoad() {
   if (importMode.value === "units") {
     loadAsUnits();
+  } else if (importMode.value === "unit-tracks") {
+    loadAsUnitTracks();
   } else {
     loadAsFeatures();
   }
@@ -176,17 +192,82 @@ function loadAsUnits() {
 }
 
 function loadAsFeatures() {
-  if (!activeLayer.value) return;
-  const features = selectedFeatures.value
+  const features = getSelectedScenarioFeatures();
+  scnStore.groupUpdate(() => {
+    features.forEach((feature) => geo.addFeature(feature, feature._pid));
+  });
+}
+
+function loadAsUnitTracks() {
+  const trackFeatures = selectedFeatures.value.filter(isAssignableTrackFeature);
+  if (!trackFeatures.length) return;
+
+  let stateCount = 0;
+  let skippedPointCount = 0;
+  scnStore.groupUpdate(() => {
+    getSelectedScenarioFeatures().forEach((feature) =>
+      geo.addFeature(feature, feature._pid),
+    );
+    trackFeatures.forEach((feature) => {
+      const unitId = getTrackAssignmentUnitId(feature);
+      if (!unitId) return;
+      const result = createUnitTrackStatesFromFeature(
+        feature,
+        scnStore.state.currentTime,
+      );
+      skippedPointCount += result.skippedPoints;
+      result.states.forEach((state) => {
+        unitActions.addUnitStateEntry(unitId, state, true);
+        stateCount++;
+      });
+    });
+  });
+
+  if (stateCount > 0) {
+    time.setCurrentTime(scnStore.state.currentTime);
+  }
+  const skippedMessage = skippedPointCount
+    ? ` ${skippedPointCount} route points were skipped.`
+    : "";
+  send({
+    message: `Assigned ${stateCount} track positions to unit.${skippedMessage}`,
+    type: stateCount ? "success" : "warning",
+  });
+}
+
+function getSelectedScenarioFeatures() {
+  if (!activeLayer.value) return [];
+  return selectedFeatures.value
     .map((feature) =>
       convertGeoJSONFeatureToScenarioFeature(feature, activeLayer.value, {
         nameColumn: resolvedNameColumn.value,
       }),
     )
     .filter((feature) => !!feature);
-  scnStore.groupUpdate(() => {
-    features.forEach((feature) => geo.addFeature(feature, feature._pid));
-  });
+}
+
+function getFeatureKey(feature: GeoJSONFeature): string {
+  const index = geoJSONFeatures.value.indexOf(feature);
+  if (index >= 0) return String(index);
+  return `${feature.geometry?.type ?? "feature"}-${selectedFeatures.value.indexOf(feature)}`;
+}
+
+function getTrackAssignmentUnitId(feature: GeoJSONFeature): string | undefined {
+  return (
+    trackAssignmentUnitIds.value[getFeatureKey(feature)] ?? rootUnitItems.value[0]?.code
+  );
+}
+
+function setTrackAssignmentUnitId(feature: GeoJSONFeature, unitId: string | null) {
+  if (!unitId) return;
+  trackAssignmentUnitIds.value[getFeatureKey(feature)] = unitId;
+}
+
+function getFeatureName(feature: GeoJSONFeature): string {
+  return normalizeImportedName(
+    resolvedNameColumn.value ? feature.properties?.[resolvedNameColumn.value] : undefined,
+    "Track/route",
+  );
 }
 </script>
 <template>
@@ -211,10 +292,13 @@ function loadAsFeatures() {
         <MRadioGroup class="flex flex-col gap-2">
           <InputRadio v-model="importMode" value="features">Scenario features</InputRadio>
           <InputRadio v-model="importMode" value="units">Units</InputRadio>
+          <InputRadio v-model="importMode" value="unit-tracks"
+            >Assign tracks/routes to unit</InputRadio
+          >
         </MRadioGroup>
       </fieldset>
 
-      <section class="space-y-4">
+      <section v-if="!isTrackAssignmentMode" class="space-y-4">
         <SimpleSelect
           label="Name column"
           :items="propertyNameItems"
@@ -230,18 +314,35 @@ function loadAsFeatures() {
 
       <section class="space-y-4">
         <SimpleSelect
-          v-if="isFeatureMode"
+          v-if="isFeatureMode || isTrackAssignmentMode"
           label="Layer"
           description="Which layer should the features be added to?"
           :items="existingLayers"
           v-model="activeLayer"
         />
-        <SymbolCodeSelect
-          v-else
-          label="Parent unit"
-          :items="rootUnitItems"
-          :groups="groupedRootUnitItems"
-          v-model="parentUnitId"
+        <template v-else>
+          <SymbolCodeSelect
+            label="Parent unit"
+            :items="rootUnitItems"
+            :groups="groupedRootUnitItems"
+            v-model="parentUnitId"
+          />
+        </template>
+      </section>
+
+      <section v-if="isTrackAssignmentMode" class="space-y-4">
+        <p class="text-foreground text-sm leading-6 font-semibold">Track assignments</p>
+        <p v-if="!selectedFeatures.length" class="text-muted-foreground text-sm">
+          Select tracks or routes to choose target units.
+        </p>
+        <UnitTreeSelect
+          v-for="feature in selectedFeatures.filter(isAssignableTrackFeature)"
+          :key="getFeatureKey(feature)"
+          :label="getFeatureName(feature)"
+          :units="rootUnitIds"
+          :unit-map="scnStore.state.unitMap"
+          :model-value="getTrackAssignmentUnitId(feature)"
+          @update:model-value="(unitId) => setTrackAssignmentUnitId(feature, unitId)"
         />
       </section>
     </template>
@@ -251,7 +352,13 @@ function loadAsFeatures() {
         Select which features you want to import
       </p>
       <DataGrid
-        :data="isFeatureMode ? geoJSONFeatures : geoJSONPointFeatures"
+        :data="
+          isTrackAssignmentMode
+            ? geoJSONTrackFeatures
+            : isFeatureMode
+              ? geoJSONFeatures
+              : geoJSONPointFeatures
+        "
         :columns="computedColumns"
         :row-height="40"
         select
@@ -261,11 +368,18 @@ function loadAsFeatures() {
         class="flex-1"
       />
       <AlertWarning
-        v-if="!isFeatureMode && geoJSONPointFeatures.length === 0"
+        v-if="importMode === 'units' && geoJSONPointFeatures.length === 0"
         title="No point geometries found"
         class="mt-4 shrink-0"
       >
         A unit must have a point geometry to be imported.
+      </AlertWarning>
+      <AlertWarning
+        v-if="isTrackAssignmentMode && geoJSONTrackFeatures.length === 0"
+        title="No line geometries found"
+        class="mt-4 shrink-0"
+      >
+        A unit track must have a LineString or MultiLineString geometry to be assigned.
       </AlertWarning>
     </div>
   </ImportStepLayout>

--- a/src/components/ImportGeojsonStep.vue
+++ b/src/components/ImportGeojsonStep.vue
@@ -211,9 +211,13 @@ function loadAsUnitTracks() {
     trackFeatures.forEach((feature) => {
       const unitId = getTrackAssignmentUnitId(feature);
       if (!unitId) return;
+      const unit = scnStore.state.unitMap[unitId];
       const result = createUnitTrackStatesFromFeature(
         feature,
         scnStore.state.currentTime,
+        {
+          addStartPosition: !unit?.location && !unit?._state?.location,
+        },
       );
       skippedPointCount += result.skippedPoints;
       result.states.forEach((state) => {

--- a/src/components/ImportLoadStep.vue
+++ b/src/components/ImportLoadStep.vue
@@ -15,6 +15,7 @@ import { useDropZone } from "@vueuse/core";
 import { useImportStore } from "@/stores/importExportStore";
 import { useScenarioImport } from "@/composables/scenarioImport";
 import { guessImportFormat, type ImportedFileInfo } from "@/importexport/fileHandling";
+import { convertGpxToGeoJSON } from "@/importexport/gpx";
 import { useDragStore } from "@/stores/dragStore";
 import type { OrbatGeneratorOrbat, SpatialIllusionsOrbat } from "@/types/externalModels";
 import { isUrl } from "@/utils";
@@ -40,13 +41,18 @@ import BaseButton from "@/components/BaseButton.vue";
 
 const emit = defineEmits<{
   cancel: [];
-  loaded: [format: ImportFormat, data: any, info: ImportedFileInfo | undefined];
+  loaded: [
+    format: Exclude<ImportFormat, "gpx">,
+    data: any,
+    info: ImportedFileInfo | undefined,
+  ];
   lod: [importData: ImportData];
 }>();
 
 const formatItems: SelectItem<ImportFormat>[] = [
   { label: "MilX", value: "milx" },
   { label: "GeoJSON", value: "geojson" },
+  { label: "GPX", value: "gpx" },
   { label: "Spatial Illusions ORBAT builder", value: "unitgenerator" },
   { label: "Order of Battle Generator", value: "orbatgenerator" },
   { label: "KML/KMZ", value: "kml" },
@@ -94,6 +100,7 @@ const { send } = useNotifications();
 
 const isMilx = computed(() => form.value.format === "milx");
 const isGeojson = computed(() => form.value.format === "geojson");
+const isGpx = computed(() => form.value.format === "gpx");
 const isUnitGenerator = computed(() => form.value.format === "unitgenerator");
 const isOrbatGenerator = computed(() => form.value.format === "orbatgenerator");
 const { importMilxString, importJsonString } = useScenarioImport();
@@ -146,6 +153,13 @@ async function onLoad() {
 
   if (format === "geojson" && stringSource.value) {
     const data = importJsonString<FeatureCollection>(stringSource.value);
+    send({ message: `Loaded data as ${format}` });
+    NProgress.done();
+    emit("loaded", "geojson", data, fileInfo.value);
+  }
+
+  if (format === "gpx" && stringSource.value) {
+    const data = convertGpxToGeoJSON(stringSource.value);
     send({ message: `Loaded data as ${format}` });
     NProgress.done();
     emit("loaded", "geojson", data, fileInfo.value);
@@ -324,6 +338,7 @@ onMounted(() => {
             <a href="https://www.map.army/">map.army</a>
           </p>
           <p v-else-if="isGeojson">Import units and features.</p>
+          <p v-else-if="isGpx">Import GPX tracks, routes, and waypoints.</p>
           <p v-else-if="isUnitGenerator">
             Import ORBAT generated with
             <a href="https://spatialillusions.com/unitgenerator2/" target="_blank"

--- a/src/components/UnitTreeSelect.test.ts
+++ b/src/components/UnitTreeSelect.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { computed } from "vue";
+import { describe, expect, it, vi } from "vitest";
+import UnitTreeSelect from "@/components/UnitTreeSelect.vue";
+
+vi.mock("@tanstack/vue-virtual", () => ({
+  useVirtualizer: (options: any) =>
+    computed(() => {
+      const count = options.value.count;
+      const size = options.value.estimateSize();
+      const renderedCount = Math.min(count, 8);
+      return {
+        getTotalSize: () => count * size,
+        getVirtualItems: () =>
+          Array.from({ length: renderedCount }, (_, index) => ({
+            index,
+            key: index,
+            start: index * size,
+            size,
+          })),
+      };
+    }),
+}));
+
+function makeUnit(id: string, name: string, subUnits: string[] = []) {
+  return {
+    id,
+    name,
+    sidc: "10031000000000000000",
+    subUnits,
+    _pid: "",
+    _sid: "side-1",
+  };
+}
+
+describe("UnitTreeSelect", () => {
+  it("renders nested units in tree order without virtualization below threshold", async () => {
+    const wrapper = mount(UnitTreeSelect, {
+      props: {
+        units: ["unit-1"],
+        unitMap: {
+          "unit-1": makeUnit("unit-1", "Alpha", ["unit-1-1"]),
+          "unit-1-1": makeUnit("unit-1-1", "Alpha Child"),
+        } as any,
+        virtualizationThreshold: 10,
+      },
+      global: {
+        stubs: {
+          Popover: { template: "<div><slot /></div>" },
+          PopoverTrigger: { template: "<div><slot /></div>" },
+          PopoverContent: { template: "<div><slot /></div>" },
+          UnitSymbol: true,
+        },
+      },
+    });
+
+    expect(wrapper.text()).toContain("Alpha");
+    expect(wrapper.text()).toContain("Alpha Child");
+  });
+
+  it("uses virtual rows at and above threshold", () => {
+    const unitIds = Array.from({ length: 120 }, (_, index) => `unit-${index}`);
+    const unitMap = Object.fromEntries(
+      unitIds.map((id, index) => [id, makeUnit(id, `Unit ${index}`)]),
+    );
+
+    const wrapper = mount(UnitTreeSelect, {
+      props: {
+        units: unitIds,
+        unitMap: unitMap as any,
+        virtualizationThreshold: 1,
+      },
+      global: {
+        stubs: {
+          Popover: { template: "<div><slot /></div>" },
+          PopoverTrigger: { template: "<div><slot /></div>" },
+          PopoverContent: { template: "<div><slot /></div>" },
+          UnitSymbol: true,
+        },
+      },
+    });
+
+    const renderedButtons = wrapper.findAll("button").filter((button) => {
+      return button.text().startsWith("Unit ");
+    });
+    expect(renderedButtons.length).toBeGreaterThan(0);
+    expect(renderedButtons.length).toBeLessThan(unitIds.length);
+  });
+});

--- a/src/components/UnitTreeSelect.vue
+++ b/src/components/UnitTreeSelect.vue
@@ -1,0 +1,205 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { useVirtualizer } from "@tanstack/vue-virtual";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Button } from "@/components/ui/button";
+import { Field, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import UnitSymbol from "@/components/UnitSymbol.vue";
+import type { EntityId } from "@/types/base";
+import type { NUnit } from "@/types/internalModels";
+import type { UnitSymbolOptions } from "@/types/scenarioModels";
+import { shouldVirtualizeTree } from "@/components/orbatTreeVirtualization";
+
+interface Props {
+  label?: string;
+  units: EntityId[];
+  unitMap: Record<EntityId, NUnit>;
+  symbolOptions?: UnitSymbolOptions;
+  placeholder?: string;
+  virtualizationThreshold?: number;
+  rowHeight?: number;
+  overscan?: number;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  label: "Unit",
+  placeholder: "Select unit",
+  virtualizationThreshold: 80,
+  rowHeight: 36,
+  overscan: 12,
+});
+const selectedUnitId = defineModel<EntityId | null>({ default: null });
+
+const open = ref(false);
+const filterQuery = ref("");
+const viewportRef = ref<HTMLElement | null>(null);
+
+const selectedUnit = computed(() =>
+  selectedUnitId.value ? props.unitMap[selectedUnitId.value] : null,
+);
+
+function unitMatches(unit: NUnit, query: string): boolean {
+  if (!query) return true;
+  const q = query.toLowerCase();
+  return (
+    unit.name.toLowerCase().includes(q) ||
+    unit.shortName?.toLowerCase().includes(q) ||
+    unit.sidc.toLowerCase().includes(q)
+  );
+}
+
+function unitOrDescendantMatches(unitId: EntityId, query: string): boolean {
+  const unit = props.unitMap[unitId];
+  if (!unit) return false;
+  if (unitMatches(unit, query)) return true;
+  return unit.subUnits.some((childId) => unitOrDescendantMatches(childId, query));
+}
+
+function isVisible(unitId: EntityId): boolean {
+  return unitOrDescendantMatches(unitId, filterQuery.value.trim());
+}
+
+interface UnitTreeRow {
+  unitId: EntityId;
+  level: number;
+}
+
+const visibleRows = computed(() => {
+  const rows: UnitTreeRow[] = [];
+  const query = filterQuery.value.trim();
+  const walk = (unitIds: EntityId[], level: number) => {
+    unitIds.forEach((unitId) => {
+      const unit = props.unitMap[unitId];
+      if (!unit || !unitOrDescendantMatches(unitId, query)) return;
+      rows.push({ unitId, level });
+      walk(unit.subUnits, level + 1);
+    });
+  };
+  walk(props.units, 0);
+  return rows;
+});
+
+const isVirtualized = computed(() =>
+  shouldVirtualizeTree(visibleRows.value.length, props.virtualizationThreshold),
+);
+
+const rowVirtualizerOptions = computed(() => ({
+  count: visibleRows.value.length,
+  getScrollElement: () => viewportRef.value,
+  estimateSize: () => props.rowHeight,
+  overscan: props.overscan,
+}));
+
+const rowVirtualizer = useVirtualizer(rowVirtualizerOptions);
+const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems());
+const totalSize = computed(() => rowVirtualizer.value.getTotalSize());
+
+function selectUnit(unitId: EntityId) {
+  selectedUnitId.value = unitId;
+  open.value = false;
+}
+</script>
+
+<template>
+  <Field>
+    <FieldLabel>{{ label }}</FieldLabel>
+    <Popover v-model:open="open">
+      <PopoverTrigger as-child>
+        <Button
+          type="button"
+          variant="outline"
+          class="h-10 w-full justify-start gap-2 px-3"
+        >
+          <template v-if="selectedUnit">
+            <UnitSymbol
+              class="size-6 shrink-0"
+              :sidc="selectedUnit.sidc"
+              :size="18"
+              :options="{
+                outlineWidth: 8,
+                ...symbolOptions,
+                ...selectedUnit.symbolOptions,
+              }"
+            />
+            <span class="truncate">{{ selectedUnit.name }}</span>
+          </template>
+          <span v-else class="text-muted-foreground truncate">{{ placeholder }}</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" class="w-80 p-2">
+        <Input
+          v-model="filterQuery"
+          type="search"
+          placeholder="Filter units"
+          class="mb-2"
+        />
+        <div ref="viewportRef" class="max-h-80 overflow-y-auto pr-1">
+          <div
+            v-if="isVirtualized"
+            :style="{ height: `${totalSize}px` }"
+            class="relative"
+          >
+            <button
+              v-for="virtualRow in virtualRows"
+              :key="visibleRows[virtualRow.index].unitId"
+              type="button"
+              class="hover:bg-accent absolute left-0 flex min-h-8 w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm"
+              :class="
+                selectedUnitId === visibleRows[virtualRow.index].unitId
+                  ? 'bg-accent font-semibold'
+                  : ''
+              "
+              :style="{
+                height: `${virtualRow.size}px`,
+                transform: `translateY(${virtualRow.start}px)`,
+                paddingLeft: `${0.5 + visibleRows[virtualRow.index].level * 1}rem`,
+              }"
+              @click="selectUnit(visibleRows[virtualRow.index].unitId)"
+            >
+              <UnitSymbol
+                class="size-6 shrink-0"
+                :sidc="unitMap[visibleRows[virtualRow.index].unitId].sidc"
+                :size="18"
+                :options="{
+                  outlineWidth: 8,
+                  ...symbolOptions,
+                  ...unitMap[visibleRows[virtualRow.index].unitId].symbolOptions,
+                }"
+              />
+              <span class="truncate">{{
+                unitMap[visibleRows[virtualRow.index].unitId].name
+              }}</span>
+            </button>
+          </div>
+          <template v-else>
+            <button
+              v-for="row in visibleRows"
+              :key="row.unitId"
+              type="button"
+              class="hover:bg-accent flex min-h-8 w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm"
+              :class="selectedUnitId === row.unitId ? 'bg-accent font-semibold' : ''"
+              :style="{ paddingLeft: `${0.5 + row.level * 1}rem` }"
+              @click="selectUnit(row.unitId)"
+            >
+              <UnitSymbol
+                class="size-6 shrink-0"
+                :sidc="unitMap[row.unitId].sidc"
+                :size="18"
+                :options="{
+                  outlineWidth: 8,
+                  ...symbolOptions,
+                  ...unitMap[row.unitId].symbolOptions,
+                }"
+              />
+              <span class="truncate">{{ unitMap[row.unitId].name }}</span>
+            </button>
+          </template>
+          <p v-if="!visibleRows.length" class="text-muted-foreground px-2 py-3 text-sm">
+            No units found.
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  </Field>
+</template>

--- a/src/composables/scenarioUtils.ts
+++ b/src/composables/scenarioUtils.ts
@@ -72,3 +72,16 @@ export function useRootUnits() {
 
   return { rootUnitItems, groupedRootUnitItems };
 }
+
+export function useRootUnitIds() {
+  const {
+    store: { state },
+  } = useActiveScenario();
+
+  const rootUnitIds = computed(() => [
+    ...Object.values(state.sideMap).flatMap((side) => side.subUnits ?? []),
+    ...Object.values(state.sideGroupMap).flatMap((group) => group.subUnits ?? []),
+  ]);
+
+  return { rootUnitIds };
+}

--- a/src/importexport/fileHandling.spec.ts
+++ b/src/importexport/fileHandling.spec.ts
@@ -70,6 +70,39 @@ describe("guessImportFormat", () => {
     expect(result.format).not.toBe("csv");
     expect(result.format).not.toBe("tsv");
   });
+
+  it("detects GPX files by extension", async () => {
+    const gpxContent = '<gpx version="1.1"><wpt lat="59.91" lon="10.75" /></gpx>';
+    const file = createMockFile(gpxContent, "track.gpx", {
+      type: "application/octet-stream",
+    });
+
+    const result = await guessImportFormat(file);
+
+    expect(result.format).toBe("gpx");
+    expect(result.dataAsString).toBe(gpxContent);
+  });
+
+  it("detects GPX files by common MIME type", async () => {
+    const gpxContent = '<gpx version="1.1"><wpt lat="59.91" lon="10.75" /></gpx>';
+    const file = createMockFile(gpxContent, "track", {
+      type: "application/gpx+xml",
+    });
+
+    const result = await guessImportFormat(file);
+
+    expect(result.format).toBe("gpx");
+  });
+
+  it("leaves non-GPX XML as unknown", async () => {
+    const file = createMockFile("<root><name>Not GPX</name></root>", "data.xml", {
+      type: "text/xml",
+    });
+
+    const result = await guessImportFormat(file);
+
+    expect(result.format).toBe("unknown");
+  });
 });
 
 describe("KMZ image cache cleanup", () => {

--- a/src/importexport/fileHandling.ts
+++ b/src/importexport/fileHandling.ts
@@ -120,6 +120,12 @@ export async function guessImportFormat(file: File): Promise<ImportedFileInfo> {
     return guess;
   }
 
+  if (isGpxFileType(file)) {
+    guess.format = "gpx";
+    guess.dataAsString = text;
+    return guess;
+  }
+
   // is it json
   try {
     const json = JSON.parse(text);
@@ -252,6 +258,14 @@ function isKMFileType(file: File): boolean {
   const kmlTypes = ["application/vnd.google-earth.kml+xml"];
   if (kmlTypes.includes(file.type)) return true;
   return file.name.endsWith(".kml");
+}
+
+function isGpxFileType(file: File): boolean {
+  const fileName = file.name.toLowerCase();
+  const gpxTypes = ["application/gpx+xml", "application/gpx"];
+  if (gpxTypes.includes(file.type)) return true;
+  if (file.type === "text/xml" && fileName.endsWith(".gpx")) return true;
+  return fileName.endsWith(".gpx");
 }
 
 function hasImageFileType(file: File): boolean {

--- a/src/importexport/fileHandling.ts
+++ b/src/importexport/fileHandling.ts
@@ -261,11 +261,9 @@ function isKMFileType(file: File): boolean {
 }
 
 function isGpxFileType(file: File): boolean {
-  const fileName = file.name.toLowerCase();
   const gpxTypes = ["application/gpx+xml", "application/gpx"];
   if (gpxTypes.includes(file.type)) return true;
-  if (file.type === "text/xml" && fileName.endsWith(".gpx")) return true;
-  return fileName.endsWith(".gpx");
+  return file.name.toLowerCase().endsWith(".gpx");
 }
 
 function hasImageFileType(file: File): boolean {

--- a/src/importexport/gpx.test.ts
+++ b/src/importexport/gpx.test.ts
@@ -99,6 +99,54 @@ describe("convertGpxToGeoJSON", () => {
     });
   });
 
+  it("preserves null placeholders for untimed GPX route points", () => {
+    const result = convertGpxToGeoJSON(`
+      <gpx version="1.1" creator="orbat-mapper">
+        <rte>
+          <name>Partly timed route</name>
+          <rtept lat="59.91" lon="10.75">
+            <time>2026-04-28T10:00:00Z</time>
+          </rtept>
+          <rtept lat="59.92" lon="10.76" />
+          <rtept lat="59.93" lon="10.77">
+            <time>2026-04-28T10:10:00Z</time>
+          </rtept>
+        </rte>
+      </gpx>
+    `);
+
+    expect(result.features[0].properties).toMatchObject({
+      coordinateProperties: {
+        times: ["2026-04-28T10:00:00Z", null, "2026-04-28T10:10:00Z"],
+      },
+    });
+  });
+
+  it("preserves null placeholders for untimed GPX track points", () => {
+    const result = convertGpxToGeoJSON(`
+      <gpx version="1.1" creator="orbat-mapper">
+        <trk>
+          <name>Partly timed track</name>
+          <trkseg>
+            <trkpt lat="59.91" lon="10.75">
+              <time>2026-04-28T10:00:00Z</time>
+            </trkpt>
+            <trkpt lat="59.92" lon="10.76" />
+            <trkpt lat="59.93" lon="10.77">
+              <time>2026-04-28T10:10:00Z</time>
+            </trkpt>
+          </trkseg>
+        </trk>
+      </gpx>
+    `);
+
+    expect(result.features[0].properties).toMatchObject({
+      coordinateProperties: {
+        times: ["2026-04-28T10:00:00Z", null, "2026-04-28T10:10:00Z"],
+      },
+    });
+  });
+
   it("throws a clear error for invalid XML", () => {
     expect(() => convertGpxToGeoJSON("<gpx><wpt></gpx>")).toThrow(
       "Could not parse GPX XML",

--- a/src/importexport/gpx.test.ts
+++ b/src/importexport/gpx.test.ts
@@ -42,6 +42,63 @@ describe("convertGpxToGeoJSON", () => {
     });
   });
 
+  it("preserves GPX track point timestamps as coordinate properties", () => {
+    const result = convertGpxToGeoJSON(`
+      <gpx version="1.1" creator="orbat-mapper">
+        <trk>
+          <name>Timed track</name>
+          <trkseg>
+            <trkpt lat="59.91" lon="10.75">
+              <time>2026-04-28T10:00:00Z</time>
+            </trkpt>
+            <trkpt lat="59.92" lon="10.76">
+              <time>2026-04-28T10:05:00Z</time>
+            </trkpt>
+          </trkseg>
+        </trk>
+      </gpx>
+    `);
+
+    expect(result.features[0].properties).toMatchObject({
+      coordinateProperties: {
+        times: ["2026-04-28T10:00:00Z", "2026-04-28T10:05:00Z"],
+      },
+    });
+  });
+
+  it("preserves GPX route point timestamps as coordinate properties", () => {
+    const result = convertGpxToGeoJSON(`
+      <gpx version="1.1" creator="orbat-mapper">
+        <rte>
+          <name>Timed route</name>
+          <rtept lat="59.91" lon="10.75">
+            <time>2026-04-28T10:00:00Z</time>
+          </rtept>
+          <rtept lat="59.92" lon="10.76">
+            <time>2026-04-28T10:05:00Z</time>
+          </rtept>
+        </rte>
+      </gpx>
+    `);
+
+    expect(result.features[0]).toMatchObject({
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [10.75, 59.91],
+          [10.76, 59.92],
+        ],
+      },
+      properties: {
+        _gpxType: "rte",
+        name: "Timed route",
+        coordinateProperties: {
+          times: ["2026-04-28T10:00:00Z", "2026-04-28T10:05:00Z"],
+        },
+      },
+    });
+  });
+
   it("throws a clear error for invalid XML", () => {
     expect(() => convertGpxToGeoJSON("<gpx><wpt></gpx>")).toThrow(
       "Could not parse GPX XML",

--- a/src/importexport/gpx.test.ts
+++ b/src/importexport/gpx.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { convertGpxToGeoJSON } from "@/importexport/gpx";
+
+describe("convertGpxToGeoJSON", () => {
+  it("converts GPX waypoints to point features", () => {
+    const result = convertGpxToGeoJSON(`
+      <gpx version="1.1" creator="orbat-mapper">
+        <wpt lat="59.91" lon="10.75">
+          <name>Oslo waypoint</name>
+        </wpt>
+      </gpx>
+    `);
+
+    expect(result.type).toBe("FeatureCollection");
+    expect(result.features).toHaveLength(1);
+    expect(result.features[0].geometry?.type).toBe("Point");
+    expect(result.features[0].geometry).toMatchObject({
+      coordinates: [10.75, 59.91],
+    });
+    expect(result.features[0].properties).toMatchObject({
+      name: "Oslo waypoint",
+    });
+  });
+
+  it("converts GPX tracks to line features", () => {
+    const result = convertGpxToGeoJSON(`
+      <gpx version="1.1" creator="orbat-mapper">
+        <trk>
+          <name>Patrol route</name>
+          <trkseg>
+            <trkpt lat="59.91" lon="10.75" />
+            <trkpt lat="59.92" lon="10.76" />
+          </trkseg>
+        </trk>
+      </gpx>
+    `);
+
+    expect(result.features).toHaveLength(1);
+    expect(result.features[0].geometry?.type).toBe("LineString");
+    expect(result.features[0].properties).toMatchObject({
+      name: "Patrol route",
+    });
+  });
+
+  it("throws a clear error for invalid XML", () => {
+    expect(() => convertGpxToGeoJSON("<gpx><wpt></gpx>")).toThrow(
+      "Could not parse GPX XML",
+    );
+  });
+
+  it("throws a clear error for empty GPX documents", () => {
+    expect(() => convertGpxToGeoJSON('<gpx version="1.1" />')).toThrow(
+      "GPX did not contain any importable features",
+    );
+  });
+});

--- a/src/importexport/gpx.ts
+++ b/src/importexport/gpx.ts
@@ -1,0 +1,23 @@
+import { gpx } from "@tmcw/togeojson";
+import type { FeatureCollection } from "geojson";
+import { isGeoJSONFeatureCollection } from "@/importexport/geojsonScenarioFeatures";
+
+export function convertGpxToGeoJSON(gpxString: string): FeatureCollection {
+  const document = new DOMParser().parseFromString(gpxString, "application/xml");
+  const parserError = document.getElementsByTagName("parsererror")[0];
+
+  if (parserError) {
+    throw new Error("Could not parse GPX XML");
+  }
+
+  const converted = gpx(document);
+  if (!isGeoJSONFeatureCollection(converted)) {
+    throw new Error("GPX did not convert to a valid GeoJSON feature collection");
+  }
+
+  if (!converted.features.length) {
+    throw new Error("GPX did not contain any importable features");
+  }
+
+  return converted;
+}

--- a/src/importexport/gpx.ts
+++ b/src/importexport/gpx.ts
@@ -40,6 +40,8 @@ function addTrackPointTimes(document: Document, converted: FeatureCollection) {
   if (!trackFeatures.length) return;
 
   const tracks = Array.from(document.getElementsByTagName("trk"));
+  // Positional alignment is only safe when togeojson emitted one feature per <trk>.
+  if (tracks.length !== trackFeatures.length) return;
   trackFeatures.forEach((feature, index) => {
     const track = tracks[index];
     if (!track) return;
@@ -63,6 +65,7 @@ function addRoutePointTimes(document: Document, converted: FeatureCollection) {
   if (!routeFeatures.length) return;
 
   const routes = Array.from(document.getElementsByTagName("rte"));
+  if (routes.length !== routeFeatures.length) return;
   routeFeatures.forEach((feature, index) => {
     const route = routes[index];
     if (!route) return;

--- a/src/importexport/gpx.ts
+++ b/src/importexport/gpx.ts
@@ -1,5 +1,5 @@
 import { gpx } from "@tmcw/togeojson";
-import type { FeatureCollection } from "geojson";
+import type { Feature, FeatureCollection, GeoJsonProperties, LineString } from "geojson";
 import { isGeoJSONFeatureCollection } from "@/importexport/geojsonScenarioFeatures";
 
 export function convertGpxToGeoJSON(gpxString: string): FeatureCollection {
@@ -19,5 +19,58 @@ export function convertGpxToGeoJSON(gpxString: string): FeatureCollection {
     throw new Error("GPX did not contain any importable features");
   }
 
+  addRoutePointTimes(document, converted);
+
   return converted;
+}
+
+function addRoutePointTimes(document: Document, converted: FeatureCollection) {
+  const routeFeatures = converted.features.filter(isRouteLineFeature);
+  if (!routeFeatures.length) return;
+
+  const routes = Array.from(document.getElementsByTagName("rte"));
+  routeFeatures.forEach((feature, index) => {
+    const route = routes[index];
+    if (!route) return;
+
+    const times = Array.from(route.getElementsByTagName("rtept"))
+      .map((routePoint) =>
+        routePoint.getElementsByTagName("time")[0]?.textContent?.trim(),
+      )
+      .filter((time): time is string => !!time);
+
+    if (!times.length) return;
+
+    const properties = getMutableProperties(feature);
+    const coordinateProperties = getCoordinateProperties(properties);
+    coordinateProperties.times = times;
+  });
+}
+
+function isRouteLineFeature(
+  feature: Feature,
+): feature is Feature<LineString, GeoJsonProperties> {
+  return (
+    feature.geometry?.type === "LineString" && feature.properties?._gpxType === "rte"
+  );
+}
+
+function getMutableProperties(feature: Feature): Record<string, unknown> {
+  if (!feature.properties) {
+    feature.properties = {};
+  }
+  return feature.properties;
+}
+
+function getCoordinateProperties(
+  properties: Record<string, unknown>,
+): Record<string, unknown> {
+  if (
+    typeof properties.coordinateProperties !== "object" ||
+    properties.coordinateProperties === null ||
+    Array.isArray(properties.coordinateProperties)
+  ) {
+    properties.coordinateProperties = {};
+  }
+  return properties.coordinateProperties as Record<string, unknown>;
 }

--- a/src/importexport/gpx.ts
+++ b/src/importexport/gpx.ts
@@ -1,5 +1,11 @@
 import { gpx } from "@tmcw/togeojson";
-import type { Feature, FeatureCollection, GeoJsonProperties, LineString } from "geojson";
+import type {
+  Feature,
+  FeatureCollection,
+  GeoJsonProperties,
+  LineString,
+  MultiLineString,
+} from "geojson";
 import { isGeoJSONFeatureCollection } from "@/importexport/geojsonScenarioFeatures";
 
 export function convertGpxToGeoJSON(gpxString: string): FeatureCollection {
@@ -19,9 +25,37 @@ export function convertGpxToGeoJSON(gpxString: string): FeatureCollection {
     throw new Error("GPX did not contain any importable features");
   }
 
-  addRoutePointTimes(document, converted);
+  addPointTimes(document, converted);
 
   return converted;
+}
+
+function addPointTimes(document: Document, converted: FeatureCollection) {
+  addTrackPointTimes(document, converted);
+  addRoutePointTimes(document, converted);
+}
+
+function addTrackPointTimes(document: Document, converted: FeatureCollection) {
+  const trackFeatures = converted.features.filter(isTrackLineFeature);
+  if (!trackFeatures.length) return;
+
+  const tracks = Array.from(document.getElementsByTagName("trk"));
+  trackFeatures.forEach((feature, index) => {
+    const track = tracks[index];
+    if (!track) return;
+
+    const segmentTimes = Array.from(track.getElementsByTagName("trkseg")).map((segment) =>
+      getChildPointTimes(segment, "trkpt"),
+    );
+    const times =
+      feature.geometry.type === "MultiLineString" ? segmentTimes : segmentTimes[0];
+
+    if (!hasAnyTime(times)) return;
+
+    const properties = getMutableProperties(feature);
+    const coordinateProperties = getCoordinateProperties(properties);
+    coordinateProperties.times = times;
+  });
 }
 
 function addRoutePointTimes(document: Document, converted: FeatureCollection) {
@@ -33,18 +67,35 @@ function addRoutePointTimes(document: Document, converted: FeatureCollection) {
     const route = routes[index];
     if (!route) return;
 
-    const times = Array.from(route.getElementsByTagName("rtept"))
-      .map((routePoint) =>
-        routePoint.getElementsByTagName("time")[0]?.textContent?.trim(),
-      )
-      .filter((time): time is string => !!time);
+    const times = getChildPointTimes(route, "rtept");
 
-    if (!times.length) return;
+    if (!hasAnyTime(times)) return;
 
     const properties = getMutableProperties(feature);
     const coordinateProperties = getCoordinateProperties(properties);
     coordinateProperties.times = times;
   });
+}
+
+function getChildPointTimes(element: Element, pointTagName: string): (string | null)[] {
+  return Array.from(element.getElementsByTagName(pointTagName)).map(
+    (point) => point.getElementsByTagName("time")[0]?.textContent?.trim() || null,
+  );
+}
+
+function hasAnyTime(times: unknown): boolean {
+  if (!Array.isArray(times)) return false;
+  return times.flat(Infinity).some((time) => typeof time === "string" && !!time);
+}
+
+function isTrackLineFeature(
+  feature: Feature,
+): feature is Feature<LineString | MultiLineString, GeoJsonProperties> {
+  return (
+    (feature.geometry?.type === "LineString" ||
+      feature.geometry?.type === "MultiLineString") &&
+    feature.properties?._gpxType === "trk"
+  );
 }
 
 function isRouteLineFeature(

--- a/src/importexport/unitTrackAssignment.test.ts
+++ b/src/importexport/unitTrackAssignment.test.ts
@@ -11,9 +11,22 @@ describe("unitTrackAssignment", () => {
       isAssignableTrackFeature({
         type: "Feature",
         properties: {},
-        geometry: { type: "LineString", coordinates: [] },
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [10, 60],
+            [11, 61],
+          ],
+        },
       }),
     ).toBe(true);
+    expect(
+      isAssignableTrackFeature({
+        type: "Feature",
+        properties: {},
+        geometry: { type: "LineString", coordinates: [] },
+      }),
+    ).toBe(false);
     expect(
       isAssignableTrackFeature({
         type: "Feature",

--- a/src/importexport/unitTrackAssignment.test.ts
+++ b/src/importexport/unitTrackAssignment.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+import type { Feature, LineString, MultiLineString } from "geojson";
+import {
+  createUnitTrackStatesFromFeature,
+  isAssignableTrackFeature,
+} from "@/importexport/unitTrackAssignment";
+
+describe("unitTrackAssignment", () => {
+  it("detects assignable line features", () => {
+    expect(
+      isAssignableTrackFeature({
+        type: "Feature",
+        properties: {},
+        geometry: { type: "LineString", coordinates: [] },
+      }),
+    ).toBe(true);
+    expect(
+      isAssignableTrackFeature({
+        type: "Feature",
+        properties: {},
+        geometry: { type: "Point", coordinates: [10, 60] },
+      }),
+    ).toBe(false);
+  });
+
+  it("creates one location state per timestamped LineString coordinate", () => {
+    const feature: Feature<LineString> = {
+      type: "Feature",
+      properties: {
+        coordinateProperties: {
+          times: ["2026-04-28T10:00:00Z", "2026-04-28T10:05:00Z"],
+        },
+      },
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [10, 60],
+          [11, 61],
+        ],
+      },
+    };
+
+    const result = createUnitTrackStatesFromFeature(feature, 123);
+
+    expect(result).toEqual({
+      skippedPoints: 0,
+      states: [
+        { t: Date.parse("2026-04-28T10:00:00Z"), location: [10, 60] },
+        { t: Date.parse("2026-04-28T10:05:00Z"), location: [11, 61] },
+      ],
+    });
+  });
+
+  it("handles nested MultiLineString coordinate times", () => {
+    const feature: Feature<MultiLineString> = {
+      type: "Feature",
+      properties: {
+        coordinateProperties: {
+          times: [
+            ["2026-04-28T10:00:00Z", "2026-04-28T10:05:00Z"],
+            ["2026-04-28T10:10:00Z"],
+          ],
+        },
+      },
+      geometry: {
+        type: "MultiLineString",
+        coordinates: [
+          [
+            [10, 60],
+            [11, 61],
+          ],
+          [[12, 62]],
+        ],
+      },
+    };
+
+    const result = createUnitTrackStatesFromFeature(feature, 123);
+
+    expect(result.states).toEqual([
+      { t: Date.parse("2026-04-28T10:00:00Z"), location: [10, 60] },
+      { t: Date.parse("2026-04-28T10:05:00Z"), location: [11, 61] },
+      { t: Date.parse("2026-04-28T10:10:00Z"), location: [12, 62] },
+    ]);
+  });
+
+  it("uses current time and route via points for untimestamped lines", () => {
+    const feature: Feature<LineString> = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [10, 60],
+          [11, 61],
+          [12, 62],
+        ],
+      },
+    };
+
+    const result = createUnitTrackStatesFromFeature(feature, 123);
+
+    expect(result).toEqual({
+      skippedPoints: 0,
+      states: [{ t: 123, location: [12, 62], via: [[11, 61]] }],
+    });
+  });
+
+  it("skips malformed times without throwing", () => {
+    const feature: Feature<LineString> = {
+      type: "Feature",
+      properties: {
+        coordinateProperties: {
+          times: ["not-a-date", "2026-04-28T10:05:00Z"],
+        },
+      },
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [10, 60],
+          [11, 61],
+          [12, 62],
+        ],
+      },
+    };
+
+    const result = createUnitTrackStatesFromFeature(feature, 123);
+
+    expect(result).toEqual({
+      skippedPoints: 2,
+      states: [{ t: Date.parse("2026-04-28T10:05:00Z"), location: [11, 61] }],
+    });
+  });
+
+  it("keeps timestamps aligned when intermediate route points have no time", () => {
+    const feature: Feature<LineString> = {
+      type: "Feature",
+      properties: {
+        coordinateProperties: {
+          times: ["2026-04-28T10:00:00Z", null, "2026-04-28T10:10:00Z"],
+        },
+      },
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [10, 60],
+          [11, 61],
+          [12, 62],
+        ],
+      },
+    };
+
+    const result = createUnitTrackStatesFromFeature(feature, 123);
+
+    expect(result).toEqual({
+      skippedPoints: 1,
+      states: [
+        { t: Date.parse("2026-04-28T10:00:00Z"), location: [10, 60] },
+        { t: Date.parse("2026-04-28T10:10:00Z"), location: [12, 62] },
+      ],
+    });
+  });
+});

--- a/src/importexport/unitTrackAssignment.test.ts
+++ b/src/importexport/unitTrackAssignment.test.ts
@@ -105,6 +105,58 @@ describe("unitTrackAssignment", () => {
     });
   });
 
+  it("adds a current-time start state for untimestamped lines when requested", () => {
+    const feature: Feature<LineString> = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [10, 60],
+          [11, 61],
+          [12, 62],
+        ],
+      },
+    };
+
+    const result = createUnitTrackStatesFromFeature(feature, 123, {
+      addStartPosition: true,
+    });
+
+    expect(result).toEqual({
+      skippedPoints: 0,
+      states: [
+        { t: 123, location: [10, 60], interpolate: false },
+        { t: 123, location: [12, 62], via: [[11, 61]], viaStartTime: 123 },
+      ],
+    });
+  });
+
+  it("calculates end time based on average speed when provided", () => {
+    const feature: Feature<LineString> = {
+      type: "Feature",
+      properties: {},
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [10, 60],
+          [10, 61], // 1 degree of latitude is roughly 111 km
+        ],
+      },
+    };
+
+    const result = createUnitTrackStatesFromFeature(feature, 1000, {
+      addStartPosition: true,
+      averageSpeed: 10, // 10 m/s
+    });
+
+    expect(result.states).toHaveLength(2);
+    expect(result.states[0].t).toBe(1000);
+    // 111km at 10m/s is 11100s = 11,100,000 ms.
+    expect(result.states[1].t).toBeGreaterThan(10000000);
+    expect(result.states[1].location).toEqual([10, 61]);
+  });
+
   it("skips malformed times without throwing", () => {
     const feature: Feature<LineString> = {
       type: "Feature",

--- a/src/importexport/unitTrackAssignment.ts
+++ b/src/importexport/unitTrackAssignment.ts
@@ -1,0 +1,90 @@
+import type { Feature, LineString, MultiLineString, Position } from "geojson";
+import type { StateAdd } from "@/types/scenarioModels";
+
+type LineFeature = Feature<LineString | MultiLineString>;
+
+export interface TrackAssignmentResult {
+  states: StateAdd[];
+  skippedPoints: number;
+}
+
+export function isAssignableTrackFeature(feature: Feature): feature is LineFeature {
+  return (
+    feature.geometry?.type === "LineString" ||
+    feature.geometry?.type === "MultiLineString"
+  );
+}
+
+export function createUnitTrackStatesFromFeature(
+  feature: LineFeature,
+  currentTime: number,
+): TrackAssignmentResult {
+  const timedStates = getTimedStates(feature);
+  if (timedStates.states.length) return timedStates;
+
+  const coordinates = flattenCoordinates(feature);
+  if (!coordinates.length) return { states: [], skippedPoints: 0 };
+
+  const finalCoordinate = coordinates[coordinates.length - 1];
+  const via = coordinates.length > 2 ? coordinates.slice(1, -1) : undefined;
+  return {
+    states: [
+      {
+        t: currentTime,
+        location: finalCoordinate,
+        ...(via?.length ? { via } : {}),
+      },
+    ],
+    skippedPoints: 0,
+  };
+}
+
+function getTimedStates(feature: LineFeature): TrackAssignmentResult {
+  const times = getCoordinateTimes(feature);
+  if (!times) return { states: [], skippedPoints: 0 };
+
+  const coordinates = flattenCoordinates(feature);
+  const flatTimes = flattenTimes(times);
+  const count = Math.min(coordinates.length, flatTimes.length);
+  const states: StateAdd[] = [];
+  let skippedPoints = Math.abs(coordinates.length - flatTimes.length);
+
+  for (let i = 0; i < count; i++) {
+    const time = flatTimes[i];
+    const t = typeof time === "string" ? Date.parse(time) : NaN;
+    if (!Number.isFinite(t)) {
+      skippedPoints++;
+      continue;
+    }
+    states.push({
+      t,
+      location: coordinates[i],
+    });
+  }
+
+  return { states, skippedPoints };
+}
+
+function getCoordinateTimes(feature: LineFeature): unknown {
+  const coordinateProperties = feature.properties?.coordinateProperties;
+  if (
+    typeof coordinateProperties !== "object" ||
+    coordinateProperties === null ||
+    Array.isArray(coordinateProperties)
+  ) {
+    return undefined;
+  }
+  return (coordinateProperties as Record<string, unknown>).times;
+}
+
+function flattenCoordinates(feature: LineFeature): Position[] {
+  if (feature.geometry.type === "LineString") {
+    return feature.geometry.coordinates;
+  }
+  return feature.geometry.coordinates.flat();
+}
+
+function flattenTimes(times: unknown): unknown[] {
+  if (!Array.isArray(times)) return [];
+  return times.flat(Infinity);
+}

--- a/src/importexport/unitTrackAssignment.ts
+++ b/src/importexport/unitTrackAssignment.ts
@@ -1,11 +1,17 @@
 import type { Feature, LineString, MultiLineString, Position } from "geojson";
 import type { StateAdd } from "@/types/scenarioModels";
+import length from "@turf/length";
 
 type LineFeature = Feature<LineString | MultiLineString>;
 
 export interface TrackAssignmentResult {
   states: StateAdd[];
   skippedPoints: number;
+}
+
+export interface TrackAssignmentOptions {
+  addStartPosition?: boolean;
+  averageSpeed?: number;
 }
 
 export function isAssignableTrackFeature(feature: Feature): feature is LineFeature {
@@ -18,32 +24,59 @@ export function isAssignableTrackFeature(feature: Feature): feature is LineFeatu
 export function createUnitTrackStatesFromFeature(
   feature: LineFeature,
   currentTime: number,
+  options: TrackAssignmentOptions = {},
 ): TrackAssignmentResult {
-  const timedStates = getTimedStates(feature);
+  const coordinates = flattenCoordinates(feature);
+  const timedStates = getTimedStates(feature, coordinates);
   if (timedStates.states.length) return timedStates;
 
-  const coordinates = flattenCoordinates(feature);
   if (!coordinates.length) return { states: [], skippedPoints: 0 };
 
   const finalCoordinate = coordinates[coordinates.length - 1];
+  const startCoordinate = coordinates[0];
   const via = coordinates.length > 2 ? coordinates.slice(1, -1) : undefined;
+
+  let endTime = currentTime;
+  if (options.averageSpeed && options.averageSpeed > 0) {
+    const distanceMeters = length(feature, { units: "meters" });
+    endTime = Math.round(currentTime + (distanceMeters / options.averageSpeed) * 1000);
+  }
+
+  console.log(
+    "Creating track states for feature with",
+    coordinates.length,
+    "points",
+    options,
+  );
   return {
     states: [
+      ...(options.addStartPosition
+        ? [
+            {
+              t: currentTime,
+              location: startCoordinate,
+              interpolate: false,
+            },
+          ]
+        : []),
       {
-        t: currentTime,
+        t: endTime,
         location: finalCoordinate,
         ...(via?.length ? { via } : {}),
+        ...(options.addStartPosition ? { viaStartTime: currentTime } : {}),
       },
     ],
     skippedPoints: 0,
   };
 }
 
-function getTimedStates(feature: LineFeature): TrackAssignmentResult {
+function getTimedStates(
+  feature: LineFeature,
+  coordinates: Position[],
+): TrackAssignmentResult {
   const times = getCoordinateTimes(feature);
   if (!times) return { states: [], skippedPoints: 0 };
 
-  const coordinates = flattenCoordinates(feature);
   const flatTimes = flattenTimes(times);
   const count = Math.min(coordinates.length, flatTimes.length);
   const states: StateAdd[] = [];

--- a/src/importexport/unitTrackAssignment.ts
+++ b/src/importexport/unitTrackAssignment.ts
@@ -15,10 +15,13 @@ export interface TrackAssignmentOptions {
 }
 
 export function isAssignableTrackFeature(feature: Feature): feature is LineFeature {
-  return (
-    feature.geometry?.type === "LineString" ||
-    feature.geometry?.type === "MultiLineString"
-  );
+  if (feature.geometry?.type === "LineString") {
+    return feature.geometry.coordinates.length >= 2;
+  }
+  if (feature.geometry?.type === "MultiLineString") {
+    return feature.geometry.coordinates.some((line) => line.length >= 2);
+  }
+  return false;
 }
 
 export function createUnitTrackStatesFromFeature(
@@ -42,12 +45,6 @@ export function createUnitTrackStatesFromFeature(
     endTime = Math.round(currentTime + (distanceMeters / options.averageSpeed) * 1000);
   }
 
-  console.log(
-    "Creating track states for feature with",
-    coordinates.length,
-    "points",
-    options,
-  );
   return {
     states: [
       ...(options.addStartPosition

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.test.ts
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.test.ts
@@ -22,6 +22,61 @@ describe("ScenarioFeatureDetails", () => {
     setActivePinia(createPinia());
   });
 
+  function makeScenarioProvide(overrides: Record<string, unknown> = {}) {
+    return {
+      geo: {
+        getGeometryLayerItemById: vi.fn(),
+        updateFeature: vi.fn(),
+      },
+      store: {
+        state: {
+          currentTime: Date.parse("2026-04-28T10:00:00Z"),
+          unitMap: {},
+          sideMap: {},
+          sideGroupMap: {},
+        },
+        groupUpdate: (callback: () => void) => callback(),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+      unitActions: {
+        addUnitStateEntry: vi.fn(),
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      ...overrides,
+    };
+  }
+
+  const baseStubs = {
+    GlobalEvents: true,
+    EditableLabel: true,
+    IconButton: true,
+    ItemMedia: true,
+    ScenarioFeatureDropdownMenu: true,
+    ScenarioFeatureState: true,
+    EditMetaForm: true,
+    EditMediaForm: true,
+    FeatureTransformations: true,
+    PanelDataGrid: { template: "<div><slot /></div>" },
+    ScrollTabs: { template: "<div><slot /></div>" },
+    TabsContent: { template: "<div><slot /></div>" },
+    Button: { template: "<button><slot /></button>" },
+    ScenarioFeatureVisibilitySettings: true,
+    ScenarioFeatureStrokeSettings: true,
+    ScenarioFeatureArrowSettings: true,
+    ScenarioFeatureFillSettings: true,
+    ScenarioFeatureTextSettings: true,
+    UnitTreeSelect: true,
+    ToggleField: defineComponent({
+      name: "ToggleField",
+      props: { modelValue: Boolean },
+      emits: ["update:modelValue"],
+      template:
+        "<button data-test='toggle-field' @click=\"$emit('update:modelValue', !modelValue)\"><slot /></button>",
+    }),
+  };
+
   it("updates feature styling without requiring an OpenLayers select interaction", async () => {
     const updateFeature = vi.fn();
     const feature = {
@@ -38,6 +93,12 @@ describe("ScenarioFeatureDetails", () => {
       name: "Alpha",
       style: {},
     };
+    const scenario = makeScenarioProvide({
+      geo: {
+        getGeometryLayerItemById: vi.fn(() => ({ layerItem: feature })),
+        updateFeature,
+      },
+    });
 
     const wrapper = mount(ScenarioFeatureDetails, {
       props: {
@@ -47,13 +108,7 @@ describe("ScenarioFeatureDetails", () => {
         plugins: [createPinia()],
         provide: {
           [activeScenarioKey as symbol]: {
-            geo: {
-              getGeometryLayerItemById: vi.fn(() => ({ layerItem: feature })),
-              updateFeature,
-            },
-            store: {
-              groupUpdate: (callback: () => void) => callback(),
-            },
+            ...scenario,
           },
           [activeScenarioMapEngineKey as symbol]: shallowRef({
             layers: {
@@ -66,31 +121,7 @@ describe("ScenarioFeatureDetails", () => {
           } as any),
         },
         stubs: {
-          GlobalEvents: true,
-          EditableLabel: true,
-          IconButton: true,
-          ItemMedia: true,
-          ScenarioFeatureDropdownMenu: true,
-          ScenarioFeatureState: true,
-          EditMetaForm: true,
-          EditMediaForm: true,
-          FeatureTransformations: true,
-          PanelDataGrid: { template: "<div><slot /></div>" },
-          ScrollTabs: { template: "<div><slot /></div>" },
-          TabsContent: { template: "<div><slot /></div>" },
-          Button: { template: "<button><slot /></button>" },
-          ScenarioFeatureVisibilitySettings: true,
-          ScenarioFeatureStrokeSettings: true,
-          ScenarioFeatureArrowSettings: true,
-          ScenarioFeatureFillSettings: true,
-          ScenarioFeatureTextSettings: true,
-          ToggleField: defineComponent({
-            name: "ToggleField",
-            props: { modelValue: Boolean },
-            emits: ["update:modelValue"],
-            template:
-              "<button data-test='toggle-field' @click=\"$emit('update:modelValue', !modelValue)\"><slot /></button>",
-          }),
+          ...baseStubs,
           ScenarioFeatureMarkerSettings: {
             name: "ScenarioFeatureMarkerSettings",
             template: "<div />",
@@ -125,6 +156,12 @@ describe("ScenarioFeatureDetails", () => {
       name: "Alpha",
       style: {},
     };
+    const scenario = makeScenarioProvide({
+      geo: {
+        getGeometryLayerItemById: vi.fn(() => ({ layerItem: feature })),
+        updateFeature: vi.fn(),
+      },
+    });
 
     const wrapper = mount(ScenarioFeatureDetails, {
       props: {
@@ -134,13 +171,7 @@ describe("ScenarioFeatureDetails", () => {
         plugins: [createPinia()],
         provide: {
           [activeScenarioKey as symbol]: {
-            geo: {
-              getGeometryLayerItemById: vi.fn(() => ({ layerItem: feature })),
-              updateFeature: vi.fn(),
-            },
-            store: {
-              groupUpdate: (callback: () => void) => callback(),
-            },
+            ...scenario,
           },
           [activeScenarioMapEngineKey as symbol]: shallowRef({
             layers: {
@@ -153,39 +184,127 @@ describe("ScenarioFeatureDetails", () => {
           } as any),
         },
         stubs: {
-          GlobalEvents: true,
-          EditableLabel: true,
-          IconButton: true,
-          ItemMedia: true,
-          ScenarioFeatureDropdownMenu: true,
-          ScenarioFeatureState: true,
-          EditMetaForm: true,
-          EditMediaForm: true,
-          FeatureTransformations: true,
-          PanelDataGrid: { template: "<div><slot /></div>" },
+          ...baseStubs,
           ScrollTabs: {
             props: ["items"],
             template: "<div><slot /></div>",
           },
-          TabsContent: { template: "<div><slot /></div>" },
-          Button: { template: "<button><slot /></button>" },
-          ScenarioFeatureVisibilitySettings: true,
-          ScenarioFeatureStrokeSettings: true,
-          ScenarioFeatureArrowSettings: true,
-          ScenarioFeatureFillSettings: true,
-          ScenarioFeatureTextSettings: true,
           ScenarioFeatureMarkerSettings: true,
-          ToggleField: defineComponent({
-            name: "ToggleField",
-            props: { modelValue: Boolean },
-            emits: ["update:modelValue"],
-            template:
-              "<button data-test='toggle-field' @click=\"$emit('update:modelValue', !modelValue)\"><slot /></button>",
-          }),
         },
       },
     });
 
     expect(wrapper.find("feature-transformations-stub").exists()).toBe(true);
+  });
+
+  it("assigns a line feature to a unit as timestamped unit state", async () => {
+    const addUnitStateEntry = vi.fn();
+    const setCurrentTime = vi.fn();
+    const feature = {
+      id: "feature-1",
+      kind: "geometry",
+      _pid: "layer-1",
+      geometry: {
+        type: "LineString",
+        coordinates: [
+          [10, 60],
+          [11, 61],
+        ],
+      },
+      geometryMeta: {
+        geometryKind: "LineString",
+      },
+      userData: {
+        coordinateProperties: {
+          times: ["2026-04-28T10:00:00Z", "2026-04-28T10:05:00Z"],
+        },
+      },
+      name: "Timed route",
+      style: {},
+    };
+    const scenario = makeScenarioProvide({
+      geo: {
+        getGeometryLayerItemById: vi.fn(() => ({ layerItem: feature })),
+        updateFeature: vi.fn(),
+      },
+      store: {
+        state: {
+          currentTime: Date.parse("2026-04-28T10:00:00Z"),
+          unitMap: {
+            "unit-1": {
+              id: "unit-1",
+              name: "Alpha",
+              sidc: "10031000000000000000",
+              subUnits: ["unit-child"],
+            },
+            "unit-child": {
+              id: "unit-child",
+              name: "Alpha Child",
+              sidc: "10031000000000000000",
+              subUnits: [],
+            },
+          },
+          sideMap: {
+            "side-1": {
+              id: "side-1",
+              name: "Blue",
+              subUnits: ["unit-1"],
+            },
+          },
+          sideGroupMap: {},
+        },
+        groupUpdate: (callback: () => void) => callback(),
+      },
+      time: {
+        setCurrentTime,
+      },
+      unitActions: {
+        addUnitStateEntry,
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+    });
+
+    const wrapper = mount(ScenarioFeatureDetails, {
+      props: {
+        selectedIds: new Set(["feature-1"]),
+      },
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeScenarioKey as symbol]: scenario,
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            layers: {
+              capabilities: {
+                featureTransform: false,
+              },
+            },
+            suspendFeatureSelection: vi.fn(),
+            resumeFeatureSelection: vi.fn(),
+          } as any),
+        },
+        stubs: baseStubs,
+      },
+    });
+
+    const assignButton = wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Assign to unit");
+    expect(assignButton).toBeTruthy();
+    await assignButton!.trigger("click");
+
+    expect(addUnitStateEntry).toHaveBeenCalledTimes(2);
+    expect(addUnitStateEntry).toHaveBeenNthCalledWith(
+      1,
+      "unit-1",
+      { t: Date.parse("2026-04-28T10:00:00Z"), location: [10, 60] },
+      true,
+    );
+    expect(addUnitStateEntry).toHaveBeenNthCalledWith(
+      2,
+      "unit-1",
+      { t: Date.parse("2026-04-28T10:05:00Z"), location: [11, 61] },
+      true,
+    );
+    expect(setCurrentTime).toHaveBeenCalledWith(Date.parse("2026-04-28T10:00:00Z"));
   });
 });

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
@@ -77,6 +77,8 @@ const { featureDetailsTab: selectedTab } = storeToRefs(useTabStore());
 const toolbarStore = useMainToolbarStore();
 const { rootUnitIds } = useRootUnitIds();
 
+const DEFAULT_ASSIGN_SPEED_M_S = convertSpeedToMetric(30, "km/h");
+
 const feature = computed(() => {
   if (props.selectedIds.size === 1) {
     return geo.getGeometryLayerItemById(props.selectedIds.values().next().value!)
@@ -321,7 +323,7 @@ function assignFeatureToUnit() {
   const speedValue = unit.properties?.averageSpeed || unit.properties?.maxSpeed;
   const averageSpeed = speedValue
     ? convertSpeedToMetric(speedValue.value, speedValue.uom)
-    : convertSpeedToMetric(30, "km/h");
+    : DEFAULT_ASSIGN_SPEED_M_S;
 
   const result = createUnitTrackStatesFromFeature(
     geoJsonFeature,

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
@@ -53,6 +53,7 @@ import {
   isAssignableTrackFeature,
 } from "@/importexport/unitTrackAssignment";
 import type { Feature } from "geojson";
+import { convertSpeedToMetric } from "@/utils/convert";
 
 interface Props {
   selectedIds: SelectedScenarioFeatures;
@@ -314,9 +315,21 @@ function assignFeatureToUnit() {
   const geoJsonFeature = toGeoJSONFeature(feature.value);
   if (!isAssignableTrackFeature(geoJsonFeature)) return;
 
+  const unit = store.state.unitMap[assignmentUnitId.value];
+  if (!unit) return;
+
+  const speedValue = unit.properties?.averageSpeed || unit.properties?.maxSpeed;
+  const averageSpeed = speedValue
+    ? convertSpeedToMetric(speedValue.value, speedValue.uom)
+    : convertSpeedToMetric(30, "km/h");
+
   const result = createUnitTrackStatesFromFeature(
     geoJsonFeature,
     store.state.currentTime,
+    {
+      addStartPosition: !unit.location && !unit._state?.location,
+      averageSpeed,
+    },
   );
   if (!result.states.length) {
     notify({ message: "No track positions were available to assign.", type: "warning" });
@@ -421,26 +434,6 @@ function assignFeatureToUnit() {
         </TabsContent>
         <TabsContent value="1" class="mx-4">
           <ScenarioFeatureGeometryStats v-if="feature && !isEditing" :feature="feature" />
-          <div
-            v-if="feature && !isEditing && canAssignFeatureToUnit"
-            class="border-border mt-4 space-y-3 border-t pt-4"
-          >
-            <UnitTreeSelect
-              label="Assign track/route to unit"
-              :units="rootUnitIds"
-              :unit-map="store.state.unitMap"
-              v-model="assignmentUnitId"
-            />
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              :disabled="!assignmentUnitId"
-              @click="assignFeatureToUnit"
-            >
-              Assign to unit
-            </Button>
-          </div>
           <ScenarioFeaturesGeometryStats
             v-else-if="isMultiMode && selectedFeatures.length"
             :features="selectedFeatures"
@@ -466,9 +459,29 @@ function assignFeatureToUnit() {
             />
           </div>
         </TabsContent>
-        <TabsContent value="2" class="mx-4"
-          ><ScenarioFeatureState v-if="feature" :feature="feature"
-        /></TabsContent>
+        <TabsContent value="2" class="mx-4">
+          <ScenarioFeatureState v-if="feature" :feature="feature" />
+          <div
+            v-if="feature && canAssignFeatureToUnit"
+            class="border-border mt-4 space-y-3 border-t pt-4"
+          >
+            <UnitTreeSelect
+              label="Assign track/route to unit"
+              :units="rootUnitIds"
+              :unit-map="store.state.unitMap"
+              v-model="assignmentUnitId"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              :disabled="!assignmentUnitId"
+              @click="assignFeatureToUnit"
+            >
+              Assign to unit
+            </Button>
+          </div>
+        </TabsContent>
         <TabsContent v-if="canTransformFeature" value="3" class="mx-4">
           <FeatureTransformations class="mt-4" />
         </TabsContent>

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
@@ -46,6 +46,13 @@ import { Button } from "@/components/ui/button";
 import type { NGeometryLayerItem } from "@/types/internalModels";
 import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue";
 import PanelTitle from "@/modules/scenarioeditor/PanelTitle.vue";
+import UnitTreeSelect from "@/components/UnitTreeSelect.vue";
+import { useRootUnitIds } from "@/composables/scenarioUtils";
+import {
+  createUnitTrackStatesFromFeature,
+  isAssignableTrackFeature,
+} from "@/importexport/unitTrackAssignment";
+import type { Feature } from "geojson";
 
 interface Props {
   selectedIds: SelectedScenarioFeatures;
@@ -57,10 +64,8 @@ const FeatureTransformations = defineAsyncComponent(
   () => import("@/modules/scenarioeditor/FeatureTransformations.vue"),
 );
 
-const {
-  geo,
-  store: { groupUpdate },
-} = injectStrict(activeScenarioKey);
+const { geo, store, time, unitActions } = injectStrict(activeScenarioKey);
+const { groupUpdate } = store;
 const engineRef = injectStrict(activeScenarioMapEngineKey);
 
 const { send: notify } = useNotifications();
@@ -69,6 +74,7 @@ const { selectedFeatureIds, clear: clearSelection } = useSelectedItems();
 const uiStore = useUiStore();
 const { featureDetailsTab: selectedTab } = storeToRefs(useTabStore());
 const toolbarStore = useMainToolbarStore();
+const { rootUnitIds } = useRootUnitIds();
 
 const feature = computed(() => {
   if (props.selectedIds.size === 1) {
@@ -135,6 +141,16 @@ const hasFill = computed(
 const canTransformFeature = computed(() =>
   Boolean(engineRef.value?.layers.capabilities.featureTransform),
 );
+const canAssignFeatureToUnit = computed(
+  () => !!feature.value && isAssignableTrackFeature(toGeoJSONFeature(feature.value)),
+);
+const selectedAssignmentUnitId = ref<string | null>(null);
+const assignmentUnitId = computed({
+  get: () => selectedAssignmentUnitId.value ?? rootUnitIds.value[0] ?? null,
+  set: (unitId: string | null) => {
+    selectedAssignmentUnitId.value = unitId;
+  },
+});
 
 watch(canTransformFeature, (enabled) => {
   if (!enabled && selectedTab.value === 3) {
@@ -284,6 +300,44 @@ function onAction(action: ScenarioFeatureActions) {
   }
   featureActions.onFeatureAction([...props.selectedIds], action);
 }
+
+function toGeoJSONFeature(item: NGeometryLayerItem): Feature {
+  return {
+    type: "Feature",
+    properties: item.userData ?? {},
+    geometry: item.geometry,
+  };
+}
+
+function assignFeatureToUnit() {
+  if (!feature.value || !assignmentUnitId.value) return;
+  const geoJsonFeature = toGeoJSONFeature(feature.value);
+  if (!isAssignableTrackFeature(geoJsonFeature)) return;
+
+  const result = createUnitTrackStatesFromFeature(
+    geoJsonFeature,
+    store.state.currentTime,
+  );
+  if (!result.states.length) {
+    notify({ message: "No track positions were available to assign.", type: "warning" });
+    return;
+  }
+
+  groupUpdate(() => {
+    result.states.forEach((state) => {
+      unitActions.addUnitStateEntry(assignmentUnitId.value!, state, true);
+    });
+  });
+  time.setCurrentTime(store.state.currentTime);
+
+  const skippedMessage = result.skippedPoints
+    ? ` ${result.skippedPoints} route points were skipped.`
+    : "";
+  notify({
+    message: `Assigned ${result.states.length} track positions to unit.${skippedMessage}`,
+    type: "success",
+  });
+}
 </script>
 <template>
   <div>
@@ -367,6 +421,26 @@ function onAction(action: ScenarioFeatureActions) {
         </TabsContent>
         <TabsContent value="1" class="mx-4">
           <ScenarioFeatureGeometryStats v-if="feature && !isEditing" :feature="feature" />
+          <div
+            v-if="feature && !isEditing && canAssignFeatureToUnit"
+            class="border-border mt-4 space-y-3 border-t pt-4"
+          >
+            <UnitTreeSelect
+              label="Assign track/route to unit"
+              :units="rootUnitIds"
+              :unit-map="store.state.unitMap"
+              v-model="assignmentUnitId"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              :disabled="!assignmentUnitId"
+              @click="assignFeatureToUnit"
+            >
+              Assign to unit
+            </Button>
+          </div>
           <ScenarioFeaturesGeometryStats
             v-else-if="isMultiMode && selectedFeatures.length"
             :features="selectedFeatures"

--- a/src/modules/scenarioeditor/scenarioDrawHelpers.ts
+++ b/src/modules/scenarioeditor/scenarioDrawHelpers.ts
@@ -94,10 +94,7 @@ export function addScenarioDrawFeature(
   const zIndex =
     scenarioLayer.items.length === 0
       ? 0
-      : Math.max(
-          scenarioLayer.items.length,
-          (lastFeatureInLayer?._zIndex ?? -1) + 1,
-        );
+      : Math.max(scenarioLayer.items.length, (lastFeatureInLayer?._zIndex ?? -1) + 1);
   const scenarioFeature: GeometryLayerItem = {
     ...feature,
     id: feature.id || nanoid(),

--- a/src/types/importExport.ts
+++ b/src/types/importExport.ts
@@ -16,6 +16,7 @@ export type ExportFormat =
 export type ImportFormat =
   | "milx"
   | "geojson"
+  | "gpx"
   | "unitgenerator"
   | "orbatgenerator"
   | "image"


### PR DESCRIPTION
## Summary
- detect GPX files and expose GPX in the import format selector
- convert GPX to GeoJSON with @tmcw/togeojson and reuse the GeoJSON import flow
- preserve trackpoint and route-point timestamps as coordinateProperties.times

## Tests
- pnpm vitest run src/importexport/fileHandling.spec.ts src/importexport/gpx.test.ts
- pnpm exec vue-tsc --build