### PR TITLE
Add toggle to disable great-circle measurement paths in MapLibre

### DIFF
--- a/src/composables/geoMeasurement.ts
+++ b/src/composables/geoMeasurement.ts
@@ -405,6 +405,7 @@ export interface MeasurementInteractionOptions {
   measurementUnit?: MaybeRef<MeasurementUnit>;
   snap?: MaybeRef<boolean>;
   showCircle?: MaybeRef<boolean>;
+  showGeodesicPaths?: MaybeRef<boolean>;
 }
 
 export function useMeasurementInteraction(

--- a/src/composables/maplibreDrawInteraction.ts
+++ b/src/composables/maplibreDrawInteraction.ts
@@ -10,6 +10,11 @@ import type { FeatureId } from "@/types/scenarioGeoModels";
 import type { DrawType } from "@/composables/geoEditing";
 import { unwrapPositionRelative } from "@/geo/longitude";
 import {
+  isGlobeProjection,
+  latitudeToMercatorY,
+  mercatorYToLatitude,
+} from "@/geo/mercator";
+import {
   createTouchDoubleTapTracker,
   normalizePathCoordinates,
   suppressMapEvent,
@@ -808,13 +813,6 @@ function midpoint(a: Position, b: Position): Position {
   return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
 }
 
-function isGlobeProjection(map: MlMap) {
-  const projection = (map as any).getProjection?.();
-  const projectionType =
-    typeof projection === "string" ? projection : (projection?.type ?? projection?.name);
-  return projectionType === "globe";
-}
-
 function projectedMercatorSegmentMidpoint(
   map: MlMap,
   a: Position,
@@ -876,16 +874,6 @@ function sampleMercatorSegmentCoordinates(a: Position, b: Position): Position[] 
   }
 
   return coordinates;
-}
-
-function latitudeToMercatorY(latitude: number) {
-  const clampedLatitude = Math.max(-85.05112878, Math.min(85.05112878, latitude));
-  const radians = (clampedLatitude * Math.PI) / 180;
-  return Math.log(Math.tan(Math.PI / 4 + radians / 2));
-}
-
-function mercatorYToLatitude(y: number) {
-  return (Math.atan(Math.exp(y)) * 2 - Math.PI / 2) * (180 / Math.PI);
 }
 
 function getVertexAtPath(geometry: Geometry, path: number[]): Position | undefined {

--- a/src/composables/maplibreMeasurement.test.ts
+++ b/src/composables/maplibreMeasurement.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { mount } from "@vue/test-utils";
-import { defineComponent, ref } from "vue";
+import { defineComponent, nextTick, ref } from "vue";
 import { describe, expect, it, vi } from "vitest";
 import {
   geodesicCircleGeometry,
@@ -44,6 +44,7 @@ function createHarness(
     showSegments?: boolean;
     clearPrevious?: boolean;
     showCircle?: boolean;
+    showGeodesicPaths?: boolean;
     snap?: boolean;
     queryRenderedFeatures?: (point: unknown, options?: unknown) => any[];
   } = {},
@@ -57,6 +58,7 @@ function createHarness(
   const showSegments = ref(options.showSegments ?? true);
   const clearPrevious = ref(options.clearPrevious ?? true);
   const showCircle = ref(options.showCircle ?? true);
+  const showGeodesicPaths = ref(options.showGeodesicPaths ?? true);
   const snap = ref(options.snap ?? true);
   let doubleClickZoomEnabled = true;
   const mlMap = {
@@ -125,6 +127,7 @@ function createHarness(
             showSegments,
             clearPrevious,
             showCircle,
+            showGeodesicPaths,
             snap,
           },
         );
@@ -155,6 +158,7 @@ function createHarness(
     showSegments,
     clearPrevious,
     showCircle,
+    showGeodesicPaths,
     snap,
     interaction: wrapper.vm.interaction,
   };
@@ -507,6 +511,26 @@ describe("useMapLibreMeasurementInteraction", () => {
       expect(coords[0]).toEqual([0, 0]);
       expect(coords[1][0]).toBeCloseTo(0.2, 10);
       expect(coords[1][1]).toEqual(0);
+    });
+
+    it("skips densification when showGeodesicPaths is off", async () => {
+      const harness = createHarness();
+      harness.trigger("click", createEvent(0, 0));
+      harness.trigger("click", createEvent(60, 30));
+      harness.trigger("dblclick", createEvent(60, 30));
+
+      const denseCoords =
+        harness.sourceData("maplibre-measurement").features[0].geometry.coordinates;
+      expect(denseCoords.length).toBeGreaterThan(8);
+
+      harness.showGeodesicPaths.value = false;
+      await nextTick();
+
+      const straightCoords =
+        harness.sourceData("maplibre-measurement").features[0].geometry.coordinates;
+      expect(straightCoords).toHaveLength(2);
+      expect(straightCoords[0]).toEqual([0, 0]);
+      expect(straightCoords[1]).toEqual([60, 30]);
     });
 
     it("densifies long segments and keeps a monotonic arc", () => {

--- a/src/composables/maplibreMeasurement.ts
+++ b/src/composables/maplibreMeasurement.ts
@@ -30,6 +30,7 @@ import {
 } from "@/composables/geoMeasurement";
 import { formatArea, formatLength } from "@/geo/utils";
 import { unwindCoordinates, unwrapPositionRelative } from "@/geo/longitude";
+import { isGlobeProjection, mercatorMidpoint } from "@/geo/mercator";
 import { sampleGeodesicCoordinates } from "@/geo/routing/geodesicSegments";
 import { getMapLibreSnapPosition } from "@/composables/maplibreSnapping";
 import {
@@ -95,6 +96,13 @@ export function useMapLibreMeasurementInteraction(
   const measurementUnitRef = ref(options.measurementUnit ?? "metric");
   const snapRef = ref(options.snap ?? true);
   const showCircleRef = ref(options.showCircle ?? true);
+  const showGeodesicPathsRef = ref(options.showGeodesicPaths ?? true);
+  // In globe projection MapLibre always renders lines along great-circle arcs,
+  // so geodesic midpoints/labels are the only ones that visually land on the
+  // line — the toggle is effectively forced on.
+  function useGeodesicRender(): boolean {
+    return !!unref(showGeodesicPathsRef) || isGlobeProjection(mlMap);
+  }
   const measurements = ref<MeasurementFeature[]>([]);
   const vertices = ref<Position[]>([]);
 
@@ -319,10 +327,13 @@ export function useMapLibreMeasurementInteraction(
   function getMeasurementGeoJsonFeatures(
     renderedMeasurements: MeasurementFeature[],
   ): GeoJsonFeature[] {
+    const densify = useGeodesicRender();
     const features: GeoJsonFeature[] = renderedMeasurements.map((measurement) => ({
       type: "Feature",
       id: measurement.id,
-      geometry: densifyGeometryForRender(measurement.geometry),
+      geometry: densify
+        ? densifyGeometryForRender(measurement.geometry)
+        : measurement.geometry,
       properties: { kind: "measurement" },
     }));
     const preview = getPreviewGeometry();
@@ -331,7 +342,7 @@ export function useMapLibreMeasurementInteraction(
         type: "Feature",
         id: "preview",
         geometry:
-          preview.type === "LineString" || preview.type === "Polygon"
+          densify && (preview.type === "LineString" || preview.type === "Polygon")
             ? densifyGeometryForRender(preview)
             : preview,
         properties: { kind: "preview" },
@@ -457,13 +468,16 @@ export function useMapLibreMeasurementInteraction(
     }
 
     if (unref(showSegmentsRef) && lineCoordinates.length > 2) {
+      const segmentMidpointFn = useGeodesicRender()
+        ? greatCircleMidpoint
+        : mercatorMidpoint;
       for (let index = 0; index < lineCoordinates.length - 1; index += 1) {
         const a = lineCoordinates[index]!;
         const b = lineCoordinates[index + 1]!;
         if (isZeroLengthSegment(a, b)) continue;
         features.push({
           type: "Feature",
-          geometry: point(greatCircleMidpoint(a, b)).geometry,
+          geometry: point(segmentMidpointFn(a, b)).geometry,
           properties: {
             text: formatLength(
               turfLength(lineString([a, b]), { units: "kilometers" }) * 1000,
@@ -481,8 +495,9 @@ export function useMapLibreMeasurementInteraction(
     renderedMeasurements: MeasurementFeature[],
   ): GeoJsonFeature<Point>[] {
     if (!unref(enableRef) || drawInProgress) return [];
+    const useGeodesic = useGeodesicRender();
     return renderedMeasurements.flatMap((measurement) =>
-      getVertexHandles(measurement).map((handle) => ({
+      getVertexHandles(measurement, useGeodesic).map((handle) => ({
         type: "Feature" as const,
         geometry: point(handle.position).geometry,
         properties: {
@@ -659,6 +674,7 @@ export function useMapLibreMeasurementInteraction(
   watch(showSegmentsRef, () => render());
   watch(measurementUnitRef, () => render(), { immediate: true });
   watch(showCircleRef, () => render());
+  watch(showGeodesicPathsRef, () => render());
   watch(enableRef, (enabled) => setActive(enabled), { immediate: true });
 
   tryOnBeforeUnmount(cleanup);
@@ -734,7 +750,11 @@ function decodePath(path: unknown): number[] {
   return typeof path === "string" ? JSON.parse(path) : (path as number[]);
 }
 
-function getVertexHandles(measurement: MeasurementFeature): EditHandle[] {
+function getVertexHandles(
+  measurement: MeasurementFeature,
+  useGeodesic: boolean,
+): EditHandle[] {
+  const midpointFn = useGeodesic ? greatCircleMidpoint : mercatorMidpoint;
   if (measurement.geometry.type === "LineString") {
     const coordinates = measurement.geometry.coordinates;
     const vertexHandles = coordinates.map((position, index) => ({
@@ -746,7 +766,7 @@ function getVertexHandles(measurement: MeasurementFeature): EditHandle[] {
       (position, index) =>
         ({
           kind: "midpoint" as const,
-          position: greatCircleMidpoint(position, coordinates[index + 1]!),
+          position: midpointFn(position, coordinates[index + 1]!),
           path: [index + 1],
         }) satisfies EditHandle,
     );
@@ -758,7 +778,7 @@ function getVertexHandles(measurement: MeasurementFeature): EditHandle[] {
     .map((position, index) => ({ kind: "vertex" as const, position, path: [0, index] }));
   const midpointHandles = ring.slice(0, -1).map((position, index) => ({
     kind: "midpoint" as const,
-    position: greatCircleMidpoint(position, ring[index + 1]!),
+    position: midpointFn(position, ring[index + 1]!),
     path: [0, index + 1],
   }));
   return [...vertexHandles, ...midpointHandles];

--- a/src/geo/mercator.ts
+++ b/src/geo/mercator.ts
@@ -1,0 +1,31 @@
+import type { Map as MlMap } from "maplibre-gl";
+import type { Position } from "geojson";
+import { unwrapPositionRelative } from "@/geo/longitude";
+
+export function latitudeToMercatorY(latitude: number): number {
+  const clamped = Math.max(-85.05112878, Math.min(85.05112878, latitude));
+  const radians = (clamped * Math.PI) / 180;
+  return Math.log(Math.tan(Math.PI / 4 + radians / 2));
+}
+
+export function mercatorYToLatitude(y: number): number {
+  return (Math.atan(Math.exp(y)) * 2 - Math.PI / 2) * (180 / Math.PI);
+}
+
+// Midpoint of the straight line rendered between two vertices in Mercator
+// projection. Mercator stretches latitude, so the visual midpoint sits at the
+// average mercator-Y, not the average latitude.
+export function mercatorMidpoint(a: Position, b: Position): Position {
+  const end = unwrapPositionRelative(a, b);
+  const midLng = (a[0] + end[0]) / 2;
+  const startY = latitudeToMercatorY(a[1]);
+  const endY = latitudeToMercatorY(end[1]);
+  return [midLng, mercatorYToLatitude((startY + endY) / 2)];
+}
+
+export function isGlobeProjection(map: MlMap): boolean {
+  const projection = (map as any).getProjection?.();
+  const projectionType =
+    typeof projection === "string" ? projection : (projection?.type ?? projection?.name);
+  return projectionType === "globe";
+}

--- a/src/modules/scenarioeditor/MapEditorMeasurementToolbar.vue
+++ b/src/modules/scenarioeditor/MapEditorMeasurementToolbar.vue
@@ -5,6 +5,7 @@ import {
   IconMapMarkerDistance as ShowSegmentsIcon,
   IconSelectionEllipse as ShowCircleIcon,
   IconSelectMultipleMarker as ShowMultipleIcon,
+  IconVectorRadius as GeodesicIcon,
   IconTrashCanOutline as TrashIcon,
   IconVectorLine as LengthIcon,
   IconVectorSquare as AreaIcon,
@@ -19,6 +20,8 @@ import { useMeasurementInteraction } from "@/composables/geoMeasurement";
 import { useMapLibreMeasurementInteraction } from "@/composables/maplibreMeasurement";
 import { storeToRefs } from "pinia";
 import { useMeasurementsStore } from "@/stores/geoStore";
+import { useMapSettingsStore } from "@/stores/mapSettingsStore";
+import { computed } from "vue";
 import { onUnmounted } from "vue";
 import { useMapSelectStore } from "@/stores/mapSelectStore";
 import OLMap from "ol/Map";
@@ -35,15 +38,20 @@ const {
   measurementUnit,
   snap,
   showCircle,
+  showGeodesicPaths,
 } = storeToRefs(useMeasurementsStore());
 const activeMapAdapter = mapEngineRef.value?.map;
 const nativeMap = activeMapAdapter?.getNativeMap();
+const isMapLibre = !!nativeMap && !(nativeMap instanceof OLMap);
+const { mapProjection } = storeToRefs(useMapSettingsStore());
+const showGeodesicToggle = computed(() => isMapLibre && mapProjection.value !== "globe");
 const interactionOptions = {
   showSegments,
   clearPrevious,
   measurementUnit,
   snap,
   showCircle,
+  showGeodesicPaths,
 };
 const { clear } = nativeMap
   ? nativeMap instanceof OLMap
@@ -106,6 +114,14 @@ onUnmounted(() => {
       :active="showCircle"
     >
       <ShowCircleIcon class="size-5" />
+    </MainToolbarButton>
+    <MainToolbarButton
+      v-if="showGeodesicToggle"
+      title="Show great-circle paths"
+      @click="showGeodesicPaths = !showGeodesicPaths"
+      :active="showGeodesicPaths"
+    >
+      <GeodesicIcon class="size-5" />
     </MainToolbarButton>
     <MainToolbarButton title="Toggle snapping" @click="snap = !snap" :active="snap">
       <SnapIcon class="size-5" />

--- a/src/stores/geoStore.ts
+++ b/src/stores/geoStore.ts
@@ -118,6 +118,7 @@ export const useMeasurementsStore = defineStore("measurements", () => {
   const measurementUnit = ref<MeasurementUnit>("metric");
   const snap = ref(true);
   const showCircle = useLocalStorage("showMeasurementCircle", true);
+  const showGeodesicPaths = useLocalStorage("showGeodesicPaths", true);
 
   return {
     measurementType,
@@ -126,6 +127,7 @@ export const useMeasurementsStore = defineStore("measurements", () => {
     measurementUnit,
     snap,
     showCircle,
+    showGeodesicPaths,
   };
 });
 


### PR DESCRIPTION
## Summary
- Adds a per-user toolbar toggle that suppresses geodesic densification of measurement line/polygon paths in MapLibre Mercator mode.
- Midpoint handles and segment labels follow the rendered line: geodesic when on, Mercator midpoint when off. Range circle, length, and area math stay geodesic.
- The button is hidden in globe projection.
- Extracts Mercator midpoint and globe-projection helpers to `src/geo/mercator.ts`, shared with `maplibreDrawInteraction`.