### PR TITLE
Add rectangle draw tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added a rectangle tool to the draw toolbar for drawing box-shaped polygons.
 - Added an add-multiple toggle to the draw toolbar for repeated feature drawing and unit placement.
 - Added a toolbar toggle to disable great-circle (geodesic) measurement paths in MapLibre Mercator mode.
 - Added experimental KML support for MapLibre mode.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,47 @@
+# ORBAT Mapper
+
+Client-side tool for building order of battles and plotting unit locations and
+drawn geometry on a map. This glossary captures terms whose meaning is specific
+to this project and not obvious from the code.
+
+## Language
+
+### Geometry
+
+**Geometry layer item**:
+A drawn feature on the map (point, line, circle, polygon, …) stored in an
+overlay layer. Holds a GeoJSON `geometry`, presentation `style`, and
+`geometryMeta`.
+
+**geometryKind**:
+The kind of shape a geometry layer item represents — _not_ the same as the
+GeoJSON `geometry.type`. Most kinds match the GeoJSON type, but **Circle** is
+the deliberate exception.
+_Avoid_: "geometry type" when you mean the kind.
+
+**Circle**:
+A geometryKind stored as a **Point** geometry plus a required `radius` (metres).
+There is no GeoJSON circle; the radius lives on `geometryMeta`, and the on-map
+circle is reconstructed from the point and radius at render time.
+
+**Rectangle**:
+A **Polygon** that should stay axis-aligned while edited. The geometry remains a
+plain Polygon; the intent is recorded as `geometryMeta.shape = "rectangle"`.
+Only a Polygon can be a rectangle.
+_Avoid_: treating "rectangle" as a separate geometryKind — it is a marker on a
+Polygon.
+
+**Canonical vs loadable metadata**:
+`GeometryLayerMeta` is the **canonical** strict shape (each geometryKind carries
+only its meaningful fields). `LoadableGeometryLayerMeta` is the **loose**
+counterpart used for data still being loaded, upgraded, or partially patched,
+where the kind and its extra fields cannot yet be guaranteed to line up.
+
+## Example dialogue
+
+> **Dev:** The circle isn't rendering after reload.
+> **Domain expert:** Check `geometryMeta.radius` — a Circle is a Point with a
+> radius, so if the radius is missing there's nothing to draw the ring from.
+> **Dev:** So `geometry.type` is `"Point"` but `geometryKind` is `"Circle"`?
+> **Domain expert:** Right. And for a rectangle it's the opposite — the kind is
+> just `"Polygon"`, with `shape: "rectangle"` marking that it stays axis-aligned.

--- a/docs/adr/0002-strict-geometry-layer-meta.md
+++ b/docs/adr/0002-strict-geometry-layer-meta.md
@@ -1,0 +1,17 @@
+# Strict discriminated `GeometryLayerMeta`
+
+`GeometryLayerMeta` (the metadata on a drawn geometry layer item) is a discriminated union keyed on `geometryKind`: the `"Circle"` member carries a required `radius: number`, the `"Polygon"` member carries an optional `shape?: "rectangle"`, and a single `Exclude<ScenarioFeatureType, "Circle" | "Polygon">` catch-all member covers the remaining six kinds with no extra fields. A separate flat `LoadableGeometryLayerMeta` (all fields optional, non-discriminated) is used for the load/upgrade/patch paths, and the one runtime-kinded construction in `upgrade.ts` is asserted across that boundary with `as GeometryLayerMeta` rather than routed through a factory.
+
+## Why
+
+`radius` is only meaningful for a Circle (which is stored as a Point geometry plus a radius — see CONTEXT.md) and `shape` only for a Polygon, but the previous flat interface let any kind carry either field, so radius-less circles and rectangle-marked points were representable. Encoding the constraint in the type makes those states unrepresentable and lets reads narrow on `geometryKind` instead of defensively null-checking.
+
+A strict union cannot describe data that is mid-load or partially patched, where the kind and its extra fields are not yet guaranteed to agree. `Partial<union>` does not solve this — `keyof` a union is the intersection of member keys, so it collapses to `{ geometryKind? }` and silently drops `radius`/`shape`. Hence a deliberate second, loose type for those boundaries.
+
+The legacy upgrade path builds metadata from a kind only known at runtime. A factory that switches on the kind would centralise narrowing, but there is exactly one such call site, so a localised cast is proportionate; a factory is the documented upgrade if more runtime-kinded construction sites appear.
+
+## Consequences
+
+- Two parallel metadata types now exist (`GeometryLayerMeta` strict, `LoadableGeometryLayerMeta` loose). A reader must know which boundary they are at; the strict one is canonical, the loose one is only for loading/upgrading/patching.
+- Reads of `radius`/`shape` must narrow first (`"radius" in meta`, or `geometryKind === "Circle"`). Code that already branched on `geometryKind` gets simpler — the redundant null-check on `radius` drops out.
+- The `as GeometryLayerMeta` cast at the upgrade boundary is the one place the guarantee is asserted rather than proven. A pre-3.2.0 circle missing its radius would pass as a valid `CircleMeta`; this preserves the prior tolerance (radius was optional before) rather than introducing a regression, but it is the spot to revisit (with a factory and a fallback) if legacy data proves untrustworthy.

--- a/src/composables/geoEditing.ts
+++ b/src/composables/geoEditing.ts
@@ -2,7 +2,7 @@ import OLMap from "ol/Map";
 import type VectorLayer from "ol/layer/Vector";
 import type VectorSource from "ol/source/Vector";
 import { type MaybeRef, onUnmounted, ref, unref, watch } from "vue";
-import Draw, { DrawEvent } from "ol/interaction/Draw";
+import Draw, { createBox, DrawEvent } from "ol/interaction/Draw";
 import Translate from "ol/interaction/Translate";
 import Snap from "ol/interaction/Snap";
 import Select from "ol/interaction/Select";
@@ -17,8 +17,9 @@ import {
 import type Feature from "ol/Feature";
 import Collection from "ol/Collection";
 import Geometry from "ol/geom/Geometry";
+import Polygon from "ol/geom/Polygon";
 
-export type DrawType = "Point" | "LineString" | "Polygon" | "Circle";
+export type DrawType = "Point" | "LineString" | "Polygon" | "Circle" | "Rectangle";
 
 export interface GeoEditingOptions {
   addMultiple?: MaybeRef<boolean>;
@@ -47,10 +48,8 @@ export function useEditingInteraction(
   const freehandRef = ref(options.freehand ?? false);
   let currentDrawInteraction: Draw | null | undefined;
 
-  let { lineDraw, polygonDraw, pointDraw, circleDraw } = initializeDrawInteractions(
-    source,
-    !!unref(freehandRef),
-  );
+  let { lineDraw, polygonDraw, pointDraw, circleDraw, rectangleDraw } =
+    initializeDrawInteractions(source, !!unref(freehandRef));
 
   const currentDrawType = ref<DrawType | null>(null);
   const isModifying = ref(false);
@@ -63,11 +62,20 @@ export function useEditingInteraction(
     olMap.addInteraction(polygonDraw);
     olMap.addInteraction(pointDraw);
     olMap.addInteraction(circleDraw);
+    olMap.addInteraction(rectangleDraw);
 
     useOlEvent(lineDraw.on("drawend", onDrawEnd));
     useOlEvent(polygonDraw.on("drawend", onDrawEnd));
     useOlEvent(pointDraw.on("drawend", onDrawEnd));
     useOlEvent(circleDraw.on("drawend", onDrawEnd));
+    useOlEvent(
+      rectangleDraw.on("drawend", (event) => {
+        // Tag the box so the editor recognizes it as a rectangle and keeps it
+        // axis-aligned. The geometry itself stays a plain Polygon.
+        event.feature.set("shape", "rectangle");
+        onDrawEnd(event);
+      }),
+    );
   }
 
   function removeInteractions() {
@@ -75,6 +83,7 @@ export function useEditingInteraction(
     olMap.removeInteraction(polygonDraw);
     olMap.removeInteraction(pointDraw);
     olMap.removeInteraction(circleDraw);
+    olMap.removeInteraction(rectangleDraw);
   }
 
   addInteractions();
@@ -82,16 +91,16 @@ export function useEditingInteraction(
   watch(freehandRef, () => {
     const active = currentDrawInteraction?.getActive();
     removeInteractions();
-    ({ lineDraw, polygonDraw, pointDraw, circleDraw } = initializeDrawInteractions(
-      source,
-      !!unref(freehandRef),
-    ));
+    ({ lineDraw, polygonDraw, pointDraw, circleDraw, rectangleDraw } =
+      initializeDrawInteractions(source, !!unref(freehandRef)));
     addInteractions();
     if (active) {
       if (currentDrawType.value === "LineString") currentDrawInteraction = lineDraw;
       else if (currentDrawType.value === "Polygon") currentDrawInteraction = polygonDraw;
       else if (currentDrawType.value === "Point") currentDrawInteraction = pointDraw;
       else if (currentDrawType.value === "Circle") currentDrawInteraction = circleDraw;
+      else if (currentDrawType.value === "Rectangle")
+        currentDrawInteraction = rectangleDraw;
       currentDrawInteraction?.setActive(true);
     }
   });
@@ -107,10 +116,46 @@ export function useEditingInteraction(
     olMap.addInteraction(select);
     select.setActive(false);
   }
-  const modify = new Modify({ features: select.getFeatures(), pixelTolerance: 20 });
+  const isRectangleFeature = (feature: Feature) => feature.get("shape") === "rectangle";
+
+  // Snapshot of each rectangle's corners at the start of a modify gesture, used
+  // to identify the dragged corner and rebuild an axis-aligned box on release.
+  const rectangleOriginals = new Map<Feature, number[][]>();
+
+  const modify = new Modify({
+    features: select.getFeatures(),
+    pixelTolerance: 20,
+    // Don't let users insert vertices into a rectangle — that would turn it
+    // into an arbitrary polygon.
+    insertVertexCondition: () =>
+      !select.getFeatures().getArray().some(isRectangleFeature),
+  });
+
+  useOlEvent(
+    modify.on("modifystart", (event) => {
+      rectangleOriginals.clear();
+      event.features.forEach((feature) => {
+        const geometry = feature.getGeometry();
+        if (isRectangleFeature(feature) && geometry instanceof Polygon) {
+          rectangleOriginals.set(
+            feature,
+            geometry.getCoordinates()[0].map((coordinate) => [...coordinate]),
+          );
+        }
+      });
+    }),
+  );
 
   useOlEvent(
     modify.on("modifyend", (event) => {
+      event.features.forEach((feature) => {
+        const original = rectangleOriginals.get(feature);
+        const geometry = feature.getGeometry();
+        if (!original || !(geometry instanceof Polygon)) return;
+        const squared = squareRectangleRing(original, geometry.getCoordinates()[0]);
+        if (squared) geometry.setCoordinates([squared]);
+      });
+      rectangleOriginals.clear();
       emit && emit("modify", event.features.getArray());
       options.modifyHandler && options.modifyHandler(event.features.getArray());
     }),
@@ -174,6 +219,7 @@ export function useEditingInteraction(
     if (drawType === "Polygon") currentDrawInteraction = polygonDraw;
     if (drawType === "Point") currentDrawInteraction = pointDraw;
     if (drawType === "Circle") currentDrawInteraction = circleDraw;
+    if (drawType === "Rectangle") currentDrawInteraction = rectangleDraw;
 
     currentDrawInteraction?.setActive(true);
     currentDrawType.value = drawType;
@@ -213,6 +259,7 @@ export function useEditingInteraction(
     olMap.removeInteraction(lineDraw);
     olMap.removeInteraction(polygonDraw);
     olMap.removeInteraction(circleDraw);
+    olMap.removeInteraction(rectangleDraw);
     if (!options.select) olMap.removeInteraction(select);
     olMap.removeInteraction(modify);
     olMap.removeInteraction(translateInteraction);
@@ -236,6 +283,42 @@ export function useEditingInteraction(
   return { startDrawing, currentDrawType, startModify, isModifying, cancel, isDrawing };
 }
 
+// Rebuilds an axis-aligned box ring after a single corner was dragged: the
+// dragged corner (the one that moved furthest from the original) keeps its new
+// position, the diagonally opposite corner stays anchored, and the other two
+// follow. Coordinates are in the map projection, where a rectangle is
+// axis-aligned. Returns null when the rings are not 4-corner boxes.
+function squareRectangleRing(
+  original: number[][],
+  current: number[][],
+): number[][] | null {
+  if (original.length < 5 || current.length < 5) return null;
+  const originalCorners = original.slice(0, 4);
+  const currentCorners = current.slice(0, 4);
+
+  let draggedIndex = 0;
+  let maxDistanceSq = -1;
+  for (let i = 0; i < 4; i++) {
+    const dx = currentCorners[i][0] - originalCorners[i][0];
+    const dy = currentCorners[i][1] - originalCorners[i][1];
+    const distanceSq = dx * dx + dy * dy;
+    if (distanceSq > maxDistanceSq) {
+      maxDistanceSq = distanceSq;
+      draggedIndex = i;
+    }
+  }
+
+  const [mx, my] = currentCorners[draggedIndex];
+  const [ax, ay] = originalCorners[(draggedIndex + 2) % 4];
+  return [
+    [mx, my],
+    [ax, my],
+    [ax, ay],
+    [mx, ay],
+    [mx, my],
+  ];
+}
+
 function initializeDrawInteractions(source: VectorSource<any>, freehand = false) {
   const lineDraw = new Draw({ type: "LineString", source, freehand });
   lineDraw.setActive(false);
@@ -249,5 +332,14 @@ function initializeDrawInteractions(source: VectorSource<any>, freehand = false)
   const circleDraw = new Draw({ type: "Circle", source });
   circleDraw.setActive(false);
 
-  return { lineDraw, polygonDraw, pointDraw, circleDraw };
+  // A rectangle is a box-shaped Polygon: draw with type "Circle" plus the box
+  // geometryFunction so two clicks define opposite corners.
+  const rectangleDraw = new Draw({
+    type: "Circle",
+    source,
+    geometryFunction: createBox(),
+  });
+  rectangleDraw.setActive(false);
+
+  return { lineDraw, polygonDraw, pointDraw, circleDraw, rectangleDraw };
 }

--- a/src/composables/geoEditing.ts
+++ b/src/composables/geoEditing.ts
@@ -126,9 +126,25 @@ export function useEditingInteraction(
     features: select.getFeatures(),
     pixelTolerance: 20,
     // Don't let users insert vertices into a rectangle — that would turn it
-    // into an arbitrary polygon.
-    insertVertexCondition: () =>
-      !select.getFeatures().getArray().some(isRectangleFeature),
+    // into an arbitrary polygon. Scope this to the feature under the cursor so a
+    // co-selected ordinary polygon can still gain vertices.
+    insertVertexCondition: (event) => {
+      const selected = select.getFeatures().getArray();
+      if (!selected.some(isRectangleFeature)) return true;
+      let overRectangle = false;
+      olMap.forEachFeatureAtPixel(
+        event.pixel,
+        (feature) => {
+          if (isRectangleFeature(feature as Feature) && selected.includes(feature as Feature)) {
+            overRectangle = true;
+            return true;
+          }
+          return false;
+        },
+        { layerFilter: (layer) => layer === layerRef.value, hitTolerance: 20 },
+      );
+      return !overRectangle;
+    },
   });
 
   useOlEvent(

--- a/src/composables/maplibreDrawInteraction.test.ts
+++ b/src/composables/maplibreDrawInteraction.test.ts
@@ -139,6 +139,27 @@ function selectedLine(): GeometryLayerItem {
   };
 }
 
+function selectedRectangle(): GeometryLayerItem {
+  return {
+    kind: "geometry",
+    id: "rect-1",
+    geometry: {
+      type: "Polygon",
+      coordinates: [
+        [
+          [0, 0],
+          [2, 0],
+          [2, 2],
+          [0, 2],
+          [0, 0],
+        ],
+      ],
+    },
+    geometryMeta: { geometryKind: "Polygon", shape: "rectangle" },
+    style: {},
+  };
+}
+
 describe("useMapLibreDrawInteraction", () => {
   it("preserves disabled double-click zoom after drawing is cancelled", () => {
     const harness = createHarness({ doubleClickZoomEnabled: false });
@@ -215,6 +236,106 @@ describe("useMapLibreDrawInteraction", () => {
         geometryMeta: expect.objectContaining({ geometryKind: "Circle" }),
       }),
     );
+  });
+
+  it("creates a rectangle as a box-shaped polygon from two corner clicks", () => {
+    const harness = createHarness();
+
+    harness.draw.startDrawing("Rectangle");
+    harness.trigger("click", createEvent(1, 2));
+    harness.trigger("click", createEvent(5, 8));
+
+    expect(harness.addFeature).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [1, 2],
+              [5, 2],
+              [5, 8],
+              [1, 8],
+              [1, 2],
+            ],
+          ],
+        },
+        geometryMeta: { geometryKind: "Polygon", shape: "rectangle" },
+      }),
+    );
+  });
+
+  it("unwraps rectangle corners across the antimeridian", () => {
+    const harness = createHarness();
+
+    harness.draw.startDrawing("Rectangle");
+    harness.trigger("click", createEvent(179, 10));
+    harness.trigger("click", createEvent(-179, 12));
+
+    expect(harness.addFeature).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [179, 10],
+              [181, 10],
+              [181, 12],
+              [179, 12],
+              [179, 10],
+            ],
+          ],
+        },
+      }),
+    );
+  });
+
+  it("edits a rectangle with four corner handles and no midpoint handles", () => {
+    const harness = createHarness({ selectedFeatures: [selectedRectangle()] });
+
+    harness.draw.startModify();
+
+    const vertexOverlay = harness.overlays.get("maplibre-draw-vertex-handles") as any;
+    const midpointOverlay = harness.overlays.get("maplibre-draw-midpoint-handles") as any;
+    expect(vertexOverlay.geojson.features).toHaveLength(4);
+    expect(midpointOverlay.geojson.features).toHaveLength(0);
+  });
+
+  it("resizes a rectangle by dragging a corner, anchoring the opposite corner", () => {
+    const harness = createHarness({
+      selectedFeatures: [selectedRectangle()],
+      snap: false,
+      queryRenderedFeatures: () => [
+        {
+          properties: {
+            featureId: "rect-1",
+            kind: "vertex",
+            path: JSON.stringify([0, 0]),
+          },
+        },
+      ],
+    });
+
+    harness.draw.startModify();
+    harness.trigger("mousedown", createEvent(0, 0));
+    harness.trigger("mouseup", createEvent(-1, -1));
+
+    expect(harness.updateFeatures).toHaveBeenCalledWith([
+      expect.objectContaining({
+        featureId: "rect-1",
+        geometry: {
+          type: "Polygon",
+          coordinates: [
+            [
+              [-1, -1],
+              [2, -1],
+              [2, 2],
+              [-1, 2],
+              [-1, -1],
+            ],
+          ],
+        },
+      }),
+    ]);
   });
 
   it("snaps point drawing to nearby rendered scenario vertices", () => {
@@ -402,8 +523,10 @@ describe("useMapLibreDrawInteraction", () => {
     );
 
     const feature = harness.addFeature.mock.lastCall?.[0] as GeometryLayerItem;
-    expect(feature.geometryMeta.radius).toBeGreaterThan(200_000);
-    expect(feature.geometryMeta.radius).toBeLessThan(250_000);
+    const meta = feature.geometryMeta;
+    if (meta.geometryKind !== "Circle") throw new Error("expected a circle");
+    expect(meta.radius).toBeGreaterThan(200_000);
+    expect(meta.radius).toBeLessThan(250_000);
   });
 
   it("creates a freehand line from drag samples", () => {

--- a/src/composables/maplibreDrawInteraction.ts
+++ b/src/composables/maplibreDrawInteraction.ts
@@ -97,6 +97,7 @@ export function useMapLibreDrawInteraction(
   const vertices = ref<Position[]>([]);
   let dragState: DragState | null = null;
   let circleCenter: Position | null = null;
+  let rectangleCorner: Position | null = null;
   let drawingDoubleClickZoomEnabled: boolean | null = null;
   let cleanupEsc: (() => void) | undefined;
   let cleanupEnter: (() => void) | undefined;
@@ -138,6 +139,7 @@ export function useMapLibreDrawInteraction(
     isDrawing.value = false;
     vertices.value = [];
     circleCenter = null;
+    rectangleCorner = null;
     touchDoubleTap.reset();
     mapAdapter.removeGeoJsonOverlay(DRAW_PREVIEW_OVERLAY_ID);
     options.onDrawingChange?.(false);
@@ -189,6 +191,20 @@ export function useMapLibreDrawInteraction(
       return;
     }
 
+    if (currentDrawType.value === "Rectangle") {
+      if (!rectangleCorner) {
+        rectangleCorner = position;
+        renderPreview(point(position).geometry);
+        return;
+      }
+      const opposite = unwrapPositionRelative(rectangleCorner, position);
+      commitFeature({
+        geometry: createRectanglePolygon(rectangleCorner, opposite),
+        geometryMeta: { geometryKind: "Polygon", shape: "rectangle" },
+      });
+      return;
+    }
+
     appendClickVertex(position);
     renderPathPreview(unwrapDrawPosition(position));
   }
@@ -221,6 +237,15 @@ export function useMapLibreDrawInteraction(
           createCirclePreview(
             circleCenter,
             unwrapPositionRelative(circleCenter, position),
+          ),
+        );
+        return;
+      }
+      if (currentDrawType.value === "Rectangle" && rectangleCorner) {
+        renderPreview(
+          createRectanglePolygon(
+            rectangleCorner,
+            unwrapPositionRelative(rectangleCorner, position),
           ),
         );
         return;
@@ -367,6 +392,7 @@ export function useMapLibreDrawInteraction(
     if (unref(options.addMultiple)) {
       vertices.value = [];
       circleCenter = null;
+      rectangleCorner = null;
       mapAdapter.removeGeoJsonOverlay(DRAW_PREVIEW_OVERLAY_ID);
       return;
     }
@@ -542,7 +568,7 @@ export function useMapLibreDrawInteraction(
   }
 
   function renderHandleOverlays(
-    features: Array<Pick<GeometryLayerItem, "id" | "geometry">>,
+    features: Array<Pick<GeometryLayerItem, "id" | "geometry" | "geometryMeta">>,
   ) {
     const handleFeatures = features.flatMap((feature) =>
       getEditHandles(feature, getRenderedMidpoint).flatMap((handle) => {
@@ -708,6 +734,50 @@ function createCirclePreview(center: Position, edge: Position): Geometry {
   }).geometry;
 }
 
+// Builds an axis-aligned box Polygon from two opposite corners. `opposite` is
+// expected to already be unwrapped relative to `corner` for antimeridian-safe
+// longitudes.
+function createRectanglePolygon(corner: Position, opposite: Position): Geometry {
+  const [x1, y1] = corner;
+  const [x2, y2] = opposite;
+  return polygon([
+    [
+      [x1, y1],
+      [x2, y1],
+      [x2, y2],
+      [x1, y2],
+      [x1, y1],
+    ],
+  ]).geometry;
+}
+
+function isRectangleFeature(feature: {
+  geometryMeta?: GeometryLayerItem["geometryMeta"];
+}): boolean {
+  const meta = feature.geometryMeta;
+  return !!meta && "shape" in meta && meta.shape === "rectangle";
+}
+
+// Dragging a rectangle corner keeps the shape axis-aligned: the diagonally
+// opposite corner is the anchor and the box is rebuilt from it and the dragged
+// position. Falls back to a plain vertex move if the ring is not a 4-corner box.
+function resizeRectangleByCorner(
+  geometry: Geometry,
+  path: number[],
+  position: Position,
+): Geometry {
+  if (geometry.type !== "Polygon") {
+    return updateVertexAtPath(geometry, path, position);
+  }
+  const ring = geometry.coordinates[0];
+  const cornerIndex = path[path.length - 1];
+  if (ring.length !== 5 || cornerIndex < 0 || cornerIndex > 3) {
+    return updateVertexAtPath(geometry, path, position);
+  }
+  const anchor = unwrapPositionRelative(position, ring[(cornerIndex + 2) % 4]);
+  return createRectanglePolygon(position, anchor);
+}
+
 function getDragUpdates(dragState: DragState, position: Position): DrawUpdate[] {
   if (dragState.mode === "translate") {
     const unwrappedPosition = unwrapPositionRelative(dragState.start, position);
@@ -729,20 +799,29 @@ function getDragUpdates(dragState: DragState, position: Position): DrawUpdate[] 
         getDragPositionReference(feature.geometry, dragState.handle!),
         position,
       );
+      let geometry: Geometry;
+      if (dragState.handle!.kind === "midpoint") {
+        geometry = insertVertexAtPath(
+          feature.geometry,
+          dragState.handle!.path,
+          unwrappedPosition,
+        );
+      } else if (isRectangleFeature(feature)) {
+        geometry = resizeRectangleByCorner(
+          feature.geometry,
+          dragState.handle!.path,
+          unwrappedPosition,
+        );
+      } else {
+        geometry = updateVertexAtPath(
+          feature.geometry,
+          dragState.handle!.path,
+          unwrappedPosition,
+        );
+      }
       return {
         featureId: feature.id,
-        geometry:
-          dragState.handle!.kind === "midpoint"
-            ? insertVertexAtPath(
-                feature.geometry,
-                dragState.handle!.path,
-                unwrappedPosition,
-              )
-            : updateVertexAtPath(
-                feature.geometry,
-                dragState.handle!.path,
-                unwrappedPosition,
-              ),
+        geometry,
         geometryMeta: feature.geometryMeta,
       };
     });
@@ -795,9 +874,14 @@ function mapGeometryCoordinates(
 type MidpointCalculator = (a: Position, b: Position) => Position;
 
 function getEditHandles(
-  feature: Pick<GeometryLayerItem, "id" | "geometry">,
+  feature: Pick<GeometryLayerItem, "id" | "geometry" | "geometryMeta">,
   midpointCalculator: MidpointCalculator = midpoint,
 ): EditHandle[] {
+  // Rectangles expose only their four corners — no midpoint handles, so a
+  // vertex can never be inserted and the box keeps its shape.
+  if (isRectangleFeature(feature)) {
+    return getVertexHandles(feature);
+  }
   return [
     ...getVertexHandles(feature),
     ...getMidpointHandles(feature, midpointCalculator),

--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
@@ -100,7 +100,7 @@ function normalizeMapLayerExtent(
 function toCurrentFeature(feature: NGeometryLayerItem): GeoJsonFeature | undefined {
   const geometry = feature._state?.geometry ?? feature.geometry;
   if (!geometry) return;
-  const radius = feature.geometryMeta.radius;
+  const radius = "radius" in feature.geometryMeta ? feature.geometryMeta.radius : undefined;
   if (typeof radius === "number" && geometry.type === "Point") {
     return turfCircle(geometry.coordinates as Position, radius / 1000, {
       steps: 48,

--- a/src/modules/maplibreview/maplibreScenarioFeatures.ts
+++ b/src/modules/maplibreview/maplibreScenarioFeatures.ts
@@ -281,11 +281,12 @@ function getTextVisibilityGroup(
 
 function convertCircleFeature(feature: NGeometryLayerItem) {
   const geometry = getCurrentGeometry(feature);
-  if (feature.geometryMeta.radius === undefined || geometry.type !== "Point")
+  const meta = feature.geometryMeta;
+  if (!("radius" in meta) || meta.radius === undefined || geometry.type !== "Point")
     return geometry;
   return turfCircle(
     geometry.coordinates as Position,
-    feature.geometryMeta.radius / 1000,
+    meta.radius / 1000,
     {
       steps: 48,
       units: "kilometers",

--- a/src/modules/scenarioeditor/MapEditorDrawToolbar.vue
+++ b/src/modules/scenarioeditor/MapEditorDrawToolbar.vue
@@ -10,7 +10,8 @@ import {
   IconTrashCanOutline as DeleteIcon,
   IconVectorCircleVariant as CircleIcon,
   IconVectorLine as LineStringIcon,
-  IconVectorSquare as PolygonIcon,
+  IconVectorPolygon as PolygonIcon,
+  IconVectorRectangle as RectangleIcon,
   IconClockEditOutline as IconClockEdit,
   IconGesture as FreehandIcon,
 } from "@iconify-prerendered/vue-mdi";
@@ -81,6 +82,13 @@ onKeyStroke("Escape", (event) => {
       <PolygonIcon class="size-5" />
     </MainToolbarButton>
 
+    <MainToolbarButton
+      title="Rectangle"
+      @click="startDrawing('Rectangle')"
+      :active="currentDrawType === 'Rectangle'"
+    >
+      <RectangleIcon class="size-5" />
+    </MainToolbarButton>
     <MainToolbarButton
       title="Circle"
       @click="startDrawing('Circle')"

--- a/src/modules/scenarioeditor/ScenarioFeatureGeometryStats.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureGeometryStats.vue
@@ -17,7 +17,10 @@ const { measurementUnit } = storeToRefs(useMeasurementsStore());
 
 const kind = computed(() => props.feature.geometryMeta.geometryKind);
 const geom = computed<Geometry>(() => props.feature.geometry);
-const radius = computed(() => props.feature.geometryMeta.radius);
+const radius = computed(() => {
+  const meta = props.feature.geometryMeta;
+  return "radius" in meta ? meta.radius : undefined;
+});
 
 const typeLabel = computed(() => {
   if (kind.value === "Circle") return "Circle";

--- a/src/modules/scenarioeditor/featureLayerUtils.ts
+++ b/src/modules/scenarioeditor/featureLayerUtils.ts
@@ -112,7 +112,8 @@ function getGeometryKind(item: GeometryFeatureLike): string {
 }
 
 function getGeometryRadius(item: GeometryFeatureLike): number | undefined {
-  return "geometryMeta" in item ? item.geometryMeta.radius : item.meta.radius;
+  if (!("geometryMeta" in item)) return item.meta.radius;
+  return "radius" in item.geometryMeta ? item.geometryMeta.radius : undefined;
 }
 
 function getGeometryUserData(

--- a/src/modules/scenarioeditor/scenarioDrawHelpers.ts
+++ b/src/modules/scenarioeditor/scenarioDrawHelpers.ts
@@ -53,13 +53,20 @@ export function convertOlFeatureToScenarioFeature(olFeature: Feature): GeometryL
     olFeature,
   );
 
+  const userData = { ...(gj.properties ?? {}) };
+  const isRectangle = userData.shape === "rectangle";
+  delete userData.shape;
+
   return {
     kind: "geometry",
     id: String(gj.id ?? nanoid()),
     geometry: gj.geometry,
-    userData: gj.properties ?? {},
+    userData,
     style: {},
-    geometryMeta: { geometryKind: gj.geometry.type },
+    geometryMeta: {
+      geometryKind: gj.geometry.type,
+      ...(isRectangle ? { shape: "rectangle" } : {}),
+    },
   };
 }
 

--- a/src/scenariostore/geo.test.ts
+++ b/src/scenariostore/geo.test.ts
@@ -226,6 +226,81 @@ describe("scenario geo item accessors", () => {
     expect(geo.onLayerItemEvent).toBe(geo.onFeatureLayerEvent);
   });
 
+  it("replaces geometryMeta on update so a transformed rectangle drops its shape marker", () => {
+    const store = useNewScenarioStore({
+      id: "scenario-1",
+      type: "ORBAT-mapper",
+      version: "3.2.0",
+      name: "Scenario",
+      startTime: 0,
+      sides: [],
+      events: [],
+      layers: [
+        {
+          id: "layer-1",
+          kind: "overlay",
+          name: "Features",
+          items: [
+            {
+              kind: "geometry",
+              id: "rect-1",
+              geometry: {
+                type: "Polygon",
+                coordinates: [
+                  [
+                    [0, 0],
+                    [2, 0],
+                    [2, 2],
+                    [0, 2],
+                    [0, 0],
+                  ],
+                ],
+              },
+              geometryMeta: { geometryKind: "Polygon", shape: "rectangle" },
+              style: {},
+            },
+          ],
+        },
+      ],
+      mapLayers: [],
+      settings: {
+        rangeRingGroups: [],
+        statuses: [],
+        supplyClasses: [],
+        supplyUoMs: [],
+        symbolFillColors: [],
+      },
+    } as any);
+
+    const geo = useGeo(store);
+    expect(geo.getGeometryLayerItemById("rect-1").layerItem?.geometryMeta).toEqual({
+      geometryKind: "Polygon",
+      shape: "rectangle",
+    });
+
+    // A transform replaces the geometry with a fresh, complete meta that has no
+    // shape — the result is no longer an axis-aligned rectangle.
+    geo.updateFeature("rect-1", {
+      geometry: {
+        type: "Polygon",
+        coordinates: [
+          [
+            [0, 0],
+            [3, 1],
+            [2, 3],
+            [0, 0],
+          ],
+        ],
+      },
+      geometryMeta: { geometryKind: "Polygon" },
+    });
+
+    const updatedMeta = geo.getGeometryLayerItemById("rect-1").layerItem?.geometryMeta;
+    expect(updatedMeta).toEqual({ geometryKind: "Polygon" });
+    // toEqual ignores undefined keys, so assert the marker is actually absent.
+    expect(updatedMeta).not.toHaveProperty("shape");
+  });
+
   it("creates patch-based geometry state entries at runtime", () => {
     const store = useNewScenarioStore({
       id: "scenario-1",

--- a/src/scenariostore/geo.ts
+++ b/src/scenariostore/geo.ts
@@ -644,7 +644,6 @@ export function useGeo(store: NewScenarioStore) {
           if (!feature) return;
           const {
             geometry,
-            geometryMeta = {},
             media,
             style = {},
             state,
@@ -661,7 +660,14 @@ export function useGeo(store: NewScenarioStore) {
             _state,
           } = data;
           Object.assign(feature.style, style);
-          Object.assign(feature.geometryMeta, geometryMeta);
+          // Replace, don't merge: each geometryKind is a discriminated union
+          // member with its own valid extra fields, so merging could leave a
+          // stale field behind (e.g. a transformed rectangle keeping
+          // shape:"rectangle", or radius surviving onto a non-circle). Callers
+          // that touch geometryMeta pass a complete, coherent meta.
+          if (data.geometryMeta !== undefined) {
+            feature.geometryMeta = data.geometryMeta as GeometryLayerItem["geometryMeta"];
+          }
           if (geometry) Object.assign(feature.geometry, geometry);
 
           if (state) feature.state = state;
@@ -691,7 +697,10 @@ export function useGeo(store: NewScenarioStore) {
       const layerItem = getGeometryLayerItemFromMap(state.layerItemMap, featureId);
       if (!layerItem) return;
       Object.assign(layerItem.style, data.style ?? {});
-      Object.assign(layerItem.geometryMeta, data.geometryMeta ?? {});
+      // Replace, not merge (see undoable branch above).
+      if (data.geometryMeta !== undefined) {
+        layerItem.geometryMeta = data.geometryMeta as GeometryLayerItem["geometryMeta"];
+      }
       if (data.geometry) Object.assign(layerItem.geometry, data.geometry);
       if (data.userData) {
         layerItem.userData = mergeGeometryUserData(layerItem.userData, data.userData);

--- a/src/scenariostore/upgrade.ts
+++ b/src/scenariostore/upgrade.ts
@@ -14,6 +14,7 @@ import type {
   GeometryLayerMeta,
   GeometryLayerItem,
   LoadableGeometryLayerItemState,
+  LoadableGeometryLayerMeta,
   MeasurementLayerItem,
   ScenarioLayerItemsLayer,
   TacticalGraphicLayerItem,
@@ -34,7 +35,7 @@ export type LoadableGeometryLayerItem = {
   type?: "Feature";
   properties?: GeoJsonProperties;
   meta?: Partial<ScenarioFeatureMeta>;
-  geometryMeta?: Partial<GeometryLayerMeta>;
+  geometryMeta?: LoadableGeometryLayerMeta;
   name?: string;
   description?: string;
   externalUrl?: string;
@@ -172,7 +173,11 @@ function upgradeGeometryItemToSharedBase(
   item: LoadableGeometryLayerItem,
 ): GeometryLayerItem {
   const legacyMeta = item.meta ?? {};
-  const geometryMeta: GeometryLayerMeta = {
+  // The kind is only known at runtime here, so we build the loose shape and
+  // assert it as the strict union at this legacy-upgrade boundary. Pre-3.2.0
+  // data already tolerated a radius-less circle, so this preserves that
+  // behaviour while everything constructed with a literal kind stays checked.
+  const geometryMeta = {
     geometryKind: inferGeometryKind(
       item.geometry,
       item.geometryMeta?.geometryKind ?? legacyMeta.type,
@@ -182,7 +187,7 @@ function upgradeGeometryItemToSharedBase(
       : legacyMeta.radius !== undefined
         ? { radius: legacyMeta.radius }
         : {}),
-  };
+  } as GeometryLayerMeta;
 
   return {
     id: String(item.id),

--- a/src/types/scenarioLayerItems.ts
+++ b/src/types/scenarioLayerItems.ts
@@ -71,10 +71,25 @@ export interface ScenarioLayerItemBase extends Partial<VisibilityInfo> {
   userData?: Record<string, unknown>;
 }
 
-export interface GeometryLayerMeta {
-  geometryKind: ScenarioFeatureType;
+// Canonical, strict geometry metadata. Each geometryKind carries only the
+// extra fields that are meaningful for it:
+// - "Circle" is stored as a Point geometry plus a required radius (metres).
+// - "Polygon" may be marked as an axis-aligned rectangle; the geometry itself
+//   stays a plain Polygon.
+// All other kinds carry no extra fields.
+export type GeometryLayerMeta =
+  | { geometryKind: "Circle"; radius: number }
+  | { geometryKind: "Polygon"; shape?: "rectangle" }
+  | { geometryKind: Exclude<ScenarioFeatureType, "Circle" | "Polygon"> };
+
+// Loose, non-discriminated counterpart for data that is still being loaded,
+// upgraded, or partially patched, where the kind and its extra fields cannot
+// yet be guaranteed to line up.
+export type LoadableGeometryLayerMeta = {
+  geometryKind?: ScenarioFeatureType;
   radius?: number;
-}
+  shape?: "rectangle";
+};
 
 export interface GeometryLayerItemStatePatch {
   geometry?: Geometry;
@@ -321,7 +336,7 @@ export interface NScenarioLayerItemsLayer extends Omit<ScenarioLayerItemsLayer, 
 export interface GeometryLayerItemUpdate extends Partial<
   Omit<NGeometryLayerItem, "id" | "geometryMeta" | "kind">
 > {
-  geometryMeta?: Partial<GeometryLayerMeta>;
+  geometryMeta?: LoadableGeometryLayerMeta;
 }
 
 export interface FullScenarioLayerItemsLayer extends Omit<
@@ -334,6 +349,7 @@ export interface FullScenarioLayerItemsLayer extends Omit<
 const RESERVED_GEOMETRY_ITEM_USERDATA_KEYS = new Set([
   "type",
   "radius",
+  "shape",
   "name",
   "description",
   "externalUrl",
@@ -397,8 +413,11 @@ export function toGeometryLayerItemGeoJsonProperties(
 ): GeoJsonProperties {
   const properties: Record<string, unknown> = {
     ...(item.geometryMeta.geometryKind ? { type: item.geometryMeta.geometryKind } : {}),
-    ...(item.geometryMeta.radius !== undefined
+    ...("radius" in item.geometryMeta && item.geometryMeta.radius !== undefined
       ? { radius: item.geometryMeta.radius }
+      : {}),
+    ...("shape" in item.geometryMeta && item.geometryMeta.shape !== undefined
+      ? { shape: item.geometryMeta.shape }
       : {}),
     ...(item.name !== undefined ? { name: item.name } : {}),
     ...(item.description !== undefined ? { description: item.description } : {}),


### PR DESCRIPTION
Adds a rectangle tool to the draw toolbar, available in both OpenLayers and MapLibre modes.

## Drawing
- New **Rectangle** toolbar button (between Polygon and Circle).
- Two corners define an axis-aligned box. In OpenLayers it uses `Draw` with `createBox()`; in MapLibre it's a two-click flow with a live preview. Antimeridian-safe.
- A rectangle is stored as a plain `Polygon` geometry, so rendering and serialization are unchanged.

## Editing (stays a rectangle)
- Rectangles are tagged with `geometryMeta.shape: "rectangle"`. The geometry itself remains a `Polygon`.
- **MapLibre:** four corner handles only — no midpoint handles, so vertices can't be inserted. Dragging a corner resizes the box, anchoring the diagonally-opposite corner, with a live preview.
- **OpenLayers:** vertex insertion is blocked while a rectangle is selected, and the box is re-squared on `modifyend` (the dragged corner moves, the opposite corner anchors). Mid-drag the single corner moves freely and snaps to a clean rectangle on release.
- The marker is persisted through the scenario save/reload round-trip (`geometryMeta` is serialized on save and carried through the upgrade/load path).

## Notes
- The rectangle flag is **not** exported to / imported from external GeoJSON — a rectangle copied as GeoJSON is a plain polygon. Only the native scenario format preserves it.
- Not yet manually verified in the browser; the drag interactions are covered by unit tests but not click-tested live.