### PR TITLE
Improve MapLibre geometry editing on touch devices

### DIFF
--- a/src/composables/maplibreDrawInteraction.test.ts
+++ b/src/composables/maplibreDrawInteraction.test.ts
@@ -877,4 +877,117 @@ describe("useMapLibreDrawInteraction", () => {
     expect(coordinates[0]).toBeCloseTo(55.968, 3);
     expect(coordinates[1]).toBeCloseTo(42.415, 3);
   });
+
+  it("previews a vertex drag live on touchmove", () => {
+    const feature = selectedLine();
+    const harness = createHarness({
+      selectedFeatures: [feature],
+      snap: false,
+      queryRenderedFeatures: () => [
+        {
+          properties: {
+            featureId: "feature-1",
+            kind: "vertex",
+            path: JSON.stringify([1]),
+          },
+        },
+      ],
+    });
+
+    harness.draw.startModify();
+    harness.trigger("touchstart", createEvent(11, 21, { type: "touchstart" }));
+    harness.trigger("touchmove", createEvent(12, 24, { type: "touchmove" }));
+
+    // Without a touchmove handler the drag had no feedback until the finger
+    // lifted; the preview overlay must now track the moving vertex.
+    const preview = harness.overlays.get("maplibre-draw-preview") as any;
+    expect(preview.geojson.features[0].geometry.coordinates).toEqual([
+      [10, 20],
+      [12, 24],
+    ]);
+  });
+
+  it("grabs the handle nearest the tap rather than the topmost hit", () => {
+    const feature = selectedLine();
+    const harness = createHarness({
+      selectedFeatures: [feature],
+      snap: false,
+      // The midpoint is returned first (it renders on top) but the tap lands on
+      // the vertex, so the closer vertex handle should win.
+      queryRenderedFeatures: (_point, queryOptions) => {
+        if (!(queryOptions as any)?.layers) return [];
+        return [
+          {
+            properties: {
+              featureId: "feature-1",
+              kind: "midpoint",
+              path: JSON.stringify([1]),
+            },
+            geometry: { type: "Point", coordinates: [10.5, 20.5] },
+          },
+          {
+            properties: {
+              featureId: "feature-1",
+              kind: "vertex",
+              path: JSON.stringify([0]),
+            },
+            geometry: { type: "Point", coordinates: [10, 20] },
+          },
+        ];
+      },
+    });
+
+    harness.draw.startModify();
+    harness.trigger("mousedown", createEvent(10, 20));
+    harness.trigger("mouseup", createEvent(13, 23));
+
+    expect(harness.updateFeatures).toHaveBeenCalledWith([
+      expect.objectContaining({
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [13, 23],
+            [11, 21],
+          ],
+        },
+      }),
+    ]);
+  });
+
+  it("buffers the tap into a box so offset taps still hit a handle", () => {
+    const feature = selectedLine();
+    const queryRenderedFeatures = vi.fn((_point: unknown, queryOptions?: unknown) => {
+      if (!(queryOptions as any)?.layers) return [];
+      return [
+        {
+          properties: {
+            featureId: "feature-1",
+            kind: "vertex",
+            path: JSON.stringify([1]),
+          },
+          geometry: { type: "Point", coordinates: [11, 21] },
+        },
+      ];
+    });
+    const harness = createHarness({
+      selectedFeatures: [feature],
+      snap: false,
+      queryRenderedFeatures,
+    });
+
+    harness.draw.startModify();
+    harness.trigger("mousedown", createEvent(11, 21));
+
+    const boxQuery = queryRenderedFeatures.mock.calls.find(
+      ([geometry, queryOptions]) =>
+        (queryOptions as any)?.layers && Array.isArray(geometry),
+    );
+    expect(boxQuery).toBeDefined();
+    const [[minX, minY], [maxX, maxY]] = boxQuery![0] as [
+      [number, number],
+      [number, number],
+    ];
+    expect(maxX - minX).toBe(24);
+    expect(maxY - minY).toBe(24);
+  });
 });

--- a/src/composables/maplibreDrawInteraction.ts
+++ b/src/composables/maplibreDrawInteraction.ts
@@ -1,4 +1,10 @@
-import type { Map as MlMap, MapMouseEvent, MapTouchEvent, PointLike } from "maplibre-gl";
+import type {
+  Map as MlMap,
+  MapGeoJSONFeature,
+  MapMouseEvent,
+  MapTouchEvent,
+  PointLike,
+} from "maplibre-gl";
 import { featureCollection, lineString, point, polygon } from "@turf/helpers";
 import turfCircle from "@turf/circle";
 import type { Feature as GeoJsonFeature, Geometry, Point, Position } from "geojson";
@@ -27,6 +33,18 @@ const DRAW_VERTEX_HANDLES_OVERLAY_ID = "maplibre-draw-vertex-handles";
 const DRAW_MIDPOINT_HANDLES_OVERLAY_ID = "maplibre-draw-midpoint-handles";
 const DRAW_VERTEX_HANDLE_LAYER_ID = `geojson-overlay-circle-${DRAW_VERTEX_HANDLES_OVERLAY_ID}`;
 const DRAW_MIDPOINT_HANDLE_LAYER_ID = `geojson-overlay-circle-${DRAW_MIDPOINT_HANDLES_OVERLAY_ID}`;
+
+// Hit-test tolerance (in pixels) for grabbing vertex/midpoint handles. The
+// handle circles are only 4-6px, so a single-pixel query is nearly impossible
+// to hit with a fingertip. Buffer the tap point into a small box; touch gets a
+// wider box, mirroring the selection tolerances used by MlMapLogic.
+const HANDLE_HIT_TOLERANCE_PX = 12;
+const TOUCH_HANDLE_HIT_TOLERANCE_PX = 26;
+
+const coarsePointerQuery =
+  typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(pointer: coarse)")
+    : null;
 
 interface DrawUpdate {
   featureId: FeatureId;
@@ -216,7 +234,7 @@ export function useMapLibreDrawInteraction(
       return;
     }
     if (isModifying.value || unref(options.translate)) {
-      mlMap.getCanvas().style.cursor = getTopDrawHandle(e.point) ? "grab" : "";
+      mlMap.getCanvas().style.cursor = getTopDrawHandle(e.point, e) ? "grab" : "";
     }
   }
 
@@ -235,7 +253,7 @@ export function useMapLibreDrawInteraction(
     if (!selectedFeatures.length) return;
 
     const position: Position = [e.lngLat.lng, e.lngLat.lat];
-    const handle = isModifying.value ? getTopDrawHandle(e.point) : undefined;
+    const handle = isModifying.value ? getTopDrawHandle(e.point, e) : undefined;
     if (handle) {
       dragState = {
         mode: "vertex",
@@ -293,6 +311,14 @@ export function useMapLibreDrawInteraction(
       options.updateFeatures(updates);
       renderHandles();
     }
+  }
+
+  function onTouchMove(e: MapTouchEvent) {
+    // MapLibre does not synthesize "mousemove" from touch, so without this the
+    // vertex/midpoint/translate drag has no live preview until the finger lifts.
+    if (!dragState) return;
+    suppressMapEvent(e);
+    previewDrag(getDragEventPosition(e, dragState));
   }
 
   function onTouchEnd(e: MapTouchEvent) {
@@ -422,20 +448,55 @@ export function useMapLibreDrawInteraction(
     renderHandleOverlays(options.getSelectedFeatures());
   }
 
-  function getTopDrawHandle(pointLike: PointLike): EditHandle | undefined {
-    const hits = mlMap.queryRenderedFeatures(pointLike, {
-      layers: [DRAW_VERTEX_HANDLE_LAYER_ID, DRAW_MIDPOINT_HANDLE_LAYER_ID],
+  function getTopDrawHandle(
+    pointLike: PointLike,
+    e?: MapMouseEvent | MapTouchEvent,
+  ): EditHandle | undefined {
+    const [x, y] = pointToXY(pointLike);
+    const tolerance = getHandleHitTolerance(e);
+    const hits = mlMap.queryRenderedFeatures(
+      [
+        [x - tolerance, y - tolerance],
+        [x + tolerance, y + tolerance],
+      ],
+      { layers: [DRAW_VERTEX_HANDLE_LAYER_ID, DRAW_MIDPOINT_HANDLE_LAYER_ID] },
+    );
+
+    const candidates: { handle: EditHandle; distance: number }[] = [];
+    for (const hit of hits) {
+      if (!hit.properties?.featureId || !hit.properties.path) continue;
+      candidates.push({
+        handle: {
+          featureId: String(hit.properties.featureId),
+          kind: hit.properties.kind === "midpoint" ? "midpoint" : "vertex",
+          path:
+            typeof hit.properties.path === "string"
+              ? JSON.parse(hit.properties.path)
+              : hit.properties.path,
+        },
+        distance: handleDistanceToPoint(hit, x, y),
+      });
+    }
+
+    // Pick the handle closest to the tap point; on a near-tie prefer a vertex,
+    // since dragging an existing vertex is more common than splitting an edge.
+    candidates.sort((a, b) => {
+      if (Math.abs(a.distance - b.distance) < 1 && a.handle.kind !== b.handle.kind) {
+        return a.handle.kind === "vertex" ? -1 : 1;
+      }
+      return a.distance - b.distance;
     });
-    const hit = hits[0];
-    if (!hit?.properties?.featureId || !hit.properties.path) return;
-    return {
-      featureId: String(hit.properties.featureId),
-      kind: hit.properties.kind === "midpoint" ? "midpoint" : "vertex",
-      path:
-        typeof hit.properties.path === "string"
-          ? JSON.parse(hit.properties.path)
-          : hit.properties.path,
-    };
+    return candidates[0]?.handle;
+  }
+
+  function handleDistanceToPoint(hit: MapGeoJSONFeature, x: number, y: number): number {
+    if (hit.geometry?.type !== "Point") return Number.POSITIVE_INFINITY;
+    try {
+      const projected = mlMap.project(hit.geometry.coordinates as [number, number]);
+      return Math.hypot(projected.x - x, projected.y - y);
+    } catch {
+      return Number.POSITIVE_INFINITY;
+    }
   }
 
   function previewDrag(position: Position) {
@@ -575,6 +636,7 @@ export function useMapLibreDrawInteraction(
   mlMap.on("mousemove", onMouseMove);
   mlMap.on("mousedown", onMouseDown);
   mlMap.on("touchstart", onMouseDown);
+  mlMap.on("touchmove", onTouchMove);
   mlMap.on("mouseup", onMouseUp);
   mlMap.on("touchend", onTouchEnd);
   mlMap.on("touchcancel", onMouseUp);
@@ -593,6 +655,7 @@ export function useMapLibreDrawInteraction(
     mlMap.off("mousemove", onMouseMove);
     mlMap.off("mousedown", onMouseDown);
     mlMap.off("touchstart", onMouseDown);
+    mlMap.off("touchmove", onTouchMove);
     mlMap.off("mouseup", onMouseUp);
     mlMap.off("touchend", onTouchEnd);
     mlMap.off("touchcancel", onMouseUp);
@@ -609,6 +672,20 @@ export function useMapLibreDrawInteraction(
     cancel,
     isDrawing,
   };
+}
+
+function pointToXY(point: PointLike): [number, number] {
+  if (Array.isArray(point)) return point;
+  return [point.x, point.y];
+}
+
+// A touch-driven event, or a coarse-pointer device, gets the wider tolerance.
+// `originalEvent` is absent on the synthetic events MapLibre dispatches.
+function getHandleHitTolerance(e?: MapMouseEvent | MapTouchEvent): number {
+  const isTouch =
+    (e?.originalEvent?.type?.startsWith("touch") ?? false) ||
+    (coarsePointerQuery?.matches ?? false);
+  return isTouch ? TOUCH_HANDLE_HIT_TOLERANCE_PX : HANDLE_HIT_TOLERANCE_PX;
 }
 
 function closeRing(coordinates: Position[]): Position[] {

--- a/src/composables/maplibreMeasurement.test.ts
+++ b/src/composables/maplibreMeasurement.test.ts
@@ -671,4 +671,82 @@ describe("useMapLibreMeasurementInteraction", () => {
 
     expect(() => harness.interaction.clear()).not.toThrow();
   });
+
+  it("grabs the handle nearest the tap rather than the topmost hit", () => {
+    const harness = createHarness({
+      // The midpoint renders on top and is returned first, but the tap lands on
+      // the end vertex, so the closer vertex handle should win and move it
+      // rather than subdividing the segment.
+      queryRenderedFeatures: (_point, queryOptions: any) => {
+        if (!queryOptions?.layers?.includes("maplibre-measurement-handle")) return [];
+        return [
+          {
+            properties: {
+              measurementId: "measurement-1",
+              kind: "midpoint",
+              path: JSON.stringify([1]),
+            },
+            geometry: { type: "Point", coordinates: [5, 0] },
+          },
+          {
+            properties: {
+              measurementId: "measurement-1",
+              kind: "vertex",
+              path: JSON.stringify([1]),
+            },
+            geometry: { type: "Point", coordinates: [10, 0] },
+          },
+        ];
+      },
+    });
+
+    harness.trigger("click", createEvent(0, 0));
+    harness.trigger("click", createEvent(10, 0));
+    harness.trigger("dblclick", createEvent(10, 0));
+    harness.trigger("mousedown", createEvent(10, 0));
+    harness.trigger("mousemove", createEvent(10, 5));
+    harness.trigger("mouseup", createEvent(10, 5));
+
+    // A vertex move shifts the end vertex to the drag target; a midpoint
+    // subdivide would instead leave the endpoints untouched at [10, 0].
+    const coords =
+      harness.sourceData("maplibre-measurement").features[0].geometry.coordinates;
+    expectLineEndpoints(coords, [0, 0], [10, 5]);
+  });
+
+  it("buffers the tap into a box so offset taps still hit a handle", () => {
+    const harness = createHarness({
+      queryRenderedFeatures: (_point, queryOptions: any) => {
+        if (!queryOptions?.layers?.includes("maplibre-measurement-handle")) return [];
+        return [
+          {
+            properties: {
+              measurementId: "measurement-1",
+              kind: "vertex",
+              path: JSON.stringify([1]),
+            },
+            geometry: { type: "Point", coordinates: [10, 0] },
+          },
+        ];
+      },
+    });
+
+    harness.trigger("click", createEvent(0, 0));
+    harness.trigger("click", createEvent(10, 0));
+    harness.trigger("dblclick", createEvent(10, 0));
+    harness.trigger("mousedown", createEvent(10, 0));
+
+    const boxQuery = harness.mlMap.queryRenderedFeatures.mock.calls.find(
+      ([geometry, queryOptions]) =>
+        (queryOptions as any)?.layers?.includes("maplibre-measurement-handle") &&
+        Array.isArray(geometry),
+    );
+    expect(boxQuery).toBeDefined();
+    const [[minX, minY], [maxX, maxY]] = boxQuery![0] as [
+      [number, number],
+      [number, number],
+    ];
+    expect(maxX - minX).toBe(24);
+    expect(maxY - minY).toBe(24);
+  });
 });

--- a/src/composables/maplibreMeasurement.ts
+++ b/src/composables/maplibreMeasurement.ts
@@ -1,6 +1,7 @@
 import type {
   GeoJSONSource,
   Map as MlMap,
+  MapGeoJSONFeature,
   MapMouseEvent,
   MapTouchEvent,
   PointLike,
@@ -51,6 +52,18 @@ const MEASUREMENT_LINE_LAYER_ID = "maplibre-measurement-line";
 const MEASUREMENT_POINT_LAYER_ID = "maplibre-measurement-point";
 const MEASUREMENT_LABEL_LAYER_ID = "maplibre-measurement-label";
 const MEASUREMENT_HANDLE_LAYER_ID = "maplibre-measurement-handle";
+
+// Hit-test tolerance (in pixels) for grabbing measurement vertex/midpoint
+// handles. The handle circles are small, so a single-pixel query is nearly
+// impossible to hit with a fingertip. Buffer the tap point into a small box;
+// touch gets a wider box, mirroring the selection tolerances used by MlMapLogic.
+const HANDLE_HIT_TOLERANCE_PX = 12;
+const TOUCH_HANDLE_HIT_TOLERANCE_PX = 26;
+
+const coarsePointerQuery =
+  typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(pointer: coarse)")
+    : null;
 
 interface MeasurementFeature {
   id: string;
@@ -181,7 +194,7 @@ export function useMapLibreMeasurementInteraction(
       render();
       return;
     }
-    mlMap.getCanvas().style.cursor = getTopHandle(e.point) ? "grab" : "crosshair";
+    mlMap.getCanvas().style.cursor = getTopHandle(e.point, e) ? "grab" : "crosshair";
   }
 
   function onMouseDown(e: MapMouseEvent | MapTouchEvent) {
@@ -191,7 +204,7 @@ export function useMapLibreMeasurementInteraction(
       suppressNextClick = false;
     }
     if (drawInProgress) return;
-    const handle = getTopHandle(e.point);
+    const handle = getTopHandle(e.point, e);
     if (!handle) return;
     dragState = {
       measurementId: handle.measurementId,
@@ -511,17 +524,53 @@ export function useMapLibreMeasurementInteraction(
 
   function getTopHandle(
     pointLike: PointLike,
+    e?: MapMouseEvent | MapTouchEvent,
   ): { measurementId: string; kind: EditHandle["kind"]; path: number[] } | null {
-    const hits = mlMap.queryRenderedFeatures(pointLike, {
-      layers: [MEASUREMENT_HANDLE_LAYER_ID],
+    const [x, y] = pointToXY(pointLike);
+    const tolerance = getHandleHitTolerance(e);
+    const hits = mlMap.queryRenderedFeatures(
+      [
+        [x - tolerance, y - tolerance],
+        [x + tolerance, y + tolerance],
+      ],
+      { layers: [MEASUREMENT_HANDLE_LAYER_ID] },
+    );
+
+    const candidates: {
+      handle: { measurementId: string; kind: EditHandle["kind"]; path: number[] };
+      distance: number;
+    }[] = [];
+    for (const hit of hits) {
+      if (!hit.properties?.measurementId || !hit.properties.path) continue;
+      candidates.push({
+        handle: {
+          measurementId: String(hit.properties.measurementId),
+          kind: hit.properties.kind === "midpoint" ? "midpoint" : "vertex",
+          path: decodePath(hit.properties.path),
+        },
+        distance: handleDistanceToPoint(hit, x, y),
+      });
+    }
+
+    // Pick the handle closest to the tap point; on a near-tie prefer a vertex,
+    // since dragging an existing vertex is more common than splitting an edge.
+    candidates.sort((a, b) => {
+      if (Math.abs(a.distance - b.distance) < 1 && a.handle.kind !== b.handle.kind) {
+        return a.handle.kind === "vertex" ? -1 : 1;
+      }
+      return a.distance - b.distance;
     });
-    const hit = hits[0];
-    if (!hit?.properties?.measurementId || !hit.properties.path) return null;
-    return {
-      measurementId: String(hit.properties.measurementId),
-      kind: hit.properties.kind === "midpoint" ? "midpoint" : "vertex",
-      path: decodePath(hit.properties.path),
-    };
+    return candidates[0]?.handle ?? null;
+  }
+
+  function handleDistanceToPoint(hit: MapGeoJSONFeature, x: number, y: number): number {
+    if (hit.geometry?.type !== "Point") return Number.POSITIVE_INFINITY;
+    try {
+      const projected = mlMap.project(hit.geometry.coordinates as [number, number]);
+      return Math.hypot(projected.x - x, projected.y - y);
+    } catch {
+      return Number.POSITIVE_INFINITY;
+    }
   }
 
   function updateDraggedVertex(position: Position) {
@@ -740,6 +789,20 @@ export function useMapLibreMeasurementInteraction(
       return undefined;
     }
   }
+}
+
+function pointToXY(point: PointLike): [number, number] {
+  if (Array.isArray(point)) return point;
+  return [point.x, point.y];
+}
+
+// A touch-driven event, or a coarse-pointer device, gets the wider tolerance.
+// `originalEvent` is absent on the synthetic events MapLibre dispatches.
+function getHandleHitTolerance(e?: MapMouseEvent | MapTouchEvent): number {
+  const isTouch =
+    (e?.originalEvent?.type?.startsWith("touch") ?? false) ||
+    (coarsePointerQuery?.matches ?? false);
+  return isTouch ? TOUCH_HANDLE_HIT_TOLERANCE_PX : HANDLE_HIT_TOLERANCE_PX;
 }
 
 function encodePath(path: number[]) {


### PR DESCRIPTION
## Problem

Editing feature geometry and measurements in MapLibre mode was hard to use on mobile: vertex/midpoint handles were nearly impossible to grab, and vertex drags gave no feedback until the finger lifted.

## Changes

- **Live touch feedback.** The draw interaction registered `touchstart`/`touchend` but no `touchmove`, and MapLibre does not synthesize `mousemove` from touch — so vertex/midpoint/translate drags had no preview until release. Added a `touchmove` handler that drives the drag preview. (The measurement composable already had this.)
- **Touch-aware hit tolerance.** `getTopDrawHandle` / `getTopHandle` hit-tested a single pixel against 4–6px handle circles, which is unhittable with a fingertip. They now buffer the tap into a tolerance box (12px mouse / 26px touch), reusing the same coarse-pointer detection and tolerances as selection in `MlMapLogic`.
- **Nearest-handle selection.** Instead of taking the topmost rendered hit, the closest handle to the tap wins (projecting each candidate to pixels), breaking near-ties toward vertices since moving an existing vertex is more common than splitting an edge.

Applied to both `maplibreDrawInteraction` and `maplibreMeasurement`.

## Tests

Added coverage in both suites: live touch-move drag preview, nearest-handle-over-topmost selection, and the hit-test box dimensions. `pnpm run type-check` clean; 51 tests passing across the two files.