### PR TITLE
Render MapLibre measurement paths as great-circle arcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable changes to this project will be documented in this file.
 - Added MapLibre support for custom unit symbols, including clearer selected-state highlighting.
 - Fixed MapLibre unit labels so they shift correctly for scaled ordinary and custom icons, including hostile diamond frames.
 - Fixed MapLibre scenario layer ordering so feature, raster, image, and KML reference layers stay below unit and range ring layers and respect the scenario stack order.
+- MapLibre measurement lines and polygon edges now follow great-circle paths, so paths bend correctly across the globe and across the antimeridian instead of being drawn as straight lng/lat chords.
 
 ## April 2026
 

--- a/docs/adr/0001-geodesic-measurement-rendering.md
+++ b/docs/adr/0001-geodesic-measurement-rendering.md
@@ -1,0 +1,13 @@
+# Geodesic measurement rendering in MapLibre
+
+The MapLibre measurement tool renders each line/polygon segment as a densified great-circle arc (via `@turf/great-circle`) instead of a straight lng/lat chord — unconditionally, in both globe and Mercator projections. Densification is skipped for segments under ~100 km and capped at ~1° angular resolution (8–128 points) to avoid visual noise. Segment labels and midpoint edit handles are placed at the great-circle midpoint so they sit on the rendered arc.
+
+## Why
+
+Measurement is fundamentally about distance, and a straight lng/lat chord misrepresents what `turfLength` reports: on the globe the chord visibly leaves the surface, and even on Mercator a long chord is not the path the distance number describes. Other line tools (draw interaction, KML, OL) deliberately stay chord-based because they represent drawn shapes, not measurements — so this divergence is intentional and scoped to the measurement tool only.
+
+## Consequences
+
+- On flat Mercator maps, long measurement lines visibly bow (the classic "flight path" arc). This is the geodesically honest rendering and matches the reported length, but contributors familiar with chord-based line tools may initially read it as a bug.
+- Stored vertices remain un-densified; densification is a render-time transform only. Length math, undo/redo, and serialization are unaffected.
+- Antimeridian crossings are densified in the unwrapped vertex frame (turf's split is suppressed via `offset: 200`) so a single `LineString` survives through the layer.

--- a/src/composables/maplibreMeasurement.test.ts
+++ b/src/composables/maplibreMeasurement.test.ts
@@ -5,6 +5,22 @@ import { describe, expect, it, vi } from "vitest";
 import { useMapLibreMeasurementInteraction } from "@/composables/maplibreMeasurement";
 import type { MeasurementTypes, MeasurementUnit } from "@/composables/geoMeasurement";
 
+function expectLineEndpoints(coords: any[], start: number[], end: number[]) {
+  expect(coords[0]).toEqual(start);
+  expect(coords[coords.length - 1]).toEqual(end);
+}
+
+function expectLineThroughVertices(coords: any[], vertices: number[][]) {
+  for (const vertex of vertices) {
+    expect(
+      coords.some(
+        (c: number[]) =>
+          Math.abs(c[0]! - vertex[0]!) < 1e-9 && Math.abs(c[1]! - vertex[1]!) < 1e-9,
+      ),
+    ).toBe(true);
+  }
+}
+
 function createEvent(lng: number, lat: number, options: { timeStamp?: number } = {}) {
   return {
     lngLat: { lng, lat },
@@ -164,18 +180,11 @@ describe("useMapLibreMeasurementInteraction", () => {
     ).toBe(true);
 
     harness.trigger("dblclick", createEvent(0, 1));
-    expect(harness.sourceData("maplibre-measurement").features).toEqual([
-      expect.objectContaining({
-        id: "measurement-1",
-        geometry: {
-          type: "LineString",
-          coordinates: [
-            [0, 0],
-            [0, 1],
-          ],
-        },
-      }),
-    ]);
+    let features = harness.sourceData("maplibre-measurement").features;
+    expect(features).toHaveLength(1);
+    expect(features[0].id).toBe("measurement-1");
+    expect(features[0].geometry.type).toBe("LineString");
+    expectLineEndpoints(features[0].geometry.coordinates, [0, 0], [0, 1]);
     expect(
       harness.sourceData("maplibre-measurement-labels").features[0].properties.text,
     ).toMatch(/km$/);
@@ -183,18 +192,11 @@ describe("useMapLibreMeasurementInteraction", () => {
     harness.trigger("click", createEvent(1, 1));
     harness.trigger("click", createEvent(1, 2));
     harness.trigger("dblclick", createEvent(1, 2));
-    expect(harness.sourceData("maplibre-measurement").features).toEqual([
-      expect.objectContaining({
-        id: "measurement-2",
-        geometry: {
-          type: "LineString",
-          coordinates: [
-            [1, 1],
-            [1, 2],
-          ],
-        },
-      }),
-    ]);
+    features = harness.sourceData("maplibre-measurement").features;
+    expect(features).toHaveLength(1);
+    expect(features[0].id).toBe("measurement-2");
+    expect(features[0].geometry.type).toBe("LineString");
+    expectLineEndpoints(features[0].geometry.coordinates, [1, 1], [1, 2]);
   });
 
   it("keeps the range circle visible when touch events do not provide a live pointer", () => {
@@ -219,17 +221,9 @@ describe("useMapLibreMeasurementInteraction", () => {
     harness.trigger("click", createEvent(0, 1));
     harness.trigger("dblclick", createEvent(0, 1));
 
-    expect(harness.sourceData("maplibre-measurement").features[0]).toEqual(
-      expect.objectContaining({
-        geometry: {
-          type: "LineString",
-          coordinates: [
-            [0, 0],
-            [0, 1],
-          ],
-        },
-      }),
-    );
+    const feature = harness.sourceData("maplibre-measurement").features[0];
+    expect(feature.geometry.type).toBe("LineString");
+    expectLineEndpoints(feature.geometry.coordinates, [0, 0], [0, 1]);
     expect(
       harness
         .sourceData("maplibre-measurement-labels")
@@ -247,18 +241,11 @@ describe("useMapLibreMeasurementInteraction", () => {
     harness.trigger("click", createEvent(0, 1));
     harness.trigger("touchend", createEvent(0, 1, { timeStamp: 1200 }));
 
-    expect(harness.sourceData("maplibre-measurement").features).toEqual([
-      expect.objectContaining({
-        id: "measurement-1",
-        geometry: {
-          type: "LineString",
-          coordinates: [
-            [0, 0],
-            [0, 1],
-          ],
-        },
-      }),
-    ]);
+    const features = harness.sourceData("maplibre-measurement").features;
+    expect(features).toHaveLength(1);
+    expect(features[0].id).toBe("measurement-1");
+    expect(features[0].geometry.type).toBe("LineString");
+    expectLineEndpoints(features[0].geometry.coordinates, [0, 0], [0, 1]);
   });
 
   it("preserves multiple measurements when clearPrevious is false", () => {
@@ -281,21 +268,16 @@ describe("useMapLibreMeasurementInteraction", () => {
     harness.trigger("click", createEvent(1, 0));
     harness.trigger("click", createEvent(1, 1));
     harness.trigger("dblclick", createEvent(1, 1));
-    expect(harness.sourceData("maplibre-measurement").features[0]).toEqual(
-      expect.objectContaining({
-        geometry: {
-          type: "Polygon",
-          coordinates: [
-            [
-              [0, 0],
-              [1, 0],
-              [1, 1],
-              [0, 0],
-            ],
-          ],
-        },
-      }),
-    );
+    const feature = harness.sourceData("maplibre-measurement").features[0];
+    expect(feature.geometry.type).toBe("Polygon");
+    const ring = feature.geometry.coordinates[0];
+    expect(ring[0]).toEqual([0, 0]);
+    expect(ring[ring.length - 1]).toEqual([0, 0]);
+    expectLineThroughVertices(ring, [
+      [0, 0],
+      [1, 0],
+      [1, 1],
+    ]);
     expect(
       harness
         .sourceData("maplibre-measurement-labels")
@@ -346,9 +328,10 @@ describe("useMapLibreMeasurementInteraction", () => {
     harness.trigger("dblclick", createEvent(10, 0));
     harness.trigger("mousedown", createEvent(5, 0));
     harness.trigger("mousemove", createEvent(5, 5));
-    expect(
-      harness.sourceData("maplibre-measurement").features[0].geometry.coordinates,
-    ).toEqual([
+    let coords =
+      harness.sourceData("maplibre-measurement").features[0].geometry.coordinates;
+    expectLineEndpoints(coords, [0, 0], [10, 0]);
+    expectLineThroughVertices(coords, [
       [0, 0],
       [5, 5],
       [10, 0],
@@ -357,9 +340,9 @@ describe("useMapLibreMeasurementInteraction", () => {
     harness.trigger("mousemove", createEvent(7, 7));
     harness.trigger("mouseup", createEvent(5, 5));
 
-    expect(
-      harness.sourceData("maplibre-measurement").features[0].geometry.coordinates,
-    ).toEqual([
+    coords = harness.sourceData("maplibre-measurement").features[0].geometry.coordinates;
+    expectLineEndpoints(coords, [0, 0], [10, 0]);
+    expectLineThroughVertices(coords, [
       [0, 0],
       [7, 7],
       [10, 0],
@@ -389,12 +372,9 @@ describe("useMapLibreMeasurementInteraction", () => {
     harness.trigger("touchmove", createEvent(10, 5));
     harness.trigger("touchend", createEvent(10, 5));
 
-    expect(
-      harness.sourceData("maplibre-measurement").features[0].geometry.coordinates,
-    ).toEqual([
-      [0, 0],
-      [10, 5],
-    ]);
+    const coords =
+      harness.sourceData("maplibre-measurement").features[0].geometry.coordinates;
+    expectLineEndpoints(coords, [0, 0], [10, 5]);
   });
 
   it("uses distinct styling for measurement midpoint handles", () => {
@@ -441,16 +421,15 @@ describe("useMapLibreMeasurementInteraction", () => {
     harness.trigger("mousemove", createEvent(5, 5));
     harness.trigger("mouseup", createEvent(5, 5));
 
-    expect(
-      harness.sourceData("maplibre-measurement").features[0].geometry.coordinates,
-    ).toEqual([
-      [
-        [0, 0],
-        [5, 5],
-        [10, 0],
-        [10, 10],
-        [0, 0],
-      ],
+    const ring =
+      harness.sourceData("maplibre-measurement").features[0].geometry.coordinates[0];
+    expect(ring[0]).toEqual([0, 0]);
+    expect(ring[ring.length - 1]).toEqual([0, 0]);
+    expectLineThroughVertices(ring, [
+      [0, 0],
+      [5, 5],
+      [10, 0],
+      [10, 10],
     ]);
   });
 
@@ -508,6 +487,115 @@ describe("useMapLibreMeasurementInteraction", () => {
     expect(
       harness.sourceData("maplibre-measurement").features[0].geometry.coordinates[0],
     ).toEqual([40, 0]);
+  });
+
+  describe("great-circle densification", () => {
+    it("leaves short segments un-densified", () => {
+      const harness = createHarness();
+      // ~22 km at the equator — well under the 100 km threshold.
+      harness.trigger("click", createEvent(0, 0));
+      harness.trigger("click", createEvent(0.2, 0));
+      harness.trigger("dblclick", createEvent(0.2, 0));
+
+      const coords =
+        harness.sourceData("maplibre-measurement").features[0].geometry.coordinates;
+      // Below the densification threshold: exactly the two raw vertices.
+      expect(coords).toHaveLength(2);
+      expect(coords[0]).toEqual([0, 0]);
+      expect(coords[1][0]).toBeCloseTo(0.2, 10);
+      expect(coords[1][1]).toEqual(0);
+    });
+
+    it("densifies long segments and keeps a monotonic arc", () => {
+      const harness = createHarness();
+      harness.trigger("click", createEvent(0, 0));
+      harness.trigger("click", createEvent(60, 30));
+      harness.trigger("dblclick", createEvent(60, 30));
+
+      const coords =
+        harness.sourceData("maplibre-measurement").features[0].geometry.coordinates;
+      expect(coords.length).toBeGreaterThan(8);
+      expectLineEndpoints(coords, [0, 0], [60, 30]);
+      for (let i = 1; i < coords.length; i++) {
+        expect(coords[i][0]).toBeGreaterThanOrEqual(coords[i - 1][0]);
+      }
+      // Great-circle from equator to (60, 30) bows north of the chord midpoint.
+      const midLat = coords[Math.floor(coords.length / 2)][1];
+      expect(midLat).toBeGreaterThan(15);
+    });
+
+    it("densifies in the unwrapped frame across the antimeridian", () => {
+      const harness = createHarness();
+      harness.trigger("click", createEvent(170, 0));
+      // Crossing the antimeridian eastward; unwrapped second vertex is lng 200.
+      harness.trigger("click", createEvent(-160, 0));
+      harness.trigger("dblclick", createEvent(-160, 0));
+
+      const coords =
+        harness.sourceData("maplibre-measurement").features[0].geometry.coordinates;
+      // The crossing segment must actually densify, not fall back to a chord.
+      expect(coords.length).toBeGreaterThan(8);
+      expect(coords[0]).toEqual([170, 0]);
+      expect(coords[coords.length - 1][0]).toBeCloseTo(200, 6);
+      // Longitudes are monotonically non-decreasing in the unwrapped frame
+      // (a duplicate at the antimeridian seam is allowed; reverses are not).
+      for (let i = 1; i < coords.length; i++) {
+        expect(coords[i][0]).toBeGreaterThanOrEqual(coords[i - 1][0]);
+        expect(Math.abs(coords[i][0] - coords[i - 1][0])).toBeLessThan(180);
+      }
+    });
+
+    it("places the segment label at the great-circle midpoint, not the chord midpoint", () => {
+      const harness = createHarness({ clearPrevious: false });
+      // Three-vertex line so segment labels are emitted (lineCoordinates.length > 2).
+      harness.trigger("click", createEvent(0, 0));
+      harness.trigger("click", createEvent(60, 30));
+      harness.trigger("click", createEvent(120, 0));
+      harness.trigger("dblclick", createEvent(120, 0));
+
+      const segmentLabels = harness
+        .sourceData("maplibre-measurement-labels")
+        .features.filter((f: any) => f.properties.kind === "segment");
+      expect(segmentLabels.length).toBeGreaterThan(0);
+      const firstLabel = segmentLabels[0];
+      // Chord midpoint of (0,0)→(60,30) is (30, 15); great-circle midpoint
+      // bows north of that. Lng also shifts due to the spherical interpolation.
+      expect(firstLabel.geometry.coordinates[1]).toBeGreaterThan(15);
+      expect(firstLabel.geometry.coordinates[1]).toBeLessThan(30);
+    });
+
+    it("places midpoint edit handles on the great-circle arc", () => {
+      const harness = createHarness();
+      harness.trigger("click", createEvent(0, 0));
+      harness.trigger("click", createEvent(60, 30));
+      harness.trigger("dblclick", createEvent(60, 30));
+
+      const handles = harness.sourceData("maplibre-measurement-handles").features;
+      const midpointHandle = handles.find((f: any) => f.properties.kind === "midpoint");
+      expect(midpointHandle).toBeDefined();
+      // Chord midpoint is (30, 15); the great-circle midpoint bows north.
+      expect(midpointHandle.geometry.coordinates[1]).toBeGreaterThan(15);
+    });
+
+    it("densifies polygon ring edges", () => {
+      const harness = createHarness({ measurementType: "Polygon" });
+      harness.trigger("click", createEvent(0, 0));
+      harness.trigger("click", createEvent(60, 0));
+      harness.trigger("click", createEvent(60, 30));
+      harness.trigger("dblclick", createEvent(60, 30));
+
+      const ring =
+        harness.sourceData("maplibre-measurement").features[0].geometry.coordinates[0];
+      // Each long edge densifies to >8 points; the ring far exceeds the 4-vertex raw count.
+      expect(ring.length).toBeGreaterThan(20);
+      expect(ring[0]).toEqual([0, 0]);
+      expect(ring[ring.length - 1]).toEqual([0, 0]);
+      expectLineThroughVertices(ring, [
+        [0, 0],
+        [60, 0],
+        [60, 30],
+      ]);
+    });
   });
 
   it("cleans up layers, sources, and event handlers on unmount", () => {

--- a/src/composables/maplibreMeasurement.ts
+++ b/src/composables/maplibreMeasurement.ts
@@ -29,6 +29,7 @@ import {
 } from "@/composables/geoMeasurement";
 import { formatArea, formatLength } from "@/geo/utils";
 import { unwrapPositionRelative } from "@/geo/longitude";
+import { sampleGeodesicCoordinates } from "@/geo/routing/geodesicSegments";
 import { getMapLibreSnapPosition } from "@/composables/maplibreSnapping";
 import {
   createTouchDoubleTapTracker,
@@ -283,7 +284,7 @@ export function useMapLibreMeasurementInteraction(
     const features: GeoJsonFeature[] = renderedMeasurements.map((measurement) => ({
       type: "Feature",
       id: measurement.id,
-      geometry: measurement.geometry,
+      geometry: densifyGeometryForRender(measurement.geometry),
       properties: { kind: "measurement" },
     }));
     const preview = getPreviewGeometry();
@@ -291,7 +292,10 @@ export function useMapLibreMeasurementInteraction(
       features.push({
         type: "Feature",
         id: "preview",
-        geometry: preview,
+        geometry:
+          preview.type === "LineString" || preview.type === "Polygon"
+            ? densifyGeometryForRender(preview)
+            : preview,
         properties: { kind: "preview" },
       });
     }
@@ -424,7 +428,7 @@ export function useMapLibreMeasurementInteraction(
         if (isZeroLengthSegment(a, b)) continue;
         features.push({
           type: "Feature",
-          geometry: point(midpoint(a, b)).geometry,
+          geometry: point(greatCircleMidpoint(a, b)).geometry,
           properties: {
             text: formatLength(
               turfLength(lineString([a, b]), { units: "kilometers" }) * 1000,
@@ -707,7 +711,7 @@ function getVertexHandles(measurement: MeasurementFeature): EditHandle[] {
       (position, index) =>
         ({
           kind: "midpoint" as const,
-          position: midpoint(position, coordinates[index + 1]!),
+          position: greatCircleMidpoint(position, coordinates[index + 1]!),
           path: [index + 1],
         }) satisfies EditHandle,
     );
@@ -719,7 +723,7 @@ function getVertexHandles(measurement: MeasurementFeature): EditHandle[] {
     .map((position, index) => ({ kind: "vertex" as const, position, path: [0, index] }));
   const midpointHandles = ring.slice(0, -1).map((position, index) => ({
     kind: "midpoint" as const,
-    position: midpoint(position, ring[index + 1]!),
+    position: greatCircleMidpoint(position, ring[index + 1]!),
     path: [0, index + 1],
   }));
   return [...vertexHandles, ...midpointHandles];
@@ -765,6 +769,35 @@ function closeRing(coordinates: Position[]): Position[] {
 
 function midpoint(a: Position, b: Position): Position {
   return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
+}
+
+function densifyLineCoordinates(coordinates: Position[]): Position[] {
+  if (coordinates.length < 2) return coordinates;
+  const result: Position[] = [coordinates[0]!];
+  for (let index = 0; index < coordinates.length - 1; index += 1) {
+    const segment = sampleGeodesicCoordinates(
+      coordinates[index]!,
+      coordinates[index + 1]!,
+    );
+    for (let inner = 1; inner < segment.length; inner += 1) result.push(segment[inner]!);
+  }
+  return result;
+}
+
+function densifyGeometryForRender<G extends LineString | Polygon>(geometry: G): G {
+  if (geometry.type === "LineString") {
+    return { ...geometry, coordinates: densifyLineCoordinates(geometry.coordinates) };
+  }
+  return {
+    ...geometry,
+    coordinates: geometry.coordinates.map((ring) => densifyLineCoordinates(ring)),
+  };
+}
+
+function greatCircleMidpoint(a: Position, b: Position): Position {
+  const arc = sampleGeodesicCoordinates(a, b);
+  if (arc.length <= 2) return midpoint(a, b);
+  return arc[Math.floor(arc.length / 2)]!;
 }
 
 function suspendMapDragInteractions(mlMap: MlMap): MapDragInteractionState {


### PR DESCRIPTION
## Summary

- Densify each line/polygon segment of the MapLibre measurement tool so paths follow the geodesic between user vertices instead of a straight lng/lat chord. Stored vertices, length math, area math, and the range circle are unchanged — densification is render-only.
- Segment labels and midpoint edit handles are placed at the great-circle midpoint so they sit on the rendered arc.
- Antimeridian crossings are flattened from turf's `MultiLineString` output and smoothed by `unwindCoordinates` into a monotonic unwrapped polyline, so the crossing segment renders as a continuous arc instead of jumping back to a chord at the seam.
- Reuses the existing `sampleGeodesicCoordinates` helper from `src/geo/routing/geodesicSegments.ts` so measurement and routing share one densification implementation (same 100 km threshold).

See [`docs/adr/0001-geodesic-measurement-rendering.md`](./docs/adr/0001-geodesic-measurement-rendering.md) for design rationale: notably, the measurement tool renders geodesically in both globe and Mercator (other line tools deliberately stay chord-based because they represent drawn shapes, not measurements).