### PR TITLE
Fix MapLibre unit redraw after undo/redo

### DIFF
--- a/src/modules/maplibreview/MlMapLogic.test.ts
+++ b/src/modules/maplibreview/MlMapLogic.test.ts
@@ -862,6 +862,60 @@ describe("MlMapLogic", () => {
     );
   });
 
+  it("refreshes MapLibre units when undo/redo flips unitStateCounter", async () => {
+    // Undo/redo of addUnitPosition reverts unitStateCounter (the bump is part of
+    // the patch), which drives the redraw via the unitStateCounter watcher.
+    const mockMap = createMockMap();
+    const unitStateCounter = ref(1);
+    const visibleUnits = ref<any[]>([
+      {
+        id: "unit-undo-redraw",
+        sidc: "SFGPUCI----K",
+        shortName: "A1",
+        name: "Alpha 1",
+        _state: {
+          location: [11, 21],
+        },
+      },
+    ]);
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-maplibre-undo-redraw",
+          currentTime: 0,
+          featureStateCounter: 0,
+          get unitStateCounter() {
+            return unitStateCounter.value;
+          },
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => visibleUnits.value),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    mountMlMapLogic({ mockMap, activeScenario });
+
+    const source = mockMap.getSource("unitSource");
+    const initialCallCount = source?.setData.mock.calls.length ?? 0;
+
+    // Simulate undo: the position reverts and the counter flips back.
+    visibleUnits.value[0]._state.location = [10, 20];
+    unitStateCounter.value--;
+    await nextTick();
+
+    expect(source?.setData.mock.calls.length).toBeGreaterThan(initialCallCount);
+    const setDataCalls = source?.setData.mock.calls ?? [];
+    const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
+    expect(unitData.features[0].geometry.coordinates).toEqual([10, 20]);
+  });
+
   it("refreshes MapLibre units when unitStateCounter changes after text amplifier updates", async () => {
     const mockMap = createMockMap();
     const unitStateCounter = ref(0);

--- a/src/scenariostore/geo.test.ts
+++ b/src/scenariostore/geo.test.ts
@@ -7,7 +7,71 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+function createUnitScenario() {
+  return {
+    id: "scenario-1",
+    type: "ORBAT-mapper",
+    version: "2.7.0",
+    name: "Scenario",
+    startTime: "2025-01-01T00:00:00Z",
+    sides: [
+      {
+        id: "side-1",
+        name: "Blue",
+        standardIdentity: "3",
+        symbolOptions: {},
+        subUnits: [],
+        groups: [
+          {
+            id: "group-1",
+            name: "Units",
+            symbolOptions: {},
+            subUnits: [
+              {
+                id: "unit-1",
+                name: "1st Unit",
+                sidc: "10031000000000000000",
+                location: [10, 60],
+                subUnits: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    events: [],
+    layers: [],
+    mapLayers: [],
+    settings: {
+      rangeRingGroups: [],
+      statuses: [],
+      supplyClasses: [],
+      supplyUoMs: [],
+      symbolFillColors: [],
+    },
+  } as any;
+}
+
 describe("scenario geo item accessors", () => {
+  it("keeps addUnitPosition redraw signal undo/redo aware", () => {
+    const store = useNewScenarioStore(createUnitScenario());
+    const geo = useGeo(store);
+    const before = store.state.unitStateCounter;
+
+    geo.addUnitPosition("unit-1", [11, 61]);
+
+    expect(store.state.unitStateCounter).toBe(before + 1);
+    expect(store.state.unitMap["unit-1"]._state?.location).toEqual([11, 61]);
+
+    store.undo();
+    expect(store.state.unitStateCounter).toBe(before);
+    expect(store.state.unitMap["unit-1"]._state?.location).toEqual([10, 60]);
+
+    store.redo();
+    expect(store.state.unitStateCounter).toBe(before + 1);
+    expect(store.state.unitMap["unit-1"]._state?.location).toEqual([11, 61]);
+  });
+
   it("exposes layer-item accessors backed by the current feature store", () => {
     const store = useNewScenarioStore({
       id: "scenario-1",

--- a/src/scenariostore/geo.ts
+++ b/src/scenariostore/geo.ts
@@ -201,6 +201,9 @@ export function useGeo(store: NewScenarioStore) {
             ? { viaStartTime: options.viaStartTime }
             : {}),
         };
+        // Bump before the loop so every code path (insert/replace/append) records
+        // the change and keeps the bump inside the patch for undo/redo.
+        s.unitStateCounter++;
         if (t === s.currentTime) u._state = newState;
         if (!u.state) u.state = [];
         for (let i = 0, len = u.state.length; i < len; i++) {
@@ -216,7 +219,6 @@ export function useGeo(store: NewScenarioStore) {
       },
       { label: "addUnitPosition", value: unitId },
     );
-    store.state.unitStateCounter++;
   }
 
   function addFeatureStateGeometry(


### PR DESCRIPTION
## Summary

Units on the MapLibre map did not redraw after undo/redo of a position change. The cause: `addUnitPosition` bumped `unitStateCounter` *outside* the Immer `update()` call, so the bump was never part of the RFC 6902 patch. Undo/redo restored the unit location but left the counter unchanged, so the redraw watcher never fired.

## Changes

- **`geo.ts`** — move `s.unitStateCounter++` inside the `addUnitPosition` updater, ahead of the early-returning insert/replace/append branches. It is now captured in the patch (so undo/redo flips it) and runs on every code path, fixing a second regression where repeated edits at an already-recorded timestamp didn't bump the counter.
- Undo/redo now flips the counter, which drives the existing unit, range-ring, and history redraw watchers — so no dedicated `onUndoRedo` hook is needed, avoiding a redundant double draw.
- Tests for the undo/redo-aware counter in the scenario store and the counter-driven redraw in `MlMapLogic`.