### PR TITLE
Improve shift+click handling and selection logic in MapLibre

### DIFF
--- a/src/modules/maplibreview/MlMapLogic.test.ts
+++ b/src/modules/maplibreview/MlMapLogic.test.ts
@@ -2752,14 +2752,104 @@ describe("MlMapLogic", () => {
       },
     ]);
 
+    // MapLibre's box-zoom handler swallows the synthetic `click` for shift+click,
+    // so feature selection must be driven by the native canvas mousedown, exactly
+    // like units. Emitting the synthetic click is not enough in the real app.
+    const firstMouseDown = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+      shiftKey: true,
+      button: 0,
+      clientX: 1,
+      clientY: 2,
+    });
+    const firstClick = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      shiftKey: true,
+      clientX: 1,
+      clientY: 2,
+    });
+    mockMap.canvasContainer.dispatchEvent(firstMouseDown);
+    mockMap.canvasContainer.dispatchEvent(firstClick);
+
+    expect(firstMouseDown.defaultPrevented).toBe(true);
+    expect(firstClick.defaultPrevented).toBe(true);
+    expect(featureSelectSpy).not.toHaveBeenCalled();
+    expect(selectedFeatureIds.value.has("feature-existing")).toBe(true);
+    expect(selectedFeatureIds.value.has("feature-1")).toBe(true);
+
+    // A synthetic shift+click that does slip through must not double-toggle the
+    // feature the native mousedown already handled.
     mockMap.emit("click", {
       point: { x: 1, y: 2 },
       originalEvent: { shiftKey: true },
     });
 
     expect(featureSelectSpy).not.toHaveBeenCalled();
-    expect(selectedFeatureIds.value.has("feature-existing")).toBe(true);
     expect(selectedFeatureIds.value.has("feature-1")).toBe(true);
+
+    const secondMouseDown = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+      shiftKey: true,
+      button: 0,
+      clientX: 1,
+      clientY: 2,
+    });
+    const secondClick = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      shiftKey: true,
+      clientX: 1,
+      clientY: 2,
+    });
+    mockMap.canvasContainer.dispatchEvent(secondMouseDown);
+    mockMap.canvasContainer.dispatchEvent(secondClick);
+
+    expect(secondMouseDown.defaultPrevented).toBe(true);
+    expect(secondClick.defaultPrevented).toBe(true);
+    expect(selectedFeatureIds.value.has("feature-1")).toBe(false);
+    expect(selectedFeatureIds.value.has("feature-existing")).toBe(true);
+  });
+
+  it("ignores feature shift+click when feature selection is disabled", () => {
+    const mockMap = createMockMap();
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    useMapSelectStore().featureSelectEnabled = false;
+
+    const { selectedFeatureIds } = useSelectedItems();
+    selectedFeatureIds.value.clear();
+
+    mountMlMapLogic({
+      mockMap,
+      activeScenario: createHoverScenario(() => ({ layerItem: undefined })),
+      pinia,
+    });
+
+    mockMap.map.queryRenderedFeatures.mockReturnValue([
+      {
+        layer: { id: "scenario-feature-layer-1-line" },
+        properties: {
+          featureId: "feature-1",
+          layerId: "layer-1",
+        },
+      },
+    ]);
+
+    const mouseDown = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+      shiftKey: true,
+      button: 0,
+      clientX: 1,
+      clientY: 2,
+    });
+    mockMap.canvasContainer.dispatchEvent(mouseDown);
+
+    expect(mouseDown.defaultPrevented).toBe(false);
+    expect(selectedFeatureIds.value.size).toBe(0);
   });
 
   it("exports the maplibre map when the shared scenario action is triggered", async () => {

--- a/src/modules/maplibreview/MlMapLogic.vue
+++ b/src/modules/maplibreview/MlMapLogic.vue
@@ -629,17 +629,34 @@ function getEventPixel(e: MouseEvent): [number, number] {
   return [e.clientX - rect.left, e.clientY - rect.top];
 }
 
-function getShiftClickUnitId(e: MouseEvent): string | undefined {
+type ShiftClickTarget =
+  | { kind: "unit"; id: string }
+  | { kind: "feature"; id: string };
+
+// MapLibre's built-in box-zoom handler intercepts shift+mousedown, which prevents
+// the synthetic `click` event additive selection would otherwise rely on. So both
+// unit and feature shift-click selection are driven from the native mousedown
+// instead (see onNativeCanvasMouseDown).
+function getShiftClickTarget(e: MouseEvent): ShiftClickTarget | undefined {
   if (!e.shiftKey) return;
   if (e.button !== 0) return;
   if (routingStore.active) return;
   if (moveUnitEnabled.value) return;
-  if (!unitSelectEnabled.value) return;
 
   const topHit = queryInteractiveFeatures(getEventPixel(e), getHitTolerance(e))[0];
-  if (!topHit || !isUnitLayerId(topHit.layer.id)) return;
+  if (!topHit) return;
 
-  return topHit.properties?.id;
+  if (isUnitLayerId(topHit.layer.id)) {
+    if (!unitSelectEnabled.value) return;
+    const unitId = topHit.properties?.id;
+    return unitId ? { kind: "unit", id: unitId } : undefined;
+  }
+
+  if (isManagedScenarioFeatureLayerId(topHit.layer.id)) {
+    if (!featureSelectEnabled.value) return;
+    const featureId = getFeatureIdFromRenderedFeature(topHit);
+    return featureId ? { kind: "feature", id: featureId } : undefined;
+  }
 }
 
 function queueSuppressNextNativeClickReset() {
@@ -669,10 +686,14 @@ function onNativeCanvasClick(e: MouseEvent) {
 }
 
 function onNativeCanvasMouseDown(e: MouseEvent) {
-  const unitId = getShiftClickUnitId(e);
-  if (!unitId) return;
+  const target = getShiftClickTarget(e);
+  if (!target) return;
 
-  toggleUnitSelection(unitId);
+  if (target.kind === "unit") {
+    toggleUnitSelection(target.id);
+  } else {
+    toggleFeatureSelection(target.id);
+  }
   suppressNextNativeClick = true;
   window.addEventListener(
     "mouseup",
@@ -715,10 +736,9 @@ function onMapClick(e: MapMouseEvent) {
   const featureId = getFeatureIdFromRenderedFeature(topHit);
   const layerId = getLayerIdFromRenderedFeature(topHit);
   if (!(featureId && layerId)) return;
-  if (additive) {
-    toggleFeatureSelection(featureId);
-    return;
-  }
+  // Additive (shift) feature selection is handled by the native mousedown path
+  // (onNativeCanvasMouseDown); the synthetic click must not toggle it again.
+  if (additive) return;
   onFeatureSelectHook.trigger({ featureId, layerId, options: { noZoom: true } });
 }
 


### PR DESCRIPTION
- Refines shift+mousedown functionality to ensure both feature and unit selection work seamlessly while avoiding synthetic click issues caused by MapLibre's box-zoom handler.
- Adds comprehensive tests to verify accurate feature selection when feature-select is toggled on or off.
- Refactors and consolidates the `getShiftClickUnitId` function into `getShiftClickTarget` for streamlined handling of units and features.