### PR TITLE
Fix layer stack mapping to account for data layers and add test for temporary reference layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Temporary KML/KMZ reference layers are no longer saved into serialized scenarios.
 - MapLibre scenario feature labels now honor the configured `text-offset-x`/`text-offset-y` (previously a fixed offset was used). Pixel values are converted to ems to match OpenLayers sizing.
 - Circle drawing now works in MapLibre mode.
 - Fixed scenario timeline alignment across daylight saving time transitions by recomputing the timezone offset from the current scenario time.

--- a/src/scenariostore/io.test.ts
+++ b/src/scenariostore/io.test.ts
@@ -61,6 +61,10 @@ function getOverlayLayers(scenario: { layerStack: any[] }) {
   return scenario.layerStack.filter((layer) => layer.kind === "overlay");
 }
 
+function getReferenceLayers(scenario: { layerStack: any[] }) {
+  return scenario.layerStack.filter((layer) => layer.kind === "reference");
+}
+
 describe("Scenario IO", () => {
   it("creates empty scenarios with items[] layers", () => {
     const scenario = createEmptyScenario();
@@ -69,6 +73,46 @@ describe("Scenario IO", () => {
     expect(getOverlayLayers(scenario)[0]).toHaveProperty("items");
     expect(getOverlayLayers(scenario)[0]).not.toHaveProperty("features");
     expect((getOverlayLayers(scenario)[0] as any).items).toEqual([]);
+  });
+
+  it("does not serialize temporary reference layers", () => {
+    const state = createMinimalState({
+      layerStack: ["temporary-kml-layer", "persistent-image-layer"],
+      layerStackMap: {
+        "temporary-kml-layer": {
+          id: "temporary-kml-layer",
+          kind: "reference",
+          name: "Dropped KML",
+          source: {
+            id: "temporary-kml-layer",
+            type: "KMLLayer",
+            name: "Dropped KML",
+            url: "blob:http://localhost/temporary-kml",
+            _isTemporary: true,
+          },
+        },
+        "persistent-image-layer": {
+          id: "persistent-image-layer",
+          kind: "reference",
+          name: "Saved image",
+          source: {
+            id: "persistent-image-layer",
+            type: "ImageLayer",
+            name: "Saved image",
+            url: "https://example.test/map.png",
+          },
+        },
+      },
+    });
+
+    const store = { state } as NewScenarioStore;
+    const storeRef = shallowRef(store);
+    const { serializeToObject } = useScenarioIO(storeRef);
+    const serialized = serializeToObject();
+
+    expect(getReferenceLayers(serialized).map((layer) => layer.id)).toEqual([
+      "persistent-image-layer",
+    ]);
   });
 
   it("loads geometry items[] into the same normalized store state as legacy features[]", () => {

--- a/src/scenariostore/io.ts
+++ b/src/scenariostore/io.ts
@@ -55,6 +55,7 @@ import type {
   ScenarioStackLayer,
 } from "@/types/scenarioStackLayers";
 import {
+  isScenarioDataLayer,
   isScenarioOverlayLayer,
   isScenarioReferenceLayer,
 } from "@/types/scenarioStackLayers";
@@ -326,12 +327,13 @@ function getLayerStack(state: ScenarioState): ScenarioStackLayer[] {
     getStoredReferenceLayers(state).map((layer) => [layer.id, layer] as const),
   );
   return state.layerStack
-    .map(
-      (id) =>
-        overlayLayers.get(String(id)) ??
-        referenceLayers.get(String(id)) ??
-        state.layerStackMap[id],
-    )
+    .map((id) => {
+      const layer = state.layerStackMap[id];
+      if (isScenarioOverlayLayer(layer)) return overlayLayers.get(String(id));
+      if (isScenarioReferenceLayer(layer)) return referenceLayers.get(String(id));
+      if (isScenarioDataLayer(layer)) return layer;
+      return undefined;
+    })
     .filter(Boolean) as ScenarioStackLayer[];
 }
 


### PR DESCRIPTION
Update `getLayerStack` to properly handle scenario data layers, ensuring they are included in the layer stack when appropriate. Add a test case to verify that temporary reference layers are correctly excluded from serialization.
