### PR TITLE
Add support for rendering and managing raster tile layers in MapLibre scenario layers

### DIFF
--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
@@ -380,6 +380,153 @@ describe("createMapLibreScenarioLayerController", () => {
     );
   });
 
+  it("renders scenario XYZLayers as MapLibre raster tile layers", () => {
+    const mockMap = createMockMap();
+    const { scenario, mapLayers } = createScenario();
+    mapLayers.value = [
+      {
+        id: "xyz-1",
+        type: "XYZLayer",
+        name: "Tiles",
+        url: "https://example.test/{z}/{x}/{y}.png",
+        attributions: "Example tiles",
+        opacity: 0.5,
+      },
+    ];
+    const controller = createMapLibreScenarioLayerController({
+      getNativeMap: () => mockMap.map,
+      fitGeometry: vi.fn(),
+      fitExtent: vi.fn(),
+      animateView: vi.fn(),
+    } as any);
+
+    controller.bindScenario(scenario);
+
+    expect(mockMap.map.addSource).toHaveBeenCalledWith("scenario-raster-source-xyz-1", {
+      type: "raster",
+      tiles: ["https://example.test/{z}/{x}/{y}.png"],
+      tileSize: 256,
+      attribution: "Example tiles",
+    });
+    expect(mockMap.map.addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "scenario-raster-layer-xyz-1",
+        type: "raster",
+        source: "scenario-raster-source-xyz-1",
+        paint: { "raster-opacity": 0.5 },
+      }),
+    );
+    expect(scenario.geo.updateMapLayer).toHaveBeenCalledWith(
+      "xyz-1",
+      { _status: "initialized" },
+      { noEmit: true, undoable: false },
+    );
+  });
+
+  it("renders scenario TileJSONLayers as MapLibre raster tilejson sources", () => {
+    const mockMap = createMockMap();
+    const { scenario, mapLayers } = createScenario();
+    mapLayers.value = [
+      {
+        id: "tilejson-1",
+        type: "TileJSONLayer",
+        name: "TileJSON",
+        url: "https://example.test/tilejson.json",
+        isHidden: true,
+      },
+    ];
+    const controller = createMapLibreScenarioLayerController({
+      getNativeMap: () => mockMap.map,
+      fitGeometry: vi.fn(),
+      fitExtent: vi.fn(),
+      animateView: vi.fn(),
+    } as any);
+
+    controller.bindScenario(scenario);
+
+    expect(mockMap.map.addSource).toHaveBeenCalledWith(
+      "scenario-raster-source-tilejson-1",
+      {
+        type: "raster",
+        url: "https://example.test/tilejson.json",
+      },
+    );
+    expect(mockMap.map.addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "scenario-raster-layer-tilejson-1",
+        layout: { visibility: "none" },
+      }),
+    );
+  });
+
+  it("updates XYZLayer visibility and opacity without rebuilding the source", async () => {
+    const mockMap = createMockMap();
+    const { scenario, mapLayers, mapLayerHook } = createScenario();
+    mapLayers.value = [
+      {
+        id: "xyz-1",
+        type: "XYZLayer",
+        name: "Tiles",
+        url: "https://example.test/{z}/{x}/{y}.png",
+      },
+    ];
+    const controller = createMapLibreScenarioLayerController({
+      getNativeMap: () => mockMap.map,
+      fitGeometry: vi.fn(),
+      fitExtent: vi.fn(),
+      animateView: vi.fn(),
+    } as any);
+    controller.bindScenario(scenario);
+    mockMap.map.addSource.mockClear();
+
+    await mapLayerHook.trigger({
+      type: "update",
+      id: "xyz-1",
+      data: { isHidden: true, opacity: 0.25 },
+    });
+
+    expect(mockMap.map.addSource).not.toHaveBeenCalled();
+    expect(mockMap.map.setLayoutProperty).toHaveBeenCalledWith(
+      "scenario-raster-layer-xyz-1",
+      "visibility",
+      "none",
+    );
+    expect(mockMap.map.setPaintProperty).toHaveBeenCalledWith(
+      "scenario-raster-layer-xyz-1",
+      "raster-opacity",
+      0.25,
+    );
+  });
+
+  it("rebuilds raster tile layers after a MapLibre style reload", () => {
+    const mockMap = createMockMap();
+    const { scenario, mapLayers } = createScenario();
+    mapLayers.value = [
+      {
+        id: "xyz-1",
+        type: "XYZLayer",
+        name: "Tiles",
+        url: "https://example.test/{z}/{x}/{y}.png",
+      },
+    ];
+    const controller = createMapLibreScenarioLayerController({
+      getNativeMap: () => mockMap.map,
+      fitGeometry: vi.fn(),
+      fitExtent: vi.fn(),
+      animateView: vi.fn(),
+    } as any);
+    controller.bindScenario(scenario);
+    mockMap.clearStyle();
+    mockMap.map.addSource.mockClear();
+
+    mockMap.emit("style.load");
+
+    expect(mockMap.map.addSource).toHaveBeenCalledWith(
+      "scenario-raster-source-xyz-1",
+      expect.objectContaining({ type: "raster" }),
+    );
+  });
+
   it("updates ImageLayers immediately when map layer changes are undone", async () => {
     const mockMap = createMockMap();
     const { scenario, mapLayers, undoRedoHook } = createScenario();

--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
@@ -5,6 +5,7 @@ import type {
   ImageSourceSpecification,
   LayerSpecification,
   Map as MlMap,
+  RasterSourceSpecification,
 } from "maplibre-gl";
 import { fromLonLat, toLonLat, transformExtent } from "ol/proj";
 import type { Feature as GeoJsonFeature, Position } from "geojson";
@@ -29,6 +30,8 @@ import type {
   FeatureId,
   ScenarioImageLayer,
   ScenarioMapLayer,
+  ScenarioTileJSONLayer,
+  ScenarioXYZLayer,
 } from "@/types/scenarioGeoModels";
 import {
   isNGeometryLayerItem,
@@ -57,6 +60,15 @@ const mapLayerUndoActionLabels = [
 
 const MAPLIBRE_IMAGE_SOURCE_PREFIX = "scenario-image-source-";
 const MAPLIBRE_IMAGE_LAYER_PREFIX = "scenario-image-layer-";
+const MAPLIBRE_RASTER_SOURCE_PREFIX = "scenario-raster-source-";
+const MAPLIBRE_RASTER_LAYER_PREFIX = "scenario-raster-layer-";
+
+type ImageCoordinates = [
+  [number, number],
+  [number, number],
+  [number, number],
+  [number, number],
+];
 
 function normalizeMapLayerExtent(
   extent: number[] | undefined,
@@ -117,12 +129,26 @@ function isImageLayer(layer: ScenarioMapLayer | undefined): layer is ScenarioIma
   return layer?.type === "ImageLayer";
 }
 
+function isRasterTileLayer(
+  layer: ScenarioMapLayer | undefined,
+): layer is ScenarioTileJSONLayer | ScenarioXYZLayer {
+  return layer?.type === "TileJSONLayer" || layer?.type === "XYZLayer";
+}
+
 function getImageSourceId(layerId: FeatureId) {
   return `${MAPLIBRE_IMAGE_SOURCE_PREFIX}${layerId}`;
 }
 
 function getImageLayerId(layerId: FeatureId) {
   return `${MAPLIBRE_IMAGE_LAYER_PREFIX}${layerId}`;
+}
+
+function getRasterSourceId(layerId: FeatureId) {
+  return `${MAPLIBRE_RASTER_SOURCE_PREFIX}${layerId}`;
+}
+
+function getRasterLayerId(layerId: FeatureId) {
+  return `${MAPLIBRE_RASTER_LAYER_PREFIX}${layerId}`;
 }
 
 function toPairScale(
@@ -146,7 +172,9 @@ function rotatePoint(
   return [centerX + dx * cos - dy * sin, centerY + dx * sin + dy * cos];
 }
 
-function extentToImageCoordinates(extent: [number, number, number, number]) {
+function extentToImageCoordinates(
+  extent: [number, number, number, number],
+): ImageCoordinates {
   const [minX, minY, maxX, maxY] = extent;
   return [
     [minX, maxY],
@@ -162,17 +190,21 @@ function projectedImageCoordinates(
   rotation: number,
   width: number,
   height: number,
-) {
+): ImageCoordinates {
   const [centerX, centerY] = center;
   const [scaleX, scaleY] = scale;
   const halfWidth = (width * scaleX) / 2;
   const halfHeight = (height * scaleY) / 2;
-  return [
-    [centerX - halfWidth, centerY + halfHeight],
-    [centerX + halfWidth, centerY + halfHeight],
-    [centerX + halfWidth, centerY - halfHeight],
-    [centerX - halfWidth, centerY - halfHeight],
-  ].map(([x, y]) => toLonLat(rotatePoint(x, y, centerX, centerY, rotation)));
+  return (
+    [
+      [centerX - halfWidth, centerY + halfHeight],
+      [centerX + halfWidth, centerY + halfHeight],
+      [centerX + halfWidth, centerY - halfHeight],
+      [centerX - halfWidth, centerY - halfHeight],
+    ] as ImageCoordinates
+  ).map(([x, y]) =>
+    toLonLat(rotatePoint(x, y, centerX, centerY, rotation)),
+  ) as ImageCoordinates;
 }
 
 function getImageLayerCoordinates(
@@ -206,6 +238,7 @@ export function createMapLibreScenarioLayerController(
   let activeScenario: TScenario | null = null;
   let featureManager: MapLibreScenarioFeatureManager | null = null;
   const activeImageLayerIds = new Set<FeatureId>();
+  const activeRasterTileLayerIds = new Set<FeatureId>();
   const imageSizes = new Map<string, { width: number; height: number }>();
   const imageSizePromises = new Map<string, Promise<{ width: number; height: number }>>();
   let activeTransform: {
@@ -340,9 +373,21 @@ export function createMapLibreScenarioLayerController(
     activeImageLayerIds.delete(layerId);
   }
 
+  function removeRasterTileLayer(layerId: FeatureId) {
+    const mlLayerId = getRasterLayerId(layerId);
+    const sourceId = getRasterSourceId(layerId);
+    try {
+      if (safeGetLayer(mlLayerId)) mlMap.removeLayer(mlLayerId);
+      if (safeGetSource(sourceId)) mlMap.removeSource(sourceId);
+    } catch {
+      // MapLibre can throw while a style is being replaced; the next style load rebuilds.
+    }
+    activeRasterTileLayerIds.delete(layerId);
+  }
+
   function addImageLayerWithCoordinates(
     layer: ScenarioImageLayer,
-    coordinates: number[][],
+    coordinates: ImageCoordinates,
   ) {
     const sourceId = getImageSourceId(layer.id);
     const mlLayerId = getImageLayerId(layer.id);
@@ -372,6 +417,20 @@ export function createMapLibreScenarioLayerController(
   }
 
   function updateImageLayerStatus(
+    layerId: FeatureId,
+    status: NonNullable<ScenarioMapLayer["_status"]>,
+  ) {
+    const scenario = activeScenario;
+    if (!scenario) return;
+    const data: ScenarioMapLayerUpdate = { _status: status };
+    scenario.geo.updateMapLayer(layerId, data, {
+      noEmit: true,
+      undoable: false,
+    });
+    emitLayerEvent({ type: "map-layer-updated", layerId, data });
+  }
+
+  function updateMapLayerStatus(
     layerId: FeatureId,
     status: NonNullable<ScenarioMapLayer["_status"]>,
   ) {
@@ -448,14 +507,62 @@ export function createMapLibreScenarioLayerController(
       });
   }
 
-  function refreshImageLayers() {
+  function addRasterTileLayer(layerId: FeatureId) {
+    const scenario = activeScenario;
+    const layer = scenario?.geo.getMapLayerById(layerId);
+    if (!isRasterTileLayer(layer)) return;
+    if (!layer.url) {
+      updateMapLayerStatus(layerId, "error");
+      return;
+    }
+
+    const sourceId = getRasterSourceId(layer.id);
+    const mlLayerId = getRasterLayerId(layer.id);
+    if (!safeGetSource(sourceId)) {
+      const source =
+        layer.type === "TileJSONLayer"
+          ? ({
+              type: "raster",
+              url: layer.url,
+            } satisfies RasterSourceSpecification)
+          : ({
+              type: "raster",
+              tiles: [layer.url],
+              tileSize: 256,
+              attribution: layer.attributions,
+            } satisfies RasterSourceSpecification);
+      mlMap.addSource(sourceId, source);
+    }
+    if (!safeGetLayer(mlLayerId)) {
+      const rasterLayer = {
+        id: mlLayerId,
+        type: "raster",
+        source: sourceId,
+        layout: {
+          visibility: layer.isHidden ? "none" : "visible",
+        },
+        paint: {
+          "raster-opacity": layer.opacity ?? 0.7,
+        },
+      } satisfies LayerSpecification;
+      mlMap.addLayer(rasterLayer);
+    }
+    activeRasterTileLayerIds.add(layer.id);
+    updateMapLayerStatus(layer.id, "initialized");
+  }
+
+  function refreshMapLayers() {
     for (const layerId of [...activeImageLayerIds]) {
       removeImageLayer(layerId);
+    }
+    for (const layerId of [...activeRasterTileLayerIds]) {
+      removeRasterTileLayer(layerId);
     }
     const scenario = activeScenario;
     if (!scenario) return;
     for (const mapLayer of scenario.geo.mapLayers?.value ?? []) {
       if (isImageLayer(mapLayer)) addImageLayer(mapLayer.id);
+      if (isRasterTileLayer(mapLayer)) addRasterTileLayer(mapLayer.id);
     }
   }
 
@@ -494,6 +601,28 @@ export function createMapLibreScenarioLayerController(
     }
   }
 
+  function updateRasterTileLayer(layerId: FeatureId, data: ScenarioMapLayerUpdate) {
+    const layer = activeScenario?.geo.getMapLayerById(layerId);
+    if (!isRasterTileLayer(layer)) return;
+    const mlLayerId = getRasterLayerId(layerId);
+
+    if ("url" in data || "attributions" in data) {
+      removeRasterTileLayer(layerId);
+      addRasterTileLayer(layerId);
+      return;
+    }
+    if (data.isHidden !== undefined && safeGetLayer(mlLayerId)) {
+      mlMap.setLayoutProperty(
+        mlLayerId,
+        "visibility",
+        data.isHidden ? "none" : "visible",
+      );
+    }
+    if (data.opacity !== undefined && safeGetLayer(mlLayerId)) {
+      mlMap.setPaintProperty(mlLayerId, "raster-opacity", data.opacity);
+    }
+  }
+
   function refreshActiveTransform(layerId: FeatureId) {
     if (activeTransform?.layerId === layerId) {
       void startMapLayerTransform(layerId);
@@ -509,17 +638,21 @@ export function createMapLibreScenarioLayerController(
       if (action === "undo") {
         if (activeTransform?.layerId === layerId) endMapLayerTransform();
         removeImageLayer(layerId);
+        removeRasterTileLayer(layerId);
       } else {
         addImageLayer(layerId);
+        addRasterTileLayer(layerId);
       }
       return;
     }
     if (label === "deleteMapLayer") {
       if (action === "undo") {
         addImageLayer(layerId);
+        addRasterTileLayer(layerId);
       } else {
         if (activeTransform?.layerId === layerId) endMapLayerTransform();
         removeImageLayer(layerId);
+        removeRasterTileLayer(layerId);
       }
       return;
     }
@@ -529,11 +662,13 @@ export function createMapLibreScenarioLayerController(
       if (isImageLayer(layer)) {
         updateImageLayer(layerId, layer);
         refreshActiveTransform(layerId);
+      } else if (isRasterTileLayer(layer)) {
+        updateRasterTileLayer(layerId, layer);
       }
       return;
     }
     if (label === "moveMapLayer") {
-      refreshImageLayers();
+      refreshMapLayers();
     }
   }
 
@@ -812,7 +947,7 @@ export function createMapLibreScenarioLayerController(
         featureIds: routingStore.obstacleFeatureIds,
       }),
     );
-    refreshImageLayers();
+    refreshMapLayers();
     refreshScenarioFeatureLayers({ doClearCache: true, filterVisible: true });
 
     const stopObstacleHighlightWatch = watch(
@@ -823,7 +958,7 @@ export function createMapLibreScenarioLayerController(
     );
 
     const onStyleLoad = () => {
-      refreshImageLayers();
+      refreshMapLayers();
       refreshScenarioFeatureLayers({ doClearCache: true });
     };
     mlMap.on("style.load", onStyleLoad);
@@ -831,20 +966,23 @@ export function createMapLibreScenarioLayerController(
     const cleanupMapLayers = scenario.geo.onMapLayerEvent((event) => {
       if (event.type === "add") {
         addImageLayer(event.id);
+        addRasterTileLayer(event.id);
       } else if (event.type === "remove") {
         if (activeTransform?.layerId === event.id) {
           endMapLayerTransform();
         }
         removeImageLayer(event.id);
+        removeRasterTileLayer(event.id);
       } else if (event.type === "update") {
         updateImageLayer(event.id, event.data);
+        updateRasterTileLayer(event.id, event.data);
         emitLayerEvent({
           type: "map-layer-updated",
           layerId: event.id,
           data: event.data,
         });
       } else if (event.type === "move") {
-        refreshImageLayers();
+        refreshMapLayers();
       }
     });
 
@@ -889,6 +1027,9 @@ export function createMapLibreScenarioLayerController(
       mlMap.off("style.load", onStyleLoad);
       for (const layerId of [...activeImageLayerIds]) {
         removeImageLayer(layerId);
+      }
+      for (const layerId of [...activeRasterTileLayerIds]) {
+        removeRasterTileLayer(layerId);
       }
       endMapLayerTransform();
       featureManager?.destroy();

--- a/src/modules/scenarioeditor/ImageMapLayerSettings.test.ts
+++ b/src/modules/scenarioeditor/ImageMapLayerSettings.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { shallowRef } from "vue";
+import ImageMapLayerSettings from "@/modules/scenarioeditor/ImageMapLayerSettings.vue";
+import { activeScenarioMapEngineKey } from "@/components/injects";
+
+describe("ImageMapLayerSettings", () => {
+  function mountComponent(layerOverrides: Record<string, unknown> = {}) {
+    return mount(ImageMapLayerSettings, {
+      props: {
+        layer: {
+          id: "image-layer-1",
+          type: "ImageLayer",
+          name: "Image",
+          url: "https://example.test/image.png",
+          _status: "initialized",
+          ...layerOverrides,
+        },
+      },
+      global: {
+        provide: {
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            layers: {
+              capabilities: {
+                mapLayerTransform: false,
+                zoomToMapLayer: true,
+                mapLayerExtent: true,
+              },
+              endMapLayerTransform: vi.fn(),
+              startMapLayerTransform: vi.fn(),
+              zoomToMapLayer: vi.fn(),
+            },
+          }),
+        },
+        stubs: {
+          DescriptionItem: {
+            props: ["label"],
+            template: "<div><span>{{ label }}</span><slot /></div>",
+          },
+        },
+      },
+    });
+  }
+
+  it("does not show the load failure before a new layer is initialized", () => {
+    const wrapper = mountComponent({
+      _isNew: true,
+      _status: "error",
+    });
+
+    expect(wrapper.text()).toContain("This layer has not been initialized yet.");
+    expect(wrapper.text()).not.toContain("Failed to load layer.");
+  });
+
+  it("shows the load failure for an existing layer that errors", () => {
+    const wrapper = mountComponent({
+      _isNew: false,
+      _status: "error",
+    });
+
+    expect(wrapper.text()).toContain("Failed to load layer.");
+  });
+});

--- a/src/modules/scenarioeditor/ImageMapLayerSettings.vue
+++ b/src/modules/scenarioeditor/ImageMapLayerSettings.vue
@@ -2,7 +2,7 @@
 import type { ScenarioImageLayer } from "@/types/scenarioGeoModels";
 import { activeScenarioMapEngineKey } from "@/components/injects";
 import { injectStrict } from "@/utils";
-import { onMounted, onUnmounted, ref, watch } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import type {
   ScenarioImageLayerUpdate,
   ScenarioMapLayerUpdate,
@@ -25,6 +25,7 @@ const engineRef = injectStrict(activeScenarioMapEngineKey);
 const editMode = ref((props.layer._isNew && !props.layer._isTemporary) ?? false);
 
 const { layerTypeLabel, status, isInitialized } = useMapLayerInfo(props.layer);
+const hasLoadFailed = computed(() => status.value === "error" && !props.layer._isNew);
 const canTransformMapLayer = () =>
   Boolean(engineRef.value?.layers.capabilities.mapLayerTransform);
 const canZoomMapLayer = () =>
@@ -98,9 +99,7 @@ function updateData(formData: ScenarioImageLayerUpdate) {
     <p v-if="!isInitialized" class="text-muted-foreground mt-2 text-sm">
       This layer has not been initialized yet.
     </p>
-    <p v-if="status === 'error'" class="mt-2 text-sm text-red-600">
-      Failed to load layer.
-    </p>
+    <p v-if="hasLoadFailed" class="mt-2 text-sm text-red-600">Failed to load layer.</p>
     <p
       v-if="isInitialized && !canTransformMapLayer()"
       class="text-muted-foreground mt-2 text-sm"

--- a/src/modules/scenarioeditor/TileMapLayerSettings.test.ts
+++ b/src/modules/scenarioeditor/TileMapLayerSettings.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi } from "vitest";
+import { mount } from "@vue/test-utils";
+import { shallowRef } from "vue";
+import TileMapLayerSettings from "@/modules/scenarioeditor/TileMapLayerSettings.vue";
+import { activeScenarioMapEngineKey } from "@/components/injects";
+
+describe("TileMapLayerSettings", () => {
+  function mountComponent(layerOverrides: Record<string, unknown> = {}) {
+    return mount(TileMapLayerSettings, {
+      props: {
+        layer: {
+          id: "tile-layer-1",
+          type: "TileJSONLayer",
+          name: "Tiles",
+          url: "https://example.test/tilejson.json",
+          _status: "initialized",
+          ...layerOverrides,
+        },
+      },
+      global: {
+        provide: {
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            layers: {
+              capabilities: {
+                zoomToMapLayer: true,
+                mapLayerExtent: true,
+              },
+              zoomToMapLayer: vi.fn(),
+            },
+          }),
+        },
+        stubs: {
+          DescriptionItem: {
+            props: ["label"],
+            template: "<div><span>{{ label }}</span><slot /></div>",
+          },
+        },
+      },
+    });
+  }
+
+  it("notes that tile map layers only support raster tiles", () => {
+    const wrapper = mountComponent();
+
+    expect(wrapper.text()).toContain(
+      "Only raster tiles are supported for TileJSON and XYZ map layers.",
+    );
+  });
+
+  it("does not show the load failure before a new layer is initialized", () => {
+    const wrapper = mountComponent({
+      _isNew: true,
+      _status: "error",
+    });
+
+    expect(wrapper.text()).toContain("This layer has not been initialized yet.");
+    expect(wrapper.text()).not.toContain("Failed to load layer.");
+  });
+
+  it("shows the load failure for an existing layer that errors", () => {
+    const wrapper = mountComponent({
+      _isNew: false,
+      _status: "error",
+    });
+
+    expect(wrapper.text()).toContain("Failed to load layer.");
+  });
+});

--- a/src/modules/scenarioeditor/TileMapLayerSettings.vue
+++ b/src/modules/scenarioeditor/TileMapLayerSettings.vue
@@ -20,6 +20,7 @@ const props = defineProps<Props>();
 const emit = defineEmits(["update"]);
 const engineRef = injectStrict(activeScenarioMapEngineKey);
 const { status, isInitialized, layerTypeLabel } = useMapLayerInfo(props.layer);
+const hasLoadFailed = computed(() => status.value === "error" && !props.layer._isNew);
 const canZoomMapLayer = () =>
   Boolean(engineRef.value?.layers.capabilities.zoomToMapLayer) &&
   Boolean(engineRef.value?.layers.capabilities.mapLayerExtent);
@@ -61,6 +62,9 @@ function updateData(formData: ScenarioTileJSONLayerUpdate | ScenarioXYZLayerUpda
     <header class="flex justify-end">
       <span class="badge">{{ layerTypeLabel }}</span>
     </header>
+    <p class="text-muted-foreground mt-3 text-sm">
+      Only raster tiles are supported for TileJSON and XYZ map layers.
+    </p>
     <TileMapLayerSettingsForm
       v-if="editMode"
       :key="layer.id"
@@ -79,8 +83,6 @@ function updateData(formData: ScenarioTileJSONLayerUpdate | ScenarioXYZLayerUpda
     <p v-if="!isInitialized" class="text-muted-foreground mt-2 text-sm">
       This layer has not been initialized yet.
     </p>
-    <p v-if="status === 'error'" class="mt-2 text-sm text-red-600">
-      Failed to load layer.
-    </p>
+    <p v-if="hasLoadFailed" class="mt-2 text-sm text-red-600">Failed to load layer.</p>
   </section>
 </template>


### PR DESCRIPTION
- Implement logic to add, update, and remove `TileJSONLayer` and `XYZLayer` types with support for visibility, opacity, and error handling.
- Introduce tests to validate layer rendering, style updates, and undo/redo behavior.
- Update map layer operations to support both image and raster tile layers.
