### PR TITLE
Add MapLibre custom symbols and fix scaled unit label offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file.
 - Added feature hover tooltips to MapLibre mode.
 - Fixed MapLibre scenario feature marker sizes so point features match OpenLayers sizing.
 - Fixed MapLibre scenario feature rendering for null polygon fills and zero-opacity fills.
+- Added MapLibre support for custom unit symbols, including clearer selected-state highlighting.
+- Fixed MapLibre unit labels so they shift correctly for scaled ordinary and custom icons, including hostile diamond frames.
 
 ## April 2026
 

--- a/src/modules/maplibreview/MlMapLogic.test.ts
+++ b/src/modules/maplibreview/MlMapLogic.test.ts
@@ -363,6 +363,7 @@ describe("MlMapLogic", () => {
     expect(getAddedLayerSpec(mockMap, "unitLayer")?.layout).toMatchObject({
       "icon-rotation-alignment": "viewport",
       "text-rotation-alignment": "viewport",
+      "text-offset": ["get", "textOffset"],
     });
     expect(mockMap.getSource("unitSource")?.setData).toHaveBeenCalled();
     expect(mockMap.map.setCenter).toHaveBeenCalledWith([10, 20]);
@@ -467,6 +468,100 @@ describe("MlMapLogic", () => {
       "SFGPUCI----K",
       expect.objectContaining({ size: 32 }),
     );
+  });
+
+  it("scales MapLibre unit label offset with ordinary icon size overrides", () => {
+    const mockMap = createMockMap();
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    useMapSettingsStore(pinia).mapUnitLabelBelow = true;
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-maplibre-label-offset-size-override",
+          currentTime: 0,
+          featureStateCounter: 0,
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => [
+          {
+            id: "unit-label-offset",
+            sidc: "SFGPUCI----K",
+            shortName: "A1",
+            name: "Alpha 1",
+            style: {
+              mapSymbolSize: 60,
+            },
+            _state: {
+              location: [10, 20],
+            },
+          },
+        ]),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    mountMlMapLogic({ mockMap, activeScenario, pinia });
+
+    const setDataCalls = mockMap.getSource("unitSource")?.setData.mock.calls ?? [];
+    const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
+    expect(unitData.features[0].properties).toMatchObject({
+      label: "A1",
+      textOffset: [0, 3],
+    });
+  });
+
+  it("adds extra MapLibre unit label clearance for scaled hostile diamond icons", () => {
+    const mockMap = createMockMap();
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    useMapSettingsStore(pinia).mapUnitLabelBelow = true;
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-maplibre-hostile-label-offset",
+          currentTime: 0,
+          featureStateCounter: 0,
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => [
+          {
+            id: "unit-hostile-label-offset",
+            sidc: "10061000000000000000",
+            shortName: "H1",
+            name: "Hostile 1",
+            style: {
+              mapSymbolSize: 60,
+            },
+            _state: {
+              location: [10, 20],
+            },
+          },
+        ]),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    mountMlMapLogic({ mockMap, activeScenario, pinia });
+
+    const setDataCalls = mockMap.getSource("unitSource")?.setData.mock.calls ?? [];
+    const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
+    expect(unitData.features[0].properties).toMatchObject({
+      label: "H1",
+      textOffset: [0, 3.75],
+    });
   });
 
   it("registers custom MapLibre unit symbols without generating milsymbols", async () => {
@@ -653,6 +748,61 @@ describe("MlMapLogic", () => {
 
     expect(source?.setData.mock.calls.length).toBeGreaterThan(initialCallCount);
     restoreImage();
+  });
+
+  it("scales MapLibre unit label offset with custom icon scale", () => {
+    const mockMap = createMockMap();
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const mapSettings = useMapSettingsStore(pinia);
+    mapSettings.mapUnitLabelBelow = true;
+    mapSettings.mapIconSize = 40;
+    mapSettings.mapCustomIconScale = 2;
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-maplibre-custom-label-offset",
+          currentTime: 0,
+          featureStateCounter: 0,
+          customSymbolMap: {
+            "custom-1": {
+              id: "custom-1",
+              name: "Custom",
+              src: "data:image/png;base64,custom",
+              sidc: "10031000000000000000",
+            },
+          },
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => [
+          {
+            id: "unit-custom-label-offset",
+            sidc: "custom1:10031000000000000000:custom-1",
+            shortName: "C1",
+            name: "Custom 1",
+            _state: {
+              location: [10, 20],
+            },
+          },
+        ]),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    mountMlMapLogic({ mockMap, activeScenario, pinia });
+
+    const setDataCalls = mockMap.getSource("unitSource")?.setData.mock.calls ?? [];
+    const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
+    expect(unitData.features[0].properties).toMatchObject({
+      label: "C1",
+      textOffset: [0, 4],
+    });
   });
 
   it("refreshes MapLibre units when unitStateCounter changes after a size override", async () => {

--- a/src/modules/maplibreview/MlMapLogic.test.ts
+++ b/src/modules/maplibreview/MlMapLogic.test.ts
@@ -162,6 +162,7 @@ function createMockMap() {
     removeFeatureState: vi.fn(),
     hasImage: vi.fn(() => false),
     addImage: vi.fn(),
+    removeImage: vi.fn(),
     queryRenderedFeatures: vi.fn(() => []),
     getCanvas: vi.fn(() => canvas),
     getCanvasContainer: vi.fn(() => canvasContainer),
@@ -188,6 +189,26 @@ function createMockMap() {
     emit(event: string, payload?: unknown) {
       listeners.get(event)?.forEach((handler) => handler(payload));
     },
+  };
+}
+
+function mockLoadedImage(width = 20, height = 10) {
+  const previousImage = globalThis.Image;
+  class MockImage {
+    crossOrigin = "";
+    naturalWidth = width;
+    naturalHeight = height;
+    width = width;
+    height = height;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    set src(_value: string) {
+      setTimeout(() => this.onload?.(), 0);
+    }
+  }
+  vi.stubGlobal("Image", MockImage as any);
+  return () => {
+    vi.stubGlobal("Image", previousImage);
   };
 }
 
@@ -270,7 +291,12 @@ describe("MlMapLogic", () => {
     vi.mocked(symbolGenerator).mockClear();
     vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
       drawImage: vi.fn(),
-      getImageData: () => ({ width: 2, height: 2, data: new Uint8ClampedArray(16) }),
+      fillRect: vi.fn(),
+      getImageData: (_x: number, _y: number, width: number, height: number) => ({
+        width,
+        height,
+        data: new Uint8ClampedArray(width * height * 4),
+      }),
     } as any);
     useMapSettingsStore().mapLibreUnitRotationMode = "screen";
     useMapSettingsStore().showFeatureTooltip = true;
@@ -441,6 +467,192 @@ describe("MlMapLogic", () => {
       "SFGPUCI----K",
       expect.objectContaining({ size: 32 }),
     );
+  });
+
+  it("registers custom MapLibre unit symbols without generating milsymbols", async () => {
+    const restoreImage = mockLoadedImage();
+    const mockMap = createMockMap();
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-maplibre-custom-symbol",
+          currentTime: 0,
+          featureStateCounter: 0,
+          customSymbolMap: {
+            "custom-1": {
+              id: "custom-1",
+              name: "Custom",
+              src: "data:image/png;base64,custom",
+              sidc: "10031000000000000000",
+              anchor: [0.25, 0.75],
+            },
+          },
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({ fillColor: "#112233" })),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => [
+          {
+            id: "unit-custom",
+            sidc: "custom1:10031000000000000000:custom-1",
+            shortName: "C1",
+            name: "Custom 1",
+            _state: {
+              location: [10, 20],
+            },
+          },
+        ]),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    mountMlMapLogic({ mockMap, activeScenario });
+
+    const setDataCalls = mockMap.getSource("unitSource")?.setData.mock.calls ?? [];
+    const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
+    const symbolKey = unitData.features[0].properties.symbolKey;
+    mockMap.emit("styleimagemissing", { id: symbolKey });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(symbolGenerator).not.toHaveBeenCalled();
+    expect(mockMap.map.addImage).toHaveBeenCalledWith(
+      symbolKey,
+      expect.objectContaining({ width: expect.any(Number), height: expect.any(Number) }),
+      { pixelRatio: 2 },
+    );
+    restoreImage();
+  });
+
+  it("registers selected custom MapLibre unit symbols", async () => {
+    const restoreImage = mockLoadedImage();
+    const mockMap = createMockMap();
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    useSelectedItems().selectedUnitIds.value.add("unit-custom-selected");
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-maplibre-selected-custom-symbol",
+          currentTime: 0,
+          featureStateCounter: 0,
+          customSymbolMap: {
+            "custom-1": {
+              id: "custom-1",
+              name: "Custom",
+              src: "data:image/png;base64,custom",
+              sidc: "10031000000000000000",
+            },
+          },
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => [
+          {
+            id: "unit-custom-selected",
+            sidc: "custom1:10031000000000000000:custom-1",
+            shortName: "C1",
+            name: "Custom 1",
+            _state: {
+              location: [10, 20],
+            },
+          },
+        ]),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    mountMlMapLogic({ mockMap, activeScenario, pinia });
+
+    const setDataCalls = mockMap.getSource("unitSource")?.setData.mock.calls ?? [];
+    const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
+    const symbolKey = unitData.features[0].properties.symbolKey;
+    expect(symbolKey).toMatch(/^sel-/);
+    mockMap.emit("styleimagemissing", { id: symbolKey });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(symbolGenerator).not.toHaveBeenCalled();
+    expect(mockMap.map.addImage).toHaveBeenCalledWith(symbolKey, expect.any(Object), {
+      pixelRatio: 2,
+    });
+    restoreImage();
+  });
+
+  it("uses scaled custom symbol size and refreshes when custom scale changes", async () => {
+    const restoreImage = mockLoadedImage();
+    const mockMap = createMockMap();
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const mapSettings = useMapSettingsStore(pinia);
+    mapSettings.mapIconSize = 40;
+    mapSettings.mapCustomIconScale = 2;
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-maplibre-custom-symbol-scale",
+          currentTime: 0,
+          featureStateCounter: 0,
+          customSymbolMap: {
+            "custom-1": {
+              id: "custom-1",
+              name: "Custom",
+              src: "data:image/png;base64,custom",
+              sidc: "10031000000000000000",
+            },
+          },
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => [
+          {
+            id: "unit-custom-scale",
+            sidc: "custom1:10031000000000000000:custom-1",
+            shortName: "C1",
+            name: "Custom 1",
+            style: { mapSymbolSize: 30 },
+            _state: {
+              location: [10, 20],
+            },
+          },
+        ]),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    mountMlMapLogic({ mockMap, activeScenario, pinia });
+
+    const source = mockMap.getSource("unitSource");
+    const initialCallCount = source?.setData.mock.calls.length ?? 0;
+    const setDataCalls = source?.setData.mock.calls ?? [];
+    const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
+    const symbolKey = unitData.features[0].properties.symbolKey;
+    mockMap.emit("styleimagemissing", { id: symbolKey });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const addImageCalls = mockMap.map.addImage.mock.calls;
+    expect(addImageCalls[addImageCalls.length - 1]?.[1]).toMatchObject({
+      width: 120,
+      height: 120,
+    });
+
+    mapSettings.mapCustomIconScale = 3;
+    await nextTick();
+
+    expect(source?.setData.mock.calls.length).toBeGreaterThan(initialCallCount);
+    restoreImage();
   });
 
   it("refreshes MapLibre units when unitStateCounter changes after a size override", async () => {

--- a/src/modules/maplibreview/MlMapLogic.vue
+++ b/src/modules/maplibreview/MlMapLogic.vue
@@ -55,6 +55,7 @@ import { useMaplibreDayNightTerminator } from "@/composables/maplibreDayNightTer
 import { provideMapHoverContext, type HoverFeatureLike } from "@/composables/geoHover";
 import MapHoverFeatureTooltip from "@/components/MapHoverFeatureTooltip.vue";
 import { CUSTOM_SYMBOL_PREFIX, CUSTOM_SYMBOL_SLICE } from "@/config/constants";
+import { SID_INDEX } from "@/symbology/sidc";
 
 const UNIT_LAYER_ID = "unitLayer";
 const UNIT_LAYER_PREFIX = `${UNIT_LAYER_ID}-`;
@@ -232,7 +233,7 @@ function createUnitLayerSpec(
       "text-rotate": ["get", "symbolRotation"],
       "text-rotation-alignment": alignment.text,
       "text-font": ["Noto Sans Italic"],
-      "text-offset": [0, 1.5],
+      "text-offset": ["get", "textOffset"],
       "text-anchor": "top",
       "text-size": 12,
       "icon-allow-overlap": true,
@@ -295,6 +296,15 @@ function getUnitMapSymbolSize(unit: { style?: { mapSymbolSize?: number } }) {
   return typeof unit.style?.mapSymbolSize === "number"
     ? unit.style.mapSymbolSize
     : mapSettings.mapIconSize;
+}
+
+function isHostileSidc(sidc: string) {
+  return sidc[SID_INDEX] === "6";
+}
+
+function getUnitLabelOffsetY(symbolSize: number, sidc: string) {
+  const frameMultiplier = isHostileSidc(sidc) ? 1.25 : 1;
+  return Math.max(1.5, (symbolSize / 20) * frameMultiplier);
 }
 
 function getCustomSymbolId(sidc: string) {
@@ -883,19 +893,24 @@ function addUnits(
       const customSymbol = customSymbolId
         ? activeScenario.store.state.customSymbolMap[customSymbolId]
         : undefined;
+      const baseSymbolSize = getUnitMapSymbolSize(unit);
+      const renderedSymbolSize =
+        customSymbol && customSymbolId
+          ? baseSymbolSize * (mapSettings.mapCustomIconScale || 1.7)
+          : baseSymbolSize;
       const symbolData: SymbolCacheEntry =
         customSymbol && customSymbolId
           ? {
               kind: "custom",
               customSymbol,
-              size: getUnitMapSymbolSize(unit) * (mapSettings.mapCustomIconScale || 1.7),
+              size: renderedSymbolSize,
               color: combinedSymbolOptions.fillColor,
             }
           : {
               kind: "milsymbol",
               sidc: unit.sidc,
               symbolOptions: {
-                size: getUnitMapSymbolSize(unit),
+                size: renderedSymbolSize,
                 ...combinedSymbolOptions,
               },
               textAmplifiers,
@@ -927,6 +942,7 @@ function addUnits(
           label: mapSettings.mapUnitLabelBelow
             ? unit.shortName || unit.name || "Unnamed Unit"
             : "",
+          textOffset: [0, getUnitLabelOffsetY(renderedSymbolSize, unit.sidc)],
           symbolRotation,
         },
       } as Feature;

--- a/src/modules/maplibreview/MlMapLogic.vue
+++ b/src/modules/maplibreview/MlMapLogic.vue
@@ -314,15 +314,17 @@ function createCustomSymbolImage(
     if (!(width > 0 && height > 0)) return;
 
     const pixelRatio = 2;
+    const isSelected = imageId.startsWith("sel-");
+    const highlightPadding = isSelected ? Math.max(8, Math.ceil(size * 0.3)) : 0;
     const anchor = customSymbol.anchor ?? [0.5, 0.5];
     const anchorX = anchor[0] * size;
     const anchorY = anchor[1] * size;
     const halfW = Math.max(anchorX, size - anchorX);
     const halfH = Math.max(anchorY, size - anchorY);
-    const paddedWidth = Math.ceil(2 * halfW * pixelRatio);
-    const paddedHeight = Math.ceil(2 * halfH * pixelRatio);
-    const drawX = Math.round((halfW - anchorX) * pixelRatio);
-    const drawY = Math.round((halfH - anchorY) * pixelRatio);
+    const paddedWidth = Math.ceil((2 * halfW + highlightPadding * 2) * pixelRatio);
+    const paddedHeight = Math.ceil((2 * halfH + highlightPadding * 2) * pixelRatio);
+    const drawX = Math.round((halfW - anchorX + highlightPadding) * pixelRatio);
+    const drawY = Math.round((halfH - anchorY + highlightPadding) * pixelRatio);
     const drawSize = Math.round(size * pixelRatio);
 
     const canvas = document.createElement("canvas");
@@ -330,14 +332,35 @@ function createCustomSymbolImage(
     canvas.height = paddedHeight;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
-    const isSelected = imageId.startsWith("sel-");
     if (isSelected) {
+      const outlineCanvas = document.createElement("canvas");
+      outlineCanvas.width = drawSize;
+      outlineCanvas.height = drawSize;
+      const outlineCtx = outlineCanvas.getContext("2d");
+      if (outlineCtx) {
+        outlineCtx.drawImage(image, 0, 0, drawSize, drawSize);
+        outlineCtx.globalCompositeOperation = "source-in";
+        outlineCtx.fillStyle = "yellow";
+        outlineCtx.fillRect(0, 0, drawSize, drawSize);
+        const outlineWidth = Math.max(4, Math.round(size * 0.12 * pixelRatio));
+        for (const [offsetX, offsetY] of [
+          [-outlineWidth, 0],
+          [outlineWidth, 0],
+          [0, -outlineWidth],
+          [0, outlineWidth],
+          [-outlineWidth, -outlineWidth],
+          [outlineWidth, -outlineWidth],
+          [-outlineWidth, outlineWidth],
+          [outlineWidth, outlineWidth],
+        ]) {
+          ctx.drawImage(outlineCanvas, drawX + offsetX, drawY + offsetY);
+        }
+      }
       ctx.shadowColor = "yellow";
-      ctx.shadowBlur = Math.max(6, Math.round(size * 0.2));
-      ctx.drawImage(image, drawX, drawY, drawSize, drawSize);
-      ctx.shadowBlur = 0;
+      ctx.shadowBlur = Math.max(10, Math.round(size * 0.35));
     }
     ctx.drawImage(image, drawX, drawY, drawSize, drawSize);
+    ctx.shadowBlur = 0;
     if (color && typeof ctx.fillRect === "function") {
       ctx.globalCompositeOperation = "source-atop";
       ctx.fillStyle = color;

--- a/src/modules/maplibreview/MlMapLogic.vue
+++ b/src/modules/maplibreview/MlMapLogic.vue
@@ -10,7 +10,7 @@ import {
   type PointLike,
 } from "maplibre-gl";
 import type { TScenario } from "@/scenariostore";
-import type { TextAmplifiers } from "@/types/scenarioModels";
+import type { CustomSymbol, TextAmplifiers } from "@/types/scenarioModels";
 import { computed, onUnmounted, provide, watch, watchEffect } from "vue";
 import type { Feature, Position } from "geojson";
 import type { Pixel } from "ol/pixel";
@@ -54,6 +54,7 @@ import { useRoutingStore } from "@/stores/routingStore";
 import { useMaplibreDayNightTerminator } from "@/composables/maplibreDayNightTerminator";
 import { provideMapHoverContext, type HoverFeatureLike } from "@/composables/geoHover";
 import MapHoverFeatureTooltip from "@/components/MapHoverFeatureTooltip.vue";
+import { CUSTOM_SYMBOL_PREFIX, CUSTOM_SYMBOL_SLICE } from "@/config/constants";
 
 const UNIT_LAYER_ID = "unitLayer";
 const UNIT_LAYER_PREFIX = `${UNIT_LAYER_ID}-`;
@@ -80,12 +81,22 @@ provide(activeScenarioKey, activeScenario);
 const { unitActions } = activeScenario;
 const getUnitById = activeScenario.helpers?.getUnitById ?? (() => undefined);
 
-type SymbolCacheEntry = {
+type MilSymbolCacheEntry = {
+  kind: "milsymbol";
   sidc: string;
   symbolOptions: ReturnType<typeof unitActions.getCombinedSymbolOptions>;
   textAmplifiers: Omit<TextAmplifiers, "uniqueDesignation">;
   uniqueDesignation: string;
 };
+
+type CustomSymbolCacheEntry = {
+  kind: "custom";
+  customSymbol: CustomSymbol;
+  size: number;
+  color?: string;
+};
+
+type SymbolCacheEntry = MilSymbolCacheEntry | CustomSymbolCacheEntry;
 
 const symbolCache: Map<string, SymbolCacheEntry> = new Map();
 const usedImageIds = new Set<string>();
@@ -286,6 +297,69 @@ function getUnitMapSymbolSize(unit: { style?: { mapSymbolSize?: number } }) {
     : mapSettings.mapIconSize;
 }
 
+function getCustomSymbolId(sidc: string) {
+  return sidc.startsWith(CUSTOM_SYMBOL_PREFIX) ? sidc.slice(CUSTOM_SYMBOL_SLICE) : "";
+}
+
+function createCustomSymbolImage(
+  imageId: string,
+  { customSymbol, size, color }: CustomSymbolCacheEntry,
+) {
+  const image = new Image();
+  image.crossOrigin = "anonymous";
+  image.onload = () => {
+    if (mlMap.hasImage(imageId)) return;
+    const width = image.naturalWidth || image.width;
+    const height = image.naturalHeight || image.height;
+    if (!(width > 0 && height > 0)) return;
+
+    const pixelRatio = 2;
+    const anchor = customSymbol.anchor ?? [0.5, 0.5];
+    const anchorX = anchor[0] * size;
+    const anchorY = anchor[1] * size;
+    const halfW = Math.max(anchorX, size - anchorX);
+    const halfH = Math.max(anchorY, size - anchorY);
+    const paddedWidth = Math.ceil(2 * halfW * pixelRatio);
+    const paddedHeight = Math.ceil(2 * halfH * pixelRatio);
+    const drawX = Math.round((halfW - anchorX) * pixelRatio);
+    const drawY = Math.round((halfH - anchorY) * pixelRatio);
+    const drawSize = Math.round(size * pixelRatio);
+
+    const canvas = document.createElement("canvas");
+    canvas.width = paddedWidth;
+    canvas.height = paddedHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    const isSelected = imageId.startsWith("sel-");
+    if (isSelected) {
+      ctx.shadowColor = "yellow";
+      ctx.shadowBlur = Math.max(6, Math.round(size * 0.2));
+      ctx.drawImage(image, drawX, drawY, drawSize, drawSize);
+      ctx.shadowBlur = 0;
+    }
+    ctx.drawImage(image, drawX, drawY, drawSize, drawSize);
+    if (color && typeof ctx.fillRect === "function") {
+      ctx.globalCompositeOperation = "source-atop";
+      ctx.fillStyle = color;
+      ctx.fillRect(drawX, drawY, drawSize, drawSize);
+      ctx.globalCompositeOperation = "source-over";
+    }
+
+    try {
+      const data = ctx.getImageData(0, 0, paddedWidth, paddedHeight);
+      if (data) {
+        mlMap.addImage(imageId, data, { pixelRatio });
+        usedImageIds.add(imageId);
+      }
+    } catch {
+      mlMap.addImage(imageId, image);
+      usedImageIds.add(imageId);
+    }
+  };
+  image.onerror = () => {};
+  image.src = customSymbol.src;
+}
+
 function setupMapLayers() {
   !mlMap.getSource("unitSource") &&
     mlMap.addSource("unitSource", {
@@ -307,13 +381,18 @@ function styleImageMissing(e: MapStyleImageMissingEvent) {
 
   const isSelected = e.id.startsWith("sel-");
   const symbolCode = isSelected ? e.id.slice(4) : e.id;
+  const cachedSymbol = symbolCache.get(symbolCode);
+  if (cachedSymbol?.kind === "custom") {
+    createCustomSymbolImage(e.id, cachedSymbol);
+    return;
+  }
 
   const {
     sidc = "xxxxxxx",
     symbolOptions = {},
     textAmplifiers = {},
     uniqueDesignation = "",
-  } = symbolCache.get(symbolCode) ?? {};
+  } = cachedSymbol?.kind === "milsymbol" ? cachedSymbol : {};
 
   const options = isSelected
     ? { outlineWidth: 20, outlineColor: "yellow" }
@@ -708,8 +787,13 @@ watch(
 
 watch(selectedUnitIds, () => addUnits(), { deep: true });
 
-watch([() => mapSettings.mapUnitLabelBelow, () => mapSettings.mapIconSize], () =>
-  addUnits(),
+watch(
+  [
+    () => mapSettings.mapUnitLabelBelow,
+    () => mapSettings.mapIconSize,
+    () => mapSettings.mapCustomIconScale,
+  ],
+  () => addUnits(),
 );
 
 watch(mapLibreUnitRotationMode, () => {
@@ -772,15 +856,28 @@ function addUnits(
           : resolvedUniqueDesignation;
       const { size: _symbolOptionSize, ...combinedSymbolOptions } =
         unitActions.getCombinedSymbolOptions(unit);
-      const symbolData: SymbolCacheEntry = {
-        sidc: unit.sidc,
-        symbolOptions: {
-          size: getUnitMapSymbolSize(unit),
-          ...combinedSymbolOptions,
-        },
-        textAmplifiers,
-        uniqueDesignation: symbolUniqueDesignation,
-      };
+      const customSymbolId = getCustomSymbolId(unit.sidc);
+      const customSymbol = customSymbolId
+        ? activeScenario.store.state.customSymbolMap[customSymbolId]
+        : undefined;
+      const symbolData: SymbolCacheEntry =
+        customSymbol && customSymbolId
+          ? {
+              kind: "custom",
+              customSymbol,
+              size: getUnitMapSymbolSize(unit) * (mapSettings.mapCustomIconScale || 1.7),
+              color: combinedSymbolOptions.fillColor,
+            }
+          : {
+              kind: "milsymbol",
+              sidc: unit.sidc,
+              symbolOptions: {
+                size: getUnitMapSymbolSize(unit),
+                ...combinedSymbolOptions,
+              },
+              textAmplifiers,
+              uniqueDesignation: symbolUniqueDesignation,
+            };
       const symbolKey = hashObject(symbolData);
       if (!symbolCache.has(symbolKey)) {
         symbolCache.set(symbolKey, symbolData);


### PR DESCRIPTION
## Summary
- Added custom unit symbol support in MapLibre mode, matching OpenLayers behavior for lookup, scaling, selection highlighting, and fallback rendering.
- Fixed unit label placement so scaled ordinary icons, custom icons, and hostile diamond frames keep the label clear of the symbol.
- Updated the changelog to document the MapLibre custom symbol work and label-offset fixes.

## Testing
- Added MapLibre unit-rendering coverage for custom symbols, selected custom symbols, size overrides, custom scale refreshes, and label-offset behavior.
- Verified the OpenLayers unit-style baseline still passes.
- Ran `type-check` and diff whitespace checks successfully.