### PR TITLE
Keep units and feature layers above KML in MapLibre mode

### DIFF
--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
@@ -674,6 +674,7 @@ describe("createMapLibreScenarioLayerController", () => {
         id: "scenario-kml-layer-kml-1-line",
         type: "line",
       }),
+      expect.anything(),
     );
     expect(mockMap.map.addLayer).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -682,6 +683,7 @@ describe("createMapLibreScenarioLayerController", () => {
         source: "scenario-kml-label-source-kml-1",
         minzoom: 0,
       }),
+      expect.anything(),
     );
     expect(scenario.geo.updateMapLayer).toHaveBeenCalledWith(
       "kml-1",
@@ -727,7 +729,13 @@ describe("createMapLibreScenarioLayerController", () => {
     );
     expect(kmlAddCalls.length).toBeGreaterThan(0);
     for (const call of kmlAddCalls) {
-      expect(call[1]).toBe("unitLayer");
+      const beforeId = call[1];
+      expect(typeof beforeId).toBe("string");
+      expect(
+        beforeId === "unitLayer" ||
+          beforeId.startsWith("unitLayer-") ||
+          beforeId.startsWith("scenario-feature"),
+      ).toBe(true);
     }
     const orderedLayerIds = [...mockMap.layers.keys()];
     const firstUnitIndex = orderedLayerIds.indexOf("unitLayer");
@@ -736,6 +744,41 @@ describe("createMapLibreScenarioLayerController", () => {
     );
     expect(firstKmlIndex).toBeGreaterThanOrEqual(0);
     expect(firstKmlIndex).toBeLessThan(firstUnitIndex);
+  });
+
+  it("inserts KML layers below scenario feature layers so features stay on top", async () => {
+    const mockMap = createMockMap();
+    const { scenario, mapLayers } = createScenario();
+    mapLayers.value = [
+      {
+        id: "kml-1",
+        type: "KMLLayer",
+        name: "Reference KML",
+        url: testKml,
+        extractStyles: true,
+        showPointNames: true,
+      },
+    ];
+    const controller = createMapLibreScenarioLayerController({
+      getNativeMap: () => mockMap.map,
+      fitGeometry: vi.fn(),
+      fitExtent: vi.fn(),
+      animateView: vi.fn(),
+    } as any);
+
+    controller.bindScenario(scenario);
+    await flushPromises();
+
+    const orderedLayerIds = [...mockMap.layers.keys()];
+    const firstFeatureIndex = orderedLayerIds.findIndex((id) =>
+      id.startsWith("scenario-feature"),
+    );
+    const firstKmlIndex = orderedLayerIds.findIndex((id) =>
+      id.startsWith("scenario-kml-layer-"),
+    );
+    expect(firstFeatureIndex).toBeGreaterThanOrEqual(0);
+    expect(firstKmlIndex).toBeGreaterThanOrEqual(0);
+    expect(firstKmlIndex).toBeLessThan(firstFeatureIndex);
   });
 
   it("restacks already-loaded KML layers on reorder without re-fetching", async () => {
@@ -784,7 +827,13 @@ describe("createMapLibreScenarioLayerController", () => {
     expect(movedKmlLayerIds.length).toBeGreaterThan(0);
     for (const call of mockMap.map.moveLayer.mock.calls) {
       if (typeof call[0] === "string" && call[0].startsWith("scenario-kml-layer-")) {
-        expect(call[1]).toBe("unitLayer");
+        const beforeId = call[1];
+        expect(typeof beforeId).toBe("string");
+        expect(
+          beforeId === "unitLayer" ||
+            beforeId.startsWith("unitLayer-") ||
+            beforeId.startsWith("scenario-feature"),
+        ).toBe(true);
       }
     }
     const orderedLayerIds = [...mockMap.layers.keys()];
@@ -888,6 +937,7 @@ describe("createMapLibreScenarioLayerController", () => {
         type: "symbol",
         minzoom: 8,
       }),
+      expect.anything(),
     );
   });
 

--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
@@ -133,6 +133,21 @@ function createMockMap() {
     removeLayer: vi.fn((id: string) => {
       layers.delete(id);
     }),
+    moveLayer: vi.fn((id: string, beforeId?: string) => {
+      const value = layers.get(id);
+      if (!value) return;
+      layers.delete(id);
+      if (beforeId !== undefined && layers.has(beforeId)) {
+        const entries = [...layers.entries()];
+        layers.clear();
+        for (const [layerId, layerValue] of entries) {
+          if (layerId === beforeId) layers.set(id, value);
+          layers.set(layerId, layerValue);
+        }
+        return;
+      }
+      layers.set(id, value);
+    }),
     hasImage: vi.fn(() => false),
     loadImage: vi.fn(),
     addImage: vi.fn(),
@@ -721,6 +736,64 @@ describe("createMapLibreScenarioLayerController", () => {
     );
     expect(firstKmlIndex).toBeGreaterThanOrEqual(0);
     expect(firstKmlIndex).toBeLessThan(firstUnitIndex);
+  });
+
+  it("restacks already-loaded KML layers on reorder without re-fetching", async () => {
+    const mockMap = createMockMap();
+    mockMap.map.addLayer({ id: "unitLayer" } as any);
+    const { scenario, mapLayers, mapLayerHook } = createScenario();
+    mapLayers.value = [
+      {
+        id: "kml-a",
+        type: "KMLLayer",
+        name: "KML A",
+        url: testKml,
+        extractStyles: true,
+        showPointNames: true,
+      },
+      {
+        id: "kml-b",
+        type: "KMLLayer",
+        name: "KML B",
+        url: testKml,
+        extractStyles: true,
+        showPointNames: true,
+      },
+    ];
+    const controller = createMapLibreScenarioLayerController({
+      getNativeMap: () => mockMap.map,
+      fitGeometry: vi.fn(),
+      fitExtent: vi.fn(),
+      animateView: vi.fn(),
+    } as any);
+
+    controller.bindScenario(scenario);
+    await flushPromises();
+
+    const addLayerCallsBefore = mockMap.map.addLayer.mock.calls.length;
+    mockMap.map.moveLayer.mockClear();
+
+    mapLayers.value = [mapLayers.value[1], mapLayers.value[0]];
+    await mapLayerHook.trigger({ type: "move", id: "kml-b" });
+    await flushPromises();
+
+    expect(mockMap.map.addLayer).toHaveBeenCalledTimes(addLayerCallsBefore);
+    const movedKmlLayerIds = mockMap.map.moveLayer.mock.calls
+      .map(([id]: [string]) => id)
+      .filter((id: string) => id.startsWith("scenario-kml-layer-"));
+    expect(movedKmlLayerIds.length).toBeGreaterThan(0);
+    for (const call of mockMap.map.moveLayer.mock.calls) {
+      if (typeof call[0] === "string" && call[0].startsWith("scenario-kml-layer-")) {
+        expect(call[1]).toBe("unitLayer");
+      }
+    }
+    const orderedLayerIds = [...mockMap.layers.keys()];
+    const firstAIndex = orderedLayerIds.findIndex((id) => id.includes("kml-a"));
+    const firstBIndex = orderedLayerIds.findIndex((id) => id.includes("kml-b"));
+    // After reorder to [B, A] in panel order, A is iterated last and ends up
+    // closest to (just below) the unit layer, i.e. visually above B.
+    expect(firstBIndex).toBeLessThan(firstAIndex);
+    expect(firstAIndex).toBeLessThan(orderedLayerIds.indexOf("unitLayer"));
   });
 
   it("renders labels from a point-only label source for mixed KML geometries", async () => {

--- a/src/geo/engines/maplibre/unitLayer.ts
+++ b/src/geo/engines/maplibre/unitLayer.ts
@@ -2,18 +2,26 @@ import type { Map as MlMap } from "maplibre-gl";
 
 export const UNIT_LAYER_ID = "unitLayer";
 export const UNIT_LAYER_PREFIX = `${UNIT_LAYER_ID}-`;
+export const SCENARIO_FEATURE_LAYER_PREFIX = "scenario-feature";
 
 export function isUnitLayerId(layerId: string | undefined | null) {
   return layerId === UNIT_LAYER_ID || (layerId?.startsWith(UNIT_LAYER_PREFIX) ?? false);
 }
 
-export function findFirstUnitLayerId(mlMap: MlMap): string | undefined {
+export function isScenarioFeatureMlLayerId(layerId: string | undefined | null) {
+  return typeof layerId === "string" && layerId.startsWith(SCENARIO_FEATURE_LAYER_PREFIX);
+}
+
+// Returns the id of the first MapLibre layer that should sit above KML
+// reference layers, i.e. any scenario-feature or unit layer in the style.
+export function findFirstOverlayLayerId(mlMap: MlMap): string | undefined {
   try {
     const styleLayers = mlMap.getStyle?.()?.layers;
     if (!Array.isArray(styleLayers)) return undefined;
     for (const layer of styleLayers) {
       const id = (layer as { id?: unknown }).id;
-      if (typeof id === "string" && isUnitLayerId(id)) return id;
+      if (typeof id !== "string") continue;
+      if (isUnitLayerId(id) || isScenarioFeatureMlLayerId(id)) return id;
     }
   } catch {
     // MapLibre may throw if the style is still loading.

--- a/src/geo/kml/maplibre/index.ts
+++ b/src/geo/kml/maplibre/index.ts
@@ -441,8 +441,38 @@ export function createMapLibreKmlLayerRenderer(
   }
 
   function refreshAll(layers: ScenarioKMLLayer[]) {
-    for (const layerId of [...activeLayers.keys()]) removeLayer(layerId);
-    layers.forEach((layer) => void addLayer(layer));
+    const desiredIds = new Set(layers.map((layer) => String(layer.id)));
+    for (const layerId of [...activeLayers.keys()]) {
+      if (!desiredIds.has(layerId)) removeLayer(layerId);
+    }
+    const beforeId = findFirstUnitLayerId(mlMap);
+    for (const layer of layers) {
+      const layerId = String(layer.id);
+      const existing = activeLayers.get(layerId);
+      const stillRendered =
+        existing &&
+        Boolean(safeGetLayer(getMapLibreKmlLayerId(layerId, KML_LAYER_SUFFIXES[0])));
+      if (!existing || !stillRendered || hasParseOptionsChanged(existing.layer, layer)) {
+        if (existing) removeLayer(layerId);
+        void addLayer(layer);
+        continue;
+      }
+      existing.layer = layer;
+      restackLayer(layerId, beforeId);
+    }
+  }
+
+  function restackLayer(layerId: string, beforeId: string | undefined) {
+    for (const suffix of KML_LAYER_SUFFIXES) {
+      const mlLayerId = getMapLibreKmlLayerId(layerId, suffix);
+      if (!safeGetLayer(mlLayerId)) continue;
+      try {
+        mlMap.moveLayer(mlLayerId, beforeId);
+      } catch {
+        // beforeId may have been removed mid-restack; layer order will be
+        // recomputed on the next refresh.
+      }
+    }
   }
 
   function destroy() {
@@ -490,6 +520,14 @@ export function createMapLibreKmlLayerRenderer(
       image.src = href;
     });
   }
+}
+
+function hasParseOptionsChanged(a: ScenarioKMLLayer, b: ScenarioKMLLayer): boolean {
+  return (
+    a.url !== b.url ||
+    (a.extractStyles ?? false) !== (b.extractStyles ?? false) ||
+    (a.showPointNames ?? true) !== (b.showPointNames ?? true)
+  );
 }
 
 function stringProp(value: unknown): string | undefined {

--- a/src/geo/kml/maplibre/index.ts
+++ b/src/geo/kml/maplibre/index.ts
@@ -9,7 +9,7 @@ import type { ReferenceFeatureSelection } from "@/types/referenceFeature";
 import type { ScenarioKMLLayer } from "@/types/scenarioGeoModels";
 import type { ScenarioMapLayerUpdate } from "@/types/internalModels";
 import { loadKmlLayerData, type ParsedKmlLayerData } from "@/geo/kml";
-import { findFirstUnitLayerId } from "@/geo/engines/maplibre/unitLayer";
+import { findFirstOverlayLayerId } from "@/geo/engines/maplibre/unitLayer";
 
 const KML_SOURCE_PREFIX = "scenario-kml-source-";
 const KML_LABEL_SOURCE_PREFIX = "scenario-kml-label-source-";
@@ -361,7 +361,7 @@ export function createMapLibreKmlLayerRenderer(
       },
     ];
 
-    const beforeId = findFirstUnitLayerId(mlMap);
+    const beforeId = findFirstOverlayLayerId(mlMap);
     for (const spec of layers) {
       if (safeGetLayer(spec.id)) continue;
       if (beforeId) {
@@ -445,7 +445,7 @@ export function createMapLibreKmlLayerRenderer(
     for (const layerId of [...activeLayers.keys()]) {
       if (!desiredIds.has(layerId)) removeLayer(layerId);
     }
-    const beforeId = findFirstUnitLayerId(mlMap);
+    const beforeId = findFirstOverlayLayerId(mlMap);
     for (const layer of layers) {
       const layerId = String(layer.id);
       const existing = activeLayers.get(layerId);

--- a/src/modules/maplibreview/maplibreScenarioFeatures.ts
+++ b/src/modules/maplibreview/maplibreScenarioFeatures.ts
@@ -42,7 +42,12 @@ import {
   type ObstacleHighlightState,
 } from "@/geo/routing/obstacleHighlight";
 
-export const GLOBE_SCENARIO_FEATURE_PREFIX = "scenario-feature";
+import {
+  SCENARIO_FEATURE_LAYER_PREFIX,
+  isScenarioFeatureMlLayerId,
+} from "@/geo/engines/maplibre/unitLayer";
+
+export const GLOBE_SCENARIO_FEATURE_PREFIX = SCENARIO_FEATURE_LAYER_PREFIX;
 
 type GeometryKind = "point" | "line" | "polygon";
 type MarkerRenderKind = "circle" | "icon";
@@ -1010,9 +1015,7 @@ export function buildScenarioFeatureRenderPlan(
   };
 }
 
-export function isManagedScenarioFeatureLayerId(layerId: string | undefined | null) {
-  return typeof layerId === "string" && layerId.startsWith(GLOBE_SCENARIO_FEATURE_PREFIX);
-}
+export const isManagedScenarioFeatureLayerId = isScenarioFeatureMlLayerId;
 
 export function getFeatureIdFromRenderedFeature(
   feature: MapGeoJSONFeature | { properties?: GeoJsonProperties } | undefined,


### PR DESCRIPTION
## Summary

Fixes layer stacking issues in MapLibre mode where KML reference layers could render above unit symbols, unit labels, and scenario feature layers — making the underlying items un-selectable and visually obscured.

- **`Keep units above KML reference layers in MapLibre mode`** (already on main from a previous PR) — KML sublayers are inserted with `beforeId = unitLayer` so units/labels stay topmost. Click handler in `MlMapLogic.queryInteractiveFeatures` puts unit hits first regardless of style order.
- **`Restack KML layers on reorder without re-fetching`** — `kmlLayerRenderer.refreshAll` now diffs the desired set against `activeLayers`. Already-loaded KMLs with unchanged parse options are repositioned via `mlMap.moveLayer` (deterministic, no network). Only new layers, or those whose `url`/`extractStyles`/`showPointNames` changed, go through the async `loadKmlLayerData` path.
- **`Keep scenario feature layers above KML reference layers in MapLibre mode`** — KML `beforeId` now resolves to the first unit OR scenario-feature layer in the style, so feature layers stay above KML regardless of insertion order. `GLOBE_SCENARIO_FEATURE_PREFIX` and `isManagedScenarioFeatureLayerId` are now re-exported from the shared `unitLayer` module so renderer and feature module agree on the id.

## Known bugs / limitations still in this branch

- **Panel ordering between KML and feature layers is not respected.** This PR enforces a one-way rule — feature layers and unit layers are always above KML — instead of honoring the Layers-tab panel's interleaved order. If you put a KML above a feature layer in the panel, it will still render below. Truly interleaved stacking would require coordinating both the KML renderer and the scenario feature manager through a single restack pass keyed off `geo.stackLayers`.
- **KML-to-KML order is still load-race sensitive on first add.** Reorder-only paths are now deterministic (via `moveLayer`), but when multiple KMLs are added together for the first time, the one whose fetch resolves last lands closest to the unit layer — i.e. on top of the others. The panel order isn't honored until everything has loaded and the user triggers a reorder.
- **Style reloads (basemap changes) trigger a full KML re-fetch.** Detected via `safeGetLayer(firstSublayer)` returning undefined; this falls through to the async `addLayer` path. Could be cached.

OpenLayers mode is unaffected; it already uses `scenario.geo.stackLayers.value` directly.