### PR TITLE
Improve MapLibre mode snapping

### DIFF
--- a/src/composables/maplibreDrawInteraction.ts
+++ b/src/composables/maplibreDrawInteraction.ts
@@ -288,7 +288,12 @@ export function useMapLibreDrawInteraction(
   ): Position {
     const raw: Position = [e.lngLat.lng, e.lngLat.lat];
     if (state.mode !== "vertex" || !unref(options.snap)) return raw;
-    return getMapLibreSnapPosition(mlMap, e.point) ?? raw;
+    // Exclude the feature being edited so the dragged vertex does not snap to
+    // its own un-dragged geometry rendered underneath.
+    const excludeFeatureIds = state.handle
+      ? new Set([String(state.handle.featureId)])
+      : undefined;
+    return getMapLibreSnapPosition(mlMap, e.point, { excludeFeatureIds }) ?? raw;
   }
 
   function onMouseUp(e: MapMouseEvent | MapTouchEvent) {

--- a/src/composables/maplibreSnapping.test.ts
+++ b/src/composables/maplibreSnapping.test.ts
@@ -7,6 +7,7 @@ type SnapMap = Parameters<typeof getMapLibreSnapPosition>[0];
 type SnapFeature = {
   layer: { id: string };
   geometry: Geometry;
+  properties?: Record<string, unknown>;
 };
 
 function createMap(queryRenderedFeatures: () => SnapFeature[]): SnapMap {
@@ -79,7 +80,38 @@ describe("getMapLibreSnapPosition", () => {
     expect(getMapLibreSnapPosition(mlMap, pointLike(40, 1))).toEqual([40, 8]);
   });
 
-  it("ignores non-scenario rendered layers", () => {
+  it("snaps to nearby unit layer features", () => {
+    const mlMap = createMap(() => [
+      {
+        layer: { id: "unitLayer" },
+        geometry: {
+          type: "Point",
+          coordinates: [5, 5],
+        },
+      },
+    ]);
+
+    expect(getMapLibreSnapPosition(mlMap, pointLike(5.1, 5.1))).toEqual([5, 5]);
+  });
+
+  it("snaps to nearby KML reference features", () => {
+    const mlMap = createMap(() => [
+      {
+        layer: { id: "scenario-kml-layer-abc-line" },
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [5, 5],
+            [10, 10],
+          ],
+        },
+      },
+    ]);
+
+    expect(getMapLibreSnapPosition(mlMap, pointLike(5.1, 5.1))).toEqual([5, 5]);
+  });
+
+  it("ignores non-snappable rendered layers", () => {
     const mlMap = createMap(() => [
       {
         layer: { id: "background-layer" },
@@ -91,6 +123,88 @@ describe("getMapLibreSnapPosition", () => {
     ]);
 
     expect(getMapLibreSnapPosition(mlMap, pointLike(5.1, 5.1))).toBeNull();
+  });
+
+  it("queries a tolerance-sized box around the pointer", () => {
+    const mlMap = createMap(() => []);
+
+    getMapLibreSnapPosition(mlMap, pointLike(50, 50));
+
+    expect(mlMap.queryRenderedFeatures).toHaveBeenCalledWith([
+      [38, 38],
+      [62, 62],
+    ]);
+  });
+
+  it("snaps a vertex back to its own geometry when not excluded", () => {
+    const mlMap = createMap(() => [
+      {
+        layer: { id: "scenario-feature-layer-1" },
+        properties: { featureId: "feat-1" },
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [100, 0],
+          ],
+        },
+      },
+    ]);
+
+    // Dragging the [0, 0] vertex 3px away still snaps back to it.
+    expect(getMapLibreSnapPosition(mlMap, pointLike(0, 3))).toEqual([0, 0]);
+  });
+
+  it("excludes the edited feature so its vertex does not snap to itself", () => {
+    const mlMap = createMap(() => [
+      {
+        layer: { id: "scenario-feature-layer-1" },
+        properties: { featureId: "feat-1" },
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [100, 0],
+          ],
+        },
+      },
+    ]);
+
+    expect(
+      getMapLibreSnapPosition(mlMap, pointLike(0, 3), {
+        excludeFeatureIds: new Set(["feat-1"]),
+      }),
+    ).toBeNull();
+  });
+
+  it("still snaps to other features while the edited feature is excluded", () => {
+    const mlMap = createMap(() => [
+      {
+        layer: { id: "scenario-feature-layer-1" },
+        properties: { featureId: "feat-1" },
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [0, 0],
+            [100, 0],
+          ],
+        },
+      },
+      {
+        layer: { id: "scenario-feature-layer-2" },
+        properties: { featureId: "feat-2" },
+        geometry: {
+          type: "Point",
+          coordinates: [2, 2],
+        },
+      },
+    ]);
+
+    expect(
+      getMapLibreSnapPosition(mlMap, pointLike(0, 3), {
+        excludeFeatureIds: new Set(["feat-1"]),
+      }),
+    ).toEqual([2, 2]);
   });
 
   it("returns null when candidates are outside tolerance", () => {

--- a/src/composables/maplibreSnapping.ts
+++ b/src/composables/maplibreSnapping.ts
@@ -1,6 +1,11 @@
 import type { PointLike } from "maplibre-gl";
 import type { Geometry, Position } from "geojson";
-import { isManagedScenarioFeatureLayerId } from "@/modules/maplibreview/maplibreScenarioFeatures";
+import {
+  getFeatureIdFromRenderedFeature,
+  isManagedScenarioFeatureLayerId,
+} from "@/modules/maplibreview/maplibreScenarioFeatures";
+import { isUnitLayerId } from "@/geo/engines/maplibre/unitLayer";
+import { isMapLibreKmlRenderedLayerId } from "@/geo/kml/maplibre";
 
 const DEFAULT_SNAP_TOLERANCE_PX = 12;
 
@@ -8,21 +13,43 @@ type ScreenPoint = PointLike | { x: number; y: number };
 type SnapFeature = {
   layer?: { id?: string | undefined };
   geometry?: Geometry | undefined;
+  properties?: Record<string, unknown> | null;
 };
 
 type SnapMap = {
   project(position: [number, number]): ScreenPoint;
-  queryRenderedFeatures(pointLike: PointLike): SnapFeature[];
+  queryRenderedFeatures(geometry: PointLike | [PointLike, PointLike]): SnapFeature[];
+};
+
+export type SnapOptions = {
+  /**
+   * Feature ids to exclude from snap candidates — typically the feature being
+   * edited, so a dragged vertex does not snap to its own un-dragged geometry.
+   */
+  excludeFeatureIds?: ReadonlySet<string>;
 };
 
 export function getMapLibreSnapPosition(
   mlMap: SnapMap,
   pointLike: PointLike,
+  options: SnapOptions = {},
 ): Position | null {
-  const renderedFeatures = mlMap
-    .queryRenderedFeatures(pointLike)
-    .filter(isSnappableFeature);
   const projectedPointer = toXY(pointLike);
+  // Query a tolerance-sized box around the pointer so features rendered near
+  // (but not under) the cursor are still considered, matching OpenLayers' Snap.
+  const queryBox: [PointLike, PointLike] = [
+    [
+      projectedPointer.x - DEFAULT_SNAP_TOLERANCE_PX,
+      projectedPointer.y - DEFAULT_SNAP_TOLERANCE_PX,
+    ],
+    [
+      projectedPointer.x + DEFAULT_SNAP_TOLERANCE_PX,
+      projectedPointer.y + DEFAULT_SNAP_TOLERANCE_PX,
+    ],
+  ];
+  const renderedFeatures = mlMap
+    .queryRenderedFeatures(queryBox)
+    .filter((feature) => isSnappableFeature(feature, options.excludeFeatureIds));
   const candidates = renderedFeatures.flatMap((feature) =>
     getSnapCandidates(feature.geometry, mlMap, projectedPointer),
   );
@@ -49,9 +76,22 @@ export function getMapLibreSnapPosition(
 
 function isSnappableFeature(
   feature: SnapFeature,
+  excludeFeatureIds?: ReadonlySet<string>,
 ): feature is SnapFeature & { geometry: Geometry } {
+  if (!feature.geometry) return false;
   const layerId = feature.layer?.id;
-  return isManagedScenarioFeatureLayerId(layerId) && Boolean(feature.geometry);
+  if (
+    !isManagedScenarioFeatureLayerId(layerId) &&
+    !isUnitLayerId(layerId) &&
+    !isMapLibreKmlRenderedLayerId(layerId)
+  ) {
+    return false;
+  }
+  if (excludeFeatureIds?.size) {
+    const featureId = getFeatureIdFromRenderedFeature(feature);
+    if (featureId && excludeFeatureIds.has(featureId)) return false;
+  }
+  return true;
 }
 
 function getSnapCandidates(


### PR DESCRIPTION
Improves vertex snapping in the MapLibre editing engine to better match OpenLayers' `Snap` behavior.

## Changes

- **Box-based snap queries** — `getMapLibreSnapPosition` now queries a tolerance-sized box around the pointer instead of a single point, so features rendered near (but not directly under) the cursor are still considered as snap candidates.
- **More snap targets** — snapping now also considers unit layers and rendered KML layers, in addition to managed scenario feature layers.
- **Exclude the edited feature** — when dragging a vertex, the feature being edited is excluded from snap candidates so the dragged vertex no longer snaps to its own un-dragged geometry rendered underneath.