### PR TITLE
Make scenario bounding box snappable in MapLibre mode

### DIFF
--- a/src/composables/maplibreSnapping.test.ts
+++ b/src/composables/maplibreSnapping.test.ts
@@ -111,6 +111,28 @@ describe("getMapLibreSnapPosition", () => {
     expect(getMapLibreSnapPosition(mlMap, pointLike(5.1, 5.1))).toEqual([5, 5]);
   });
 
+  it("snaps to the scenario bounding box outline", () => {
+    const mlMap = createMap(() => [
+      {
+        layer: { id: "scenarioBboxLine" },
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [0, 0],
+              [10, 0],
+              [10, 10],
+              [0, 10],
+              [0, 0],
+            ],
+          ],
+        },
+      },
+    ]);
+
+    expect(getMapLibreSnapPosition(mlMap, pointLike(10.1, 9.9))).toEqual([10, 10]);
+  });
+
   it("ignores non-snappable rendered layers", () => {
     const mlMap = createMap(() => [
       {

--- a/src/composables/maplibreSnapping.ts
+++ b/src/composables/maplibreSnapping.ts
@@ -6,6 +6,7 @@ import {
 } from "@/modules/maplibreview/maplibreScenarioFeatures";
 import { isUnitLayerId } from "@/geo/engines/maplibre/unitLayer";
 import { isMapLibreKmlRenderedLayerId } from "@/geo/kml/maplibre";
+import { isScenarioBboxLayerId } from "@/geo/engines/maplibre/bboxLayer";
 
 const DEFAULT_SNAP_TOLERANCE_PX = 12;
 
@@ -83,7 +84,8 @@ function isSnappableFeature(
   if (
     !isManagedScenarioFeatureLayerId(layerId) &&
     !isUnitLayerId(layerId) &&
-    !isMapLibreKmlRenderedLayerId(layerId)
+    !isMapLibreKmlRenderedLayerId(layerId) &&
+    !isScenarioBboxLayerId(layerId)
   ) {
     return false;
   }

--- a/src/geo/engines/maplibre/bboxLayer.ts
+++ b/src/geo/engines/maplibre/bboxLayer.ts
@@ -1,0 +1,7 @@
+export const BBOX_SOURCE_ID = "scenarioBboxSource";
+export const BBOX_FILL_LAYER_ID = "scenarioBboxFill";
+export const BBOX_LINE_LAYER_ID = "scenarioBboxLine";
+
+export function isScenarioBboxLayerId(layerId: string | undefined | null) {
+  return layerId === BBOX_FILL_LAYER_ID || layerId === BBOX_LINE_LAYER_ID;
+}

--- a/src/modules/scenarioeditor/ScenarioBoundingBox.vue
+++ b/src/modules/scenarioeditor/ScenarioBoundingBox.vue
@@ -16,10 +16,11 @@ import VectorSource from "ol/source/Vector";
 import { drawGeoJsonLayer } from "@/composables/openlayersHelpers";
 import type { GeoJSONSource, Map as MlMap } from "maplibre-gl";
 import { useBoxDraw } from "@/composables/geoBoxDraw";
-
-const BBOX_SOURCE_ID = "scenarioBboxSource";
-const BBOX_FILL_LAYER_ID = "scenarioBboxFill";
-const BBOX_LINE_LAYER_ID = "scenarioBboxLine";
+import {
+  BBOX_FILL_LAYER_ID,
+  BBOX_LINE_LAYER_ID,
+  BBOX_SOURCE_ID,
+} from "@/geo/engines/maplibre/bboxLayer";
 
 const scn = injectStrict(activeScenarioKey);
 const { store } = scn;


### PR DESCRIPTION
## Summary

The scenario bounding box rendered on the MapLibre map (`scenarioBboxFill`/`scenarioBboxLine` layers) was not a snap target while drawing or measuring. The snap gate in `isSnappableFeature` only accepted scenario-feature, unit, and KML layers.

## Changes

- Add `src/geo/engines/maplibre/bboxLayer.ts` — extracts the bbox source/layer ID constants out of `ScenarioBoundingBox.vue` and adds an `isScenarioBboxLayerId()` checker, following the existing `isUnitLayerId` pattern.
- Add the bbox layer check to `isSnappableFeature` in `maplibreSnapping.ts`. Drawing and measuring both route through `getMapLibreSnapPosition`, so this enables snapping in both tools. The box renders as a polygon, so its four corners (rank 0) and edge points (rank 1) become snap candidates; pointer positions far inside the box stay outside tolerance and don't snap.
- `ScenarioBoundingBox.vue` now imports the shared constants instead of redefining them.
- Add a test asserting a bbox corner is snapped to.

`pnpm run type-check` and the snapping test suite pass.