### PR TITLE
Fix individual feature visibility toggle in MapLibre mode

### DIFF
--- a/src/modules/maplibreview/maplibreScenarioFeatures.test.ts
+++ b/src/modules/maplibreview/maplibreScenarioFeatures.test.ts
@@ -36,6 +36,61 @@ describe("buildScenarioFeatureRenderPlan", () => {
     expect(plan.featureData.features[0].geometry.type).toBe("Polygon");
   });
 
+  it("always excludes manually hidden features even when filterVisible is false", () => {
+    // Regression: when the Layers tab is open, filterVisible is false so the
+    // map shows time-hidden features for editing — but a feature the user
+    // explicitly hid via the eye toggle (isHidden) must still stay hidden.
+    const plan = buildScenarioFeatureRenderPlan(
+      {
+        id: "layer-hidden",
+        kind: "overlay",
+        name: "Layer Hidden",
+        items: [
+          {
+            id: "visible-1",
+            kind: "geometry",
+            _pid: "layer-hidden",
+            geometry: { type: "Point", coordinates: [10, 20] },
+            geometryMeta: { geometryKind: "Point" },
+            style: {},
+          },
+          {
+            id: "eye-hidden-1",
+            kind: "geometry",
+            _pid: "layer-hidden",
+            isHidden: true,
+            _hidden: true,
+            geometry: { type: "Point", coordinates: [0, 0] },
+            geometryMeta: { geometryKind: "Point" },
+            style: {},
+          },
+          {
+            id: "time-hidden-1",
+            kind: "geometry",
+            _pid: "layer-hidden",
+            // Hidden only by the timeline window, not the eye toggle.
+            _hidden: true,
+            geometry: { type: "Point", coordinates: [5, 5] },
+            geometryMeta: { geometryKind: "Point" },
+            style: {},
+          },
+        ],
+      } as any,
+      {
+        filterVisible: false,
+        selectedFeatureIds: new Set(),
+      },
+    );
+
+    const featureIds = plan.featureData.features.map(
+      (feature) => feature.properties?.featureId,
+    );
+    expect(featureIds).toContain("visible-1");
+    expect(featureIds).not.toContain("eye-hidden-1");
+    // Time-hidden features are still revealed while the Layers tab is open.
+    expect(featureIds).toContain("time-hidden-1");
+  });
+
   it("treats null fill as no polygon fill", () => {
     const plan = buildScenarioFeatureRenderPlan(
       {

--- a/src/modules/maplibreview/maplibreScenarioFeatures.ts
+++ b/src/modules/maplibreview/maplibreScenarioFeatures.ts
@@ -398,7 +398,11 @@ function buildFeatureData(
   const imageDefinitions = new Map<string, ImageDefinition>();
 
   for (const item of layer.items.filter(isNGeometryLayerItem)) {
-    if (filterVisible && item._hidden) continue;
+    // A manually hidden feature (eye toggle) must always be filtered out, the
+    // same way a hidden layer always gets visibility:"none". Only time-window
+    // hiding (`_hidden` without `isHidden`) is gated on `filterVisible`, so the
+    // Layers panel can still reveal time-hidden features for editing.
+    if (item.isHidden || (filterVisible && item._hidden)) continue;
 
     const style = item.style || {};
     const layerId = String(layer.id);


### PR DESCRIPTION
## Problem

In MapLibre mode, hiding an individual scenario feature via its eye toggle had no effect — but only **while the Layers tab was open**. With the tab closed, feature hiding worked; with it open, you could only hide whole layers.

## Root cause

Opening the Layers tab sets `uiStore.layersPanelActive = true`, which maps to `filterVisible: false` (so time-hidden features remain visible for editing). In `buildFeatureData`, feature hiding was gated entirely on that flag:

```js
if (filterVisible && item._hidden) continue;
```

So with the panel open, a feature's hidden state was ignored. Layers kept hiding correctly because a hidden layer gets `visibility: "none"` baked directly into its layer spec, independent of `filterVisible`. Features had no equivalent per-feature mechanism — being dropped from the source data was their only way to hide.

## Fix

Always filter out manually hidden features (`isHidden`), while keeping time-window hiding (`_hidden`) gated on `filterVisible`:

```js
if (item.isHidden || (filterVisible && item._hidden)) continue;
```

This makes features behave exactly like layers: a manually hidden feature always stays hidden, while a time-hidden feature is still revealed when the Layers tab is open for editing.

Added a regression test covering a manually hidden, a time-hidden, and a visible feature with `filterVisible: false`.