### PR TITLE
fix/maplibre kml layer order

### DIFF
--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
@@ -115,7 +115,19 @@ function createMockMap() {
       sources.delete(id);
     }),
     getLayer: vi.fn((id: string) => layers.get(id)),
-    addLayer: vi.fn((layer: { id: string }) => {
+    getStyle: vi.fn(() => ({
+      layers: [...layers.values()],
+    })),
+    addLayer: vi.fn((layer: { id: string }, beforeId?: string) => {
+      if (beforeId !== undefined && layers.has(beforeId)) {
+        const entries = [...layers.entries()];
+        layers.clear();
+        for (const [id, value] of entries) {
+          if (id === beforeId) layers.set(layer.id, layer);
+          layers.set(id, value);
+        }
+        return;
+      }
       layers.set(layer.id, layer);
     }),
     removeLayer: vi.fn((id: string) => {
@@ -666,6 +678,49 @@ describe("createMapLibreScenarioLayerController", () => {
       { extent: [10, 20, 12, 22], _isNew: false },
       { noEmit: true, undoable: false },
     );
+  });
+
+  it("inserts KML layers below pre-existing unit layers so units stay topmost", async () => {
+    const mockMap = createMockMap();
+    // Simulate the unit layer registered by MlMapLogic before KML loads.
+    mockMap.map.addLayer({ id: "unitLayer" } as any);
+    mockMap.map.addLayer({ id: "unitLayer-always" } as any);
+    const { scenario, mapLayers } = createScenario();
+    mapLayers.value = [
+      {
+        id: "kml-1",
+        type: "KMLLayer",
+        name: "Reference KML",
+        url: testKml,
+        extractStyles: true,
+        showPointNames: true,
+      },
+    ];
+    const controller = createMapLibreScenarioLayerController({
+      getNativeMap: () => mockMap.map,
+      fitGeometry: vi.fn(),
+      fitExtent: vi.fn(),
+      animateView: vi.fn(),
+    } as any);
+
+    controller.bindScenario(scenario);
+    await flushPromises();
+
+    const kmlAddCalls = mockMap.map.addLayer.mock.calls.filter(
+      ([spec]: [any]) =>
+        typeof spec?.id === "string" && spec.id.startsWith("scenario-kml-layer-"),
+    );
+    expect(kmlAddCalls.length).toBeGreaterThan(0);
+    for (const call of kmlAddCalls) {
+      expect(call[1]).toBe("unitLayer");
+    }
+    const orderedLayerIds = [...mockMap.layers.keys()];
+    const firstUnitIndex = orderedLayerIds.indexOf("unitLayer");
+    const firstKmlIndex = orderedLayerIds.findIndex((id) =>
+      id.startsWith("scenario-kml-layer-"),
+    );
+    expect(firstKmlIndex).toBeGreaterThanOrEqual(0);
+    expect(firstKmlIndex).toBeLessThan(firstUnitIndex);
   });
 
   it("renders labels from a point-only label source for mixed KML geometries", async () => {

--- a/src/geo/engines/maplibre/unitLayer.ts
+++ b/src/geo/engines/maplibre/unitLayer.ts
@@ -1,0 +1,22 @@
+import type { Map as MlMap } from "maplibre-gl";
+
+export const UNIT_LAYER_ID = "unitLayer";
+export const UNIT_LAYER_PREFIX = `${UNIT_LAYER_ID}-`;
+
+export function isUnitLayerId(layerId: string | undefined | null) {
+  return layerId === UNIT_LAYER_ID || (layerId?.startsWith(UNIT_LAYER_PREFIX) ?? false);
+}
+
+export function findFirstUnitLayerId(mlMap: MlMap): string | undefined {
+  try {
+    const styleLayers = mlMap.getStyle?.()?.layers;
+    if (!Array.isArray(styleLayers)) return undefined;
+    for (const layer of styleLayers) {
+      const id = (layer as { id?: unknown }).id;
+      if (typeof id === "string" && isUnitLayerId(id)) return id;
+    }
+  } catch {
+    // MapLibre may throw if the style is still loading.
+  }
+  return undefined;
+}

--- a/src/geo/kml/maplibre/index.ts
+++ b/src/geo/kml/maplibre/index.ts
@@ -9,12 +9,11 @@ import type { ReferenceFeatureSelection } from "@/types/referenceFeature";
 import type { ScenarioKMLLayer } from "@/types/scenarioGeoModels";
 import type { ScenarioMapLayerUpdate } from "@/types/internalModels";
 import { loadKmlLayerData, type ParsedKmlLayerData } from "@/geo/kml";
+import { findFirstUnitLayerId } from "@/geo/engines/maplibre/unitLayer";
 
 const KML_SOURCE_PREFIX = "scenario-kml-source-";
 const KML_LABEL_SOURCE_PREFIX = "scenario-kml-label-source-";
 const KML_LAYER_PREFIX = "scenario-kml-layer-";
-const UNIT_LAYER_ID = "unitLayer";
-const UNIT_LAYER_PREFIX = `${UNIT_LAYER_ID}-`;
 
 const KML_LAYER_SUFFIXES = [
   "polygon-fill",
@@ -370,7 +369,7 @@ export function createMapLibreKmlLayerRenderer(
           mlMap.addLayer(spec, beforeId);
           continue;
         } catch {
-          // Fallback if beforeId was removed between lookup and addLayer.
+          // beforeId may have been removed between lookup and addLayer.
         }
       }
       mlMap.addLayer(spec);
@@ -491,21 +490,6 @@ export function createMapLibreKmlLayerRenderer(
       image.src = href;
     });
   }
-}
-
-function findFirstUnitLayerId(mlMap: MlMap): string | undefined {
-  try {
-    const styleLayers = mlMap.getStyle?.()?.layers;
-    if (!Array.isArray(styleLayers)) return undefined;
-    for (const layer of styleLayers) {
-      const id = (layer as { id?: unknown }).id;
-      if (typeof id !== "string") continue;
-      if (id === UNIT_LAYER_ID || id.startsWith(UNIT_LAYER_PREFIX)) return id;
-    }
-  } catch {
-    // MapLibre may throw if the style is still loading.
-  }
-  return undefined;
 }
 
 function stringProp(value: unknown): string | undefined {

--- a/src/geo/kml/maplibre/index.ts
+++ b/src/geo/kml/maplibre/index.ts
@@ -13,6 +13,8 @@ import { loadKmlLayerData, type ParsedKmlLayerData } from "@/geo/kml";
 const KML_SOURCE_PREFIX = "scenario-kml-source-";
 const KML_LABEL_SOURCE_PREFIX = "scenario-kml-label-source-";
 const KML_LAYER_PREFIX = "scenario-kml-layer-";
+const UNIT_LAYER_ID = "unitLayer";
+const UNIT_LAYER_PREFIX = `${UNIT_LAYER_ID}-`;
 
 const KML_LAYER_SUFFIXES = [
   "polygon-fill",
@@ -360,8 +362,18 @@ export function createMapLibreKmlLayerRenderer(
       },
     ];
 
+    const beforeId = findFirstUnitLayerId(mlMap);
     for (const spec of layers) {
-      if (!safeGetLayer(spec.id)) mlMap.addLayer(spec);
+      if (safeGetLayer(spec.id)) continue;
+      if (beforeId) {
+        try {
+          mlMap.addLayer(spec, beforeId);
+          continue;
+        } catch {
+          // Fallback if beforeId was removed between lookup and addLayer.
+        }
+      }
+      mlMap.addLayer(spec);
     }
   }
 
@@ -479,6 +491,21 @@ export function createMapLibreKmlLayerRenderer(
       image.src = href;
     });
   }
+}
+
+function findFirstUnitLayerId(mlMap: MlMap): string | undefined {
+  try {
+    const styleLayers = mlMap.getStyle?.()?.layers;
+    if (!Array.isArray(styleLayers)) return undefined;
+    for (const layer of styleLayers) {
+      const id = (layer as { id?: unknown }).id;
+      if (typeof id !== "string") continue;
+      if (id === UNIT_LAYER_ID || id.startsWith(UNIT_LAYER_PREFIX)) return id;
+    }
+  } catch {
+    // MapLibre may throw if the style is still loading.
+  }
+  return undefined;
 }
 
 function stringProp(value: unknown): string | undefined {

--- a/src/geo/mapLibreMapAdapter.ts
+++ b/src/geo/mapLibreMapAdapter.ts
@@ -18,6 +18,7 @@ import type {
   MapEventType,
   ViewConstraints,
 } from "@/geo/contracts/mapAdapter";
+import { isUnitLayerId } from "@/geo/engines/maplibre/unitLayer";
 
 const ML_EVENT_MAP: Record<MapEventType, string> = {
   moveend: "moveend",
@@ -26,13 +27,6 @@ const ML_EVENT_MAP: Record<MapEventType, string> = {
   singleclick: "click",
   dblclick: "dblclick",
 };
-
-const UNIT_LAYER_ID = "unitLayer";
-const UNIT_LAYER_PREFIX = `${UNIT_LAYER_ID}-`;
-
-function isUnitLayerId(layerId: string | undefined) {
-  return layerId === UNIT_LAYER_ID || layerId?.startsWith(UNIT_LAYER_PREFIX);
-}
 
 function toMapEventPayload(mlMap: MlMap, e: MapMouseEvent, includeUnitHit: boolean) {
   const originalEvent = e.originalEvent as Event | undefined;

--- a/src/modules/maplibreview/MlMapLogic.vue
+++ b/src/modules/maplibreview/MlMapLogic.vue
@@ -34,6 +34,11 @@ import {
   isMapLibreKmlRenderedLayerId,
   toReferenceFeatureSelection,
 } from "@/geo/kml/maplibre";
+import {
+  isUnitLayerId,
+  UNIT_LAYER_ID,
+  UNIT_LAYER_PREFIX,
+} from "@/geo/engines/maplibre/unitLayer";
 import { useSelectedItems } from "@/stores/selectedStore";
 import { useSelectionActions } from "@/composables/selectionActions";
 import { useUiStore } from "@/stores/uiStore";
@@ -60,8 +65,6 @@ import MapHoverFeatureTooltip from "@/components/MapHoverFeatureTooltip.vue";
 import { CUSTOM_SYMBOL_PREFIX, CUSTOM_SYMBOL_SLICE } from "@/config/constants";
 import { SID_INDEX } from "@/symbology/sidc";
 
-const UNIT_LAYER_ID = "unitLayer";
-const UNIT_LAYER_PREFIX = `${UNIT_LAYER_ID}-`;
 const ALWAYS_VISIBLE_UNIT_GROUP_ID = "always";
 const NATIVE_CAPTURE_OPTIONS = { capture: true };
 const NATIVE_CAPTURE_ONCE_OPTIONS = { capture: true, once: true };
@@ -189,10 +192,6 @@ function getUnitRotationAlignment(mode: MapLibreUnitRotationMode): {
     default:
       return { icon: "viewport", text: "viewport" };
   }
-}
-
-function isUnitLayerId(layerId: string | undefined | null) {
-  return layerId === UNIT_LAYER_ID || layerId?.startsWith(UNIT_LAYER_PREFIX);
 }
 
 function getUnitVisibilityGroup(
@@ -489,21 +488,23 @@ mlMap.on("style.load", onStyleLoad);
 onStyleLoad();
 
 function queryInteractiveFeatures(point: PointLike) {
-  const hits = mlMap
-    .queryRenderedFeatures(point)
-    .filter(
-      (feature) =>
-        isUnitLayerId(feature.layer.id) ||
-        UNIT_HISTORY_LAYER_IDS.includes(feature.layer.id) ||
-        isMapLibreKmlRenderedLayerId(feature.layer.id) ||
-        isManagedScenarioFeatureLayerId(feature.layer.id),
-    );
   // Units must take precedence over reference layers (KML) even when those
   // layers happen to render above the unit symbols.
-  const unitHits = hits.filter((feature) => isUnitLayerId(feature.layer.id));
-  if (!unitHits.length || unitHits.length === hits.length) return hits;
-  const otherHits = hits.filter((feature) => !isUnitLayerId(feature.layer.id));
-  return [...unitHits, ...otherHits];
+  const unitHits: MapGeoJSONFeature[] = [];
+  const otherHits: MapGeoJSONFeature[] = [];
+  for (const feature of mlMap.queryRenderedFeatures(point)) {
+    const layerId = feature.layer.id;
+    if (isUnitLayerId(layerId)) {
+      unitHits.push(feature);
+    } else if (
+      UNIT_HISTORY_LAYER_IDS.includes(layerId) ||
+      isMapLibreKmlRenderedLayerId(layerId) ||
+      isManagedScenarioFeatureLayerId(layerId)
+    ) {
+      otherHits.push(feature);
+    }
+  }
+  return unitHits.length ? unitHits.concat(otherHits) : otherHits;
 }
 
 function updateHoveredScenarioFeatures(

--- a/src/modules/maplibreview/MlMapLogic.vue
+++ b/src/modules/maplibreview/MlMapLogic.vue
@@ -489,7 +489,7 @@ mlMap.on("style.load", onStyleLoad);
 onStyleLoad();
 
 function queryInteractiveFeatures(point: PointLike) {
-  return mlMap
+  const hits = mlMap
     .queryRenderedFeatures(point)
     .filter(
       (feature) =>
@@ -498,6 +498,12 @@ function queryInteractiveFeatures(point: PointLike) {
         isMapLibreKmlRenderedLayerId(feature.layer.id) ||
         isManagedScenarioFeatureLayerId(feature.layer.id),
     );
+  // Units must take precedence over reference layers (KML) even when those
+  // layers happen to render above the unit symbols.
+  const unitHits = hits.filter((feature) => isUnitLayerId(feature.layer.id));
+  if (!unitHits.length || unitHits.length === hits.length) return hits;
+  const otherHits = hits.filter((feature) => !isUnitLayerId(feature.layer.id));
+  return [...unitHits, ...otherHits];
 }
 
 function updateHoveredScenarioFeatures(


### PR DESCRIPTION
- **Keep units above KML reference layers in MapLibre mode**
- **Consolidate MapLibre unit-layer constants and predicates**
