### PR TITLE
Add georeferenced image export (world file + GeoTIFF)

### DIFF
--- a/src/modules/maplibreview/imageExport/ExportImageForm.vue
+++ b/src/modules/maplibreview/imageExport/ExportImageForm.vue
@@ -17,7 +17,9 @@ import {
   checkExportSize,
   exportViewportFrame,
   exportMapByBounds,
+  type ExportFormat,
   getMapAttributionText,
+  isGeoreferencedFormat,
   isPaperPreset,
   type PaperOrientation,
   type PaperPreset,
@@ -74,7 +76,28 @@ const resetRotation = ref(false);
 const showScaleBar = ref(false);
 const showNorthArrow = ref(false);
 const showCredits = ref(false);
+const outputFormat = ref<ExportFormat>("png");
 const fileName = ref("map");
+
+const outputFormatItems = [
+  { value: "png", label: "PNG" },
+  { value: "world-file-zip", label: "PNG + world file (.zip)" },
+  { value: "geotiff", label: "GeoTIFF (.tif)" },
+];
+
+const isGeoreferenced = computed(() => isGeoreferencedFormat(outputFormat.value));
+
+const outputFileExtension = computed(() => {
+  if (outputFormat.value === "world-file-zip") return ".zip";
+  if (outputFormat.value === "geotiff") return ".tif";
+  return ".png";
+});
+
+const exportButtonLabel = computed(() => {
+  if (outputFormat.value === "world-file-zip") return "Export ZIP";
+  if (outputFormat.value === "geotiff") return "Export GeoTIFF";
+  return "Export PNG";
+});
 
 // The scale bar mirrors the map's current measurement units (the same store the
 // live scale control reads), so an imperial/nautical map exports a matching bar.
@@ -163,11 +186,25 @@ watch(safeZone, (value) => {
 });
 
 // Reset rotation isn't offered in frame mode (the frame captures the live
-// camera as-is), so clear any value carried over from another mode to keep it
-// from silently affecting the frame export.
+// camera as-is), so clear any value carried over from another mode. The
+// georeferenced override is applied at submit time via `effectiveResetRotation`
+// — keeping the model itself clean here avoids stale state when the user
+// switches a georeferenced format back to PNG.
 watch(mode, (value) => {
   if (value === "frame") resetRotation.value = false;
 });
+
+// Both georeferenced formats embed an axis-aligned affine, so we force the
+// north-up render and suppress decorations when one is active. These are
+// applied at submit time (see effectiveResetRotation / effectiveDecorations)
+// rather than as side-effects on the model, so the user's decoration toggles
+// and rotation choice survive switching format back to PNG.
+const effectiveResetRotation = computed(
+  () => isGeoreferenced.value || resetRotation.value,
+);
+const effectiveDecorations = computed(() =>
+  isGeoreferenced.value ? undefined : decorations.value,
+);
 
 const presetItems = [
   { value: "custom", label: "Custom" },
@@ -284,6 +321,9 @@ watch(
     showScaleBar,
     showNorthArrow,
     showCredits,
+    // outputFormat does not affect the preview pixels (preview is always the
+    // downscaled rendered raster, regardless of zip/tiff wrapping), so it's
+    // intentionally not in this list — switching formats keeps the preview.
     () => props.drawnBounds,
     viewfinderFrame,
   ],
@@ -431,15 +471,17 @@ async function onSubmit() {
           outputScale: 1,
           symbolPixelRatio: outputScale.value,
           symbolDisplayScale: outputScale.value,
-          resetRotation: resetRotation.value,
-          decorations: decorations.value,
+          resetRotation: effectiveResetRotation.value,
+          decorations: effectiveDecorations.value,
+          outputFormat: outputFormat.value,
           fileName: name,
         });
       } else {
         await exportViewportFrame(props.map, viewfinderFrame.value, {
           outputScale: outputScale.value,
-          resetRotation: resetRotation.value,
-          decorations: decorations.value,
+          resetRotation: effectiveResetRotation.value,
+          decorations: effectiveDecorations.value,
+          outputFormat: outputFormat.value,
           fileName: name,
         });
       }
@@ -462,8 +504,9 @@ async function onSubmit() {
         width: width.value,
         height: height.value,
         outputScale: outputScale.value,
-        resetRotation: resetRotation.value,
-        decorations: decorations.value,
+        resetRotation: effectiveResetRotation.value,
+        decorations: effectiveDecorations.value,
+        outputFormat: outputFormat.value,
         fileName: name,
       });
     }
@@ -502,15 +545,15 @@ async function onPreview() {
           outputScale: 1,
           symbolPixelRatio: outputScale.value,
           symbolDisplayScale: previewDisplayScale,
-          resetRotation: resetRotation.value,
-          decorations: decorations.value,
+          resetRotation: effectiveResetRotation.value,
+          decorations: effectiveDecorations.value,
           decorationReferenceShortSide: outputShortSide.value,
         });
       } else {
         blob = await renderViewportFrameToBlob(props.map, viewfinderFrame.value, {
           outputScale: 1,
-          resetRotation: resetRotation.value,
-          decorations: decorations.value,
+          resetRotation: effectiveResetRotation.value,
+          decorations: effectiveDecorations.value,
           decorationReferenceShortSide: outputShortSide.value,
         });
       }
@@ -534,8 +577,8 @@ async function onPreview() {
         width: pw,
         height: ph,
         outputScale: 1,
-        resetRotation: resetRotation.value,
-        decorations: decorations.value,
+        resetRotation: effectiveResetRotation.value,
+        decorations: effectiveDecorations.value,
         decorationReferenceShortSide: outputShortSide.value,
       });
     }
@@ -685,26 +728,52 @@ async function onPreview() {
       description="Export with the map flattened and pointing north, ignoring the current rotation and tilt."
     />
 
-    <fieldset class="space-y-2">
-      <legend class="text-foreground text-sm font-medium">Annotations</legend>
+    <div class="space-y-1">
+      <SimpleSelect
+        v-model="outputFormat"
+        label="Output format"
+        :items="outputFormatItems"
+      />
+      <p v-if="isGeoreferenced" class="text-muted-foreground text-xs">
+        Exports north-up and top-down — the embedded affine assumes axis
+        alignment, so the rendered area may differ from the viewfinder framing
+        when the live map is rotated. Annotations are disabled while a
+        georeferenced format is selected.
+      </p>
+    </div>
+
+    <fieldset class="space-y-2" :disabled="isGeoreferenced">
+      <legend
+        class="text-sm font-medium"
+        :class="isGeoreferenced ? 'text-muted-foreground' : 'text-foreground'"
+      >
+        Annotations
+      </legend>
       <InputCheckbox
         v-model="showScaleBar"
+        :disabled="isGeoreferenced"
         label="Scale bar"
         description="Draw a distance scale bar in the lower-left corner."
       />
       <InputCheckbox
         v-model="showNorthArrow"
+        :disabled="isGeoreferenced"
         label="North arrow"
         description="Draw a compass arrow in the upper-right, oriented to the map's rotation."
       />
       <InputCheckbox
         v-model="showCredits"
+        :disabled="isGeoreferenced"
         label="Map credits"
         description="Print the basemap attribution in the lower-right corner."
       />
     </fieldset>
 
-    <InputGroup v-model="fileName" label="File name" />
+    <InputGroup
+      v-model="fileName"
+      label="File name"
+      :description="`Saved as ${outputFileExtension}.`"
+    />
 
     <Alert v-if="sizeError" variant="destructive">
       <AlertDescription>{{ sizeError }}</AlertDescription>
@@ -732,7 +801,7 @@ async function onPreview() {
         {{ previewing ? "Rendering…" : "Preview" }}
       </SecondaryButton>
       <PrimaryButton type="submit" :disabled="!canExport">
-        {{ exporting ? "Exporting…" : "Export PNG" }}
+        {{ exporting ? "Exporting…" : exportButtonLabel }}
       </PrimaryButton>
     </div>
   </form>

--- a/src/modules/maplibreview/imageExport/geotiffEncoder.test.ts
+++ b/src/modules/maplibreview/imageExport/geotiffEncoder.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The jsdom + fflate realm collision (see mapLibreExport.test.ts) makes the
+// real zlibSync mis-identify our Uint8Array inputs. Replace it with an
+// identity function: the strip then ends up holding the raw RGBA, which lets
+// the tests below verify the TIFF structure end-to-end without inflating.
+vi.mock("fflate", () => ({
+  zlibSync: (data: Uint8Array) => data,
+}));
+
+import { encodeGeoTiff } from "@/modules/maplibreview/imageExport/geotiffEncoder";
+
+const TAG = {
+  ImageWidth: 256,
+  ImageLength: 257,
+  Compression: 259,
+  PhotometricInterpretation: 262,
+  StripOffsets: 273,
+  SamplesPerPixel: 277,
+  StripByteCounts: 279,
+  ModelPixelScale: 33550,
+  ModelTiepoint: 33922,
+  GeoKeyDirectory: 34735,
+  GeoAsciiParams: 34737,
+};
+
+type IFDEntry = {
+  tag: number;
+  type: number;
+  count: number;
+  valueOffset: number;
+};
+
+function readIFD(buf: Uint8Array): { entries: IFDEntry[]; dv: DataView } {
+  const dv = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+  expect(dv.getUint16(0, true)).toBe(0x4949); // "II" little-endian
+  expect(dv.getUint16(2, true)).toBe(42);
+  const ifdOffset = dv.getUint32(4, true);
+  const count = dv.getUint16(ifdOffset, true);
+  const entries: IFDEntry[] = [];
+  for (let i = 0; i < count; i++) {
+    const base = ifdOffset + 2 + i * 12;
+    entries.push({
+      tag: dv.getUint16(base, true),
+      type: dv.getUint16(base + 2, true),
+      count: dv.getUint32(base + 4, true),
+      valueOffset: dv.getUint32(base + 8, true),
+    });
+  }
+  return { entries, dv };
+}
+
+function getEntry(entries: IFDEntry[], tag: number): IFDEntry {
+  const e = entries.find((x) => x.tag === tag);
+  if (!e) throw new Error(`Tag ${tag} not found`);
+  return e;
+}
+
+function readDoubles(dv: DataView, offset: number, count: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < count; i++) out.push(dv.getFloat64(offset + i * 8, true));
+  return out;
+}
+
+function readShorts(dv: DataView, offset: number, count: number): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < count; i++) out.push(dv.getUint16(offset + i * 2, true));
+  return out;
+}
+
+describe("encodeGeoTiff", () => {
+  const width = 4;
+  const height = 2;
+  const rgba = new Uint8Array(width * height * 4);
+  for (let i = 0; i < rgba.length; i++) rgba[i] = i & 0xff;
+  const bounds = { minX: 0, minY: 0, maxX: 1000, maxY: 500 };
+
+  it("writes a valid little-endian TIFF header followed by one IFD", () => {
+    const buf = encodeGeoTiff({ width, height, rgba, bounds, epsgCode: 3857 });
+    const { entries, dv } = readIFD(buf);
+
+    expect(entries.length).toBeGreaterThan(0);
+    // IFD entries must be in ascending tag order.
+    for (let i = 1; i < entries.length; i++) {
+      expect(entries[i].tag).toBeGreaterThan(entries[i - 1].tag);
+    }
+    // After the last entry, the next-IFD pointer is zero (single IFD).
+    const ifdOffset = dv.getUint32(4, true);
+    const nextIfdAt = ifdOffset + 2 + entries.length * 12;
+    expect(dv.getUint32(nextIfdAt, true)).toBe(0);
+  });
+
+  it("records the input dimensions in the baseline tags", () => {
+    const buf = encodeGeoTiff({ width, height, rgba, bounds, epsgCode: 3857 });
+    const { entries } = readIFD(buf);
+    expect(getEntry(entries, TAG.ImageWidth).valueOffset).toBe(width);
+    expect(getEntry(entries, TAG.ImageLength).valueOffset).toBe(height);
+    expect(getEntry(entries, TAG.SamplesPerPixel).valueOffset).toBe(4);
+    expect(getEntry(entries, TAG.PhotometricInterpretation).valueOffset).toBe(2);
+    expect(getEntry(entries, TAG.Compression).valueOffset).toBe(8); // Adobe Deflate
+  });
+
+  it("places the strip at the recorded offset with the recorded byte count", () => {
+    const buf = encodeGeoTiff({ width, height, rgba, bounds, epsgCode: 3857 });
+    const { entries } = readIFD(buf);
+    const offset = getEntry(entries, TAG.StripOffsets).valueOffset;
+    const length = getEntry(entries, TAG.StripByteCounts).valueOffset;
+    expect(offset).toBeGreaterThan(0);
+    expect(length).toBe(rgba.length); // identity-mocked zlib
+
+    const strip = buf.slice(offset, offset + length);
+    expect(strip).toEqual(rgba);
+  });
+
+  it("derives ModelPixelScale and ModelTiepoint from the bounds", () => {
+    const buf = encodeGeoTiff({ width, height, rgba, bounds, epsgCode: 3857 });
+    const { entries, dv } = readIFD(buf);
+
+    const scale = getEntry(entries, TAG.ModelPixelScale);
+    const scaleVals = readDoubles(dv, scale.valueOffset, scale.count);
+    // (maxX-minX)/width=250, (maxY-minY)/height=250, Sz=0.
+    expect(scaleVals).toEqual([250, 250, 0]);
+
+    const tie = getEntry(entries, TAG.ModelTiepoint);
+    const tieVals = readDoubles(dv, tie.valueOffset, tie.count);
+    // Raster origin (0,0,0) anchored to upper-left of the mercator bbox.
+    expect(tieVals).toEqual([0, 0, 0, bounds.minX, bounds.maxY, 0]);
+  });
+
+  it("declares the projected CRS via ProjectedCSTypeGeoKey", () => {
+    const buf = encodeGeoTiff({ width, height, rgba, bounds, epsgCode: 3857 });
+    const { entries, dv } = readIFD(buf);
+
+    const dir = getEntry(entries, TAG.GeoKeyDirectory);
+    const keys = readShorts(dv, dir.valueOffset, dir.count);
+    // Header is the first 4 SHORTs: version, revision, minor, key count.
+    expect(keys[0]).toBe(1);
+    expect(keys[3]).toBe(4);
+
+    // Look up the ProjectedCSType key (3072) and read its inline value.
+    for (let i = 4; i < keys.length; i += 4) {
+      if (keys[i] === 3072) {
+        expect(keys[i + 1]).toBe(0); // inline
+        expect(keys[i + 2]).toBe(1);
+        expect(keys[i + 3]).toBe(3857);
+        return;
+      }
+    }
+    throw new Error("ProjectedCSTypeGeoKey not found in GeoKeyDirectory");
+  });
+
+  it("writes a citation string into GeoAsciiParams terminated by '|\\0'", () => {
+    const buf = encodeGeoTiff({
+      width,
+      height,
+      rgba,
+      bounds,
+      epsgCode: 3857,
+      citation: "Test CRS",
+    });
+    const { entries } = readIFD(buf);
+    const ascii = getEntry(entries, TAG.GeoAsciiParams);
+    const text = new TextDecoder().decode(
+      buf.slice(ascii.valueOffset, ascii.valueOffset + ascii.count),
+    );
+    expect(text).toBe("Test CRS|\0");
+  });
+
+  it("aligns out-of-line tag data on word boundaries", () => {
+    const buf = encodeGeoTiff({ width, height, rgba, bounds, epsgCode: 3857 });
+    const { entries } = readIFD(buf);
+    for (const e of entries) {
+      // Any entry whose value exceeds 4 bytes is stored at an offset, which
+      // the TIFF spec requires to be on a word (even) boundary.
+      const size =
+        e.count *
+        ({ 1: 1, 2: 1, 3: 2, 4: 4, 5: 8, 12: 8 } as Record<number, number>)[e.type];
+      if (size > 4) expect(e.valueOffset % 2).toBe(0);
+    }
+  });
+
+  it("rejects an RGBA buffer whose length does not match width × height × 4", () => {
+    expect(() =>
+      encodeGeoTiff({
+        width: 4,
+        height: 2,
+        rgba: new Uint8Array(10),
+        bounds,
+        epsgCode: 3857,
+      }),
+    ).toThrow();
+  });
+});

--- a/src/modules/maplibreview/imageExport/geotiffEncoder.ts
+++ b/src/modules/maplibreview/imageExport/geotiffEncoder.ts
@@ -1,0 +1,317 @@
+/**
+ * Minimal hand-rolled TIFF/GeoTIFF encoder for the image-export pipeline.
+ *
+ * Writes a little-endian, single-IFD TIFF holding 8-bit RGBA in one
+ * DEFLATE-compressed strip plus the GeoTIFF tags needed to anchor the raster
+ * in a projected CRS (EPSG code referenced via the GeoKey directory).
+ *
+ * The scope is deliberately narrow: one image, RGBA, axis-aligned, one CRS
+ * family (Projected, e.g. EPSG:3857). That avoids pulling in geotiff.js (~50KB
+ * gzipped + an experimental writer) and lets us emit exactly the tag set we
+ * want for QGIS / ArcGIS / GDAL round-trips.
+ *
+ * Format references:
+ * - TIFF 6.0 spec — overall container, IFD layout, baseline tags.
+ * - GeoTIFF 1.0 / OGC 19-008r4 — ModelPixelScale, ModelTiepoint, GeoKeys.
+ */
+
+import { zlibSync } from "fflate";
+import type { MercatorBounds } from "@/modules/maplibreview/imageExport/worldFile";
+
+const TIFF_HEADER_SIZE = 8;
+const IFD_ENTRY_SIZE = 12;
+
+/** TIFF field types. Values match the on-disk tag-type codes. */
+const T = {
+  BYTE: 1,
+  ASCII: 2,
+  SHORT: 3,
+  LONG: 4,
+  RATIONAL: 5,
+  DOUBLE: 12,
+} as const;
+
+type FieldType = (typeof T)[keyof typeof T];
+
+const TYPE_SIZE: Record<FieldType, number> = {
+  [T.BYTE]: 1,
+  [T.ASCII]: 1,
+  [T.SHORT]: 2,
+  [T.LONG]: 4,
+  [T.RATIONAL]: 8,
+  [T.DOUBLE]: 8,
+};
+
+/** Baseline + GeoTIFF tag IDs used by this encoder. */
+const TAG = {
+  ImageWidth: 256,
+  ImageLength: 257,
+  BitsPerSample: 258,
+  Compression: 259,
+  PhotometricInterpretation: 262,
+  StripOffsets: 273,
+  SamplesPerPixel: 277,
+  RowsPerStrip: 278,
+  StripByteCounts: 279,
+  XResolution: 282,
+  YResolution: 283,
+  PlanarConfiguration: 284,
+  ResolutionUnit: 296,
+  ExtraSamples: 338,
+  ModelPixelScale: 33550,
+  ModelTiepoint: 33922,
+  GeoKeyDirectory: 34735,
+  GeoAsciiParams: 34737,
+} as const;
+
+/** GeoKey IDs (see GeoTIFF spec section 6.2). */
+const KEY = {
+  GTModelType: 1024,
+  GTRasterType: 1025,
+  GTCitation: 1026,
+  ProjectedCSType: 3072,
+} as const;
+
+interface IFDEntry {
+  tag: number;
+  type: FieldType;
+  count: number;
+  /** Already serialised value bytes; length must equal count × TYPE_SIZE[type]. */
+  bytes: Uint8Array;
+}
+
+const textEncoder = new TextEncoder();
+
+function packShorts(values: readonly number[]): Uint8Array {
+  const buf = new Uint8Array(values.length * 2);
+  const dv = new DataView(buf.buffer);
+  for (let i = 0; i < values.length; i++) dv.setUint16(i * 2, values[i], true);
+  return buf;
+}
+
+function packLongs(values: readonly number[]): Uint8Array {
+  const buf = new Uint8Array(values.length * 4);
+  const dv = new DataView(buf.buffer);
+  for (let i = 0; i < values.length; i++) dv.setUint32(i * 4, values[i], true);
+  return buf;
+}
+
+function packDoubles(values: readonly number[]): Uint8Array {
+  const buf = new Uint8Array(values.length * 8);
+  const dv = new DataView(buf.buffer);
+  for (let i = 0; i < values.length; i++) dv.setFloat64(i * 8, values[i], true);
+  return buf;
+}
+
+function packRational(numerator: number, denominator: number): Uint8Array {
+  const buf = new Uint8Array(8);
+  const dv = new DataView(buf.buffer);
+  dv.setUint32(0, numerator, true);
+  dv.setUint32(4, denominator, true);
+  return buf;
+}
+
+/** Null-terminated TIFF ASCII value (the trailing `\0` is part of the count). */
+function packAscii(text: string): Uint8Array {
+  return textEncoder.encode(text + "\0");
+}
+
+export interface EncodeGeoTiffOptions {
+  width: number;
+  height: number;
+  /** Tightly packed 8-bit RGBA, length must be width × height × 4. */
+  rgba: Uint8Array;
+  /** Raster extent in the target CRS, used to derive the affine. */
+  bounds: MercatorBounds;
+  /**
+   * EPSG code of a projected CRS. Written as ProjectedCSTypeGeoKey so GIS
+   * tools can resolve the full CRS without GeoDoubleParams gymnastics.
+   */
+  epsgCode: number;
+  /**
+   * Short human-readable name written as GTCitationGeoKey (free-form). Helps
+   * GIS tools display a friendly CRS label.
+   */
+  citation?: string;
+}
+
+/**
+ * Build a GeoTIFF byte buffer from an RGBA raster and a CRS-anchored bounds.
+ *
+ * Layout:
+ *   header (8) → IFD → out-of-line tag data (word-aligned) → strip data
+ *
+ * The IFD's entries are emitted in ascending tag order (TIFF requirement).
+ * Values that don't fit in the 4-byte value/offset field are written
+ * out-of-line in the order they appear in the IFD.
+ */
+export function encodeGeoTiff(opts: EncodeGeoTiffOptions): Uint8Array {
+  const { width, height, rgba, bounds, epsgCode } = opts;
+  const citation = opts.citation ?? `EPSG:${epsgCode}`;
+
+  if (width < 1 || height < 1) {
+    throw new Error("GeoTIFF requires positive image dimensions.");
+  }
+  if (rgba.length !== width * height * 4) {
+    throw new Error(
+      `RGBA length ${rgba.length} does not match ${width}×${height}×4.`,
+    );
+  }
+
+  // Affine: north-up axis-aligned, origin at the upper-left pixel's *corner*
+  // (RasterPixelIsArea — see GTRasterTypeGeoKey below).
+  const pixelSizeX = (bounds.maxX - bounds.minX) / width;
+  const pixelSizeY = (bounds.maxY - bounds.minY) / height;
+  const modelPixelScale = [pixelSizeX, pixelSizeY, 0];
+  const modelTiepoint = [0, 0, 0, bounds.minX, bounds.maxY, 0];
+
+  // GeoAsciiParams holds pipe-terminated strings; the count for an ASCII
+  // GeoKey is the byte length *including* the pipe terminator.
+  const citationWithPipe = citation + "|";
+  const citationByteLength = textEncoder.encode(citationWithPipe).length;
+  const geoAsciiBytes = packAscii(citationWithPipe);
+
+  // GeoKey directory: 4-SHORT header + 4 SHORTs per key.
+  // For inline (location=0) keys, "value" is the actual GeoKey value.
+  // For ASCII keys, "location" is the tag id that holds the strings (34737)
+  // and "value" is the offset (in bytes) into that tag's data.
+  const geoKeys = [
+    1, 1, 1, 4, // KeyDirectoryVersion=1, KeyRevision=1, MinorRevision=1, NumberOfKeys=4
+    KEY.GTModelType, 0, 1, 1, // 1 = ModelTypeProjected
+    KEY.GTRasterType, 0, 1, 1, // 1 = RasterPixelIsArea
+    KEY.GTCitation, TAG.GeoAsciiParams, citationByteLength, 0,
+    KEY.ProjectedCSType, 0, 1, epsgCode,
+  ];
+
+  // Compress the strip up-front so we know its byte count for the IFD.
+  // Adobe Deflate (TIFF Compression code 8) expects a zlib stream (the RFC
+  // 1950 wrapper around RFC 1951 DEFLATE), which is what fflate's zlibSync
+  // emits.
+  const stripData = zlibSync(rgba);
+
+  // Build IFD entries in ascending tag order. StripOffsets is filled in once
+  // we know where the strip actually lands (after the IFD + out-of-line data).
+  const stripOffsetsEntry: IFDEntry = {
+    tag: TAG.StripOffsets,
+    type: T.LONG,
+    count: 1,
+    bytes: packLongs([0]),
+  };
+
+  const entries: IFDEntry[] = [
+    { tag: TAG.ImageWidth, type: T.LONG, count: 1, bytes: packLongs([width]) },
+    { tag: TAG.ImageLength, type: T.LONG, count: 1, bytes: packLongs([height]) },
+    {
+      tag: TAG.BitsPerSample,
+      type: T.SHORT,
+      count: 4,
+      bytes: packShorts([8, 8, 8, 8]),
+    },
+    { tag: TAG.Compression, type: T.SHORT, count: 1, bytes: packShorts([8]) },
+    {
+      tag: TAG.PhotometricInterpretation,
+      type: T.SHORT,
+      count: 1,
+      bytes: packShorts([2]),
+    },
+    stripOffsetsEntry,
+    { tag: TAG.SamplesPerPixel, type: T.SHORT, count: 1, bytes: packShorts([4]) },
+    { tag: TAG.RowsPerStrip, type: T.LONG, count: 1, bytes: packLongs([height]) },
+    {
+      tag: TAG.StripByteCounts,
+      type: T.LONG,
+      count: 1,
+      bytes: packLongs([stripData.length]),
+    },
+    { tag: TAG.XResolution, type: T.RATIONAL, count: 1, bytes: packRational(72, 1) },
+    { tag: TAG.YResolution, type: T.RATIONAL, count: 1, bytes: packRational(72, 1) },
+    {
+      tag: TAG.PlanarConfiguration,
+      type: T.SHORT,
+      count: 1,
+      bytes: packShorts([1]),
+    },
+    { tag: TAG.ResolutionUnit, type: T.SHORT, count: 1, bytes: packShorts([2]) },
+    // 2 = unassociated (straight) alpha — what HTML canvas getImageData emits.
+    { tag: TAG.ExtraSamples, type: T.SHORT, count: 1, bytes: packShorts([2]) },
+    {
+      tag: TAG.ModelPixelScale,
+      type: T.DOUBLE,
+      count: 3,
+      bytes: packDoubles(modelPixelScale),
+    },
+    {
+      tag: TAG.ModelTiepoint,
+      type: T.DOUBLE,
+      count: 6,
+      bytes: packDoubles(modelTiepoint),
+    },
+    {
+      tag: TAG.GeoKeyDirectory,
+      type: T.SHORT,
+      count: geoKeys.length,
+      bytes: packShorts(geoKeys),
+    },
+    {
+      tag: TAG.GeoAsciiParams,
+      type: T.ASCII,
+      count: geoAsciiBytes.length,
+      bytes: geoAsciiBytes,
+    },
+  ];
+
+  // Layout. The TIFF spec requires out-of-line values to start on a word
+  // boundary (even offset); pad whenever the cursor lands on an odd byte.
+  const ifdStart = TIFF_HEADER_SIZE;
+  const ifdSize = 2 + entries.length * IFD_ENTRY_SIZE + 4;
+  let cursor = ifdStart + ifdSize;
+
+  const outOfLineOffsets = new Map<IFDEntry, number>();
+  for (const e of entries) {
+    if (e.bytes.length <= 4) continue;
+    if (cursor % 2 !== 0) cursor++;
+    outOfLineOffsets.set(e, cursor);
+    cursor += e.bytes.length;
+  }
+  if (cursor % 2 !== 0) cursor++;
+  const stripOffset = cursor;
+  stripOffsetsEntry.bytes = packLongs([stripOffset]);
+
+  const totalSize = stripOffset + stripData.length;
+  const buf = new Uint8Array(totalSize);
+  const dv = new DataView(buf.buffer);
+
+  // Header: little-endian ("II"), magic 42, offset to first IFD.
+  buf[0] = 0x49;
+  buf[1] = 0x49;
+  dv.setUint16(2, 42, true);
+  dv.setUint32(4, ifdStart, true);
+
+  // IFD: entry count, entries, next-IFD pointer (0 = none).
+  dv.setUint16(ifdStart, entries.length, true);
+  let entryCursor = ifdStart + 2;
+  for (const e of entries) {
+    dv.setUint16(entryCursor, e.tag, true);
+    dv.setUint16(entryCursor + 2, e.type, true);
+    dv.setUint32(entryCursor + 4, e.count, true);
+    if (e.bytes.length <= 4) {
+      // Inline: bytes occupy the leftmost portion of the 4-byte value field.
+      buf.set(e.bytes, entryCursor + 8);
+    } else {
+      dv.setUint32(entryCursor + 8, outOfLineOffsets.get(e)!, true);
+    }
+    entryCursor += IFD_ENTRY_SIZE;
+  }
+  dv.setUint32(entryCursor, 0, true);
+
+  // Out-of-line payloads, in IFD order.
+  for (const e of entries) {
+    if (e.bytes.length <= 4) continue;
+    buf.set(e.bytes, outOfLineOffsets.get(e)!);
+  }
+
+  // Strip data.
+  buf.set(stripData, stripOffset);
+
+  return buf;
+}

--- a/src/modules/maplibreview/imageExport/mapLibreExport.test.ts
+++ b/src/modules/maplibreview/imageExport/mapLibreExport.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import type { Map as MlMap } from "maplibre-gl";
 
 const maplibreMock = vi.hoisted(() => {
@@ -37,12 +37,36 @@ const maplibreMock = vi.hoisted(() => {
 
     getCanvas() {
       const canvas = document.createElement("canvas");
-      canvas.toBlob = (callback: BlobCallback) => callback(new Blob(["png"]));
+      canvas.toBlob = (callback: BlobCallback) => {
+        const blob = new Blob(["png"]);
+        // jsdom's Blob lacks arrayBuffer in some versions; stub it so the
+        // export pipeline (which converts the rendered blob into bytes for the
+        // zip) can run in the test environment.
+        if (typeof blob.arrayBuffer !== "function") {
+          (blob as unknown as { arrayBuffer: () => Promise<ArrayBuffer> }).arrayBuffer =
+            async () =>
+              new TextEncoder().encode("png").buffer as ArrayBuffer;
+        }
+        callback(blob);
+      };
       return canvas;
     }
 
     getStyle() {
       return this.options.style;
+    }
+
+    getBounds() {
+      return {
+        getWest: () => -10,
+        getSouth: () => 40,
+        getEast: () => 10,
+        getNorth: () => 50,
+      };
+    }
+
+    getBearing() {
+      return 0;
     }
   }
 
@@ -61,9 +85,38 @@ vi.mock("../symbolImageRegistry", async (importOriginal) => {
   };
 });
 
+vi.mock("@/utils/files", () => ({
+  saveBlobToLocalFile: vi.fn(),
+}));
+
+// fflate is faked here because jsdom 27 puts Uint8Array on a different realm
+// than fflate's module-level reference; that breaks fflate's internal
+// `instanceof Uint8Array` checks, so its real zipSync silently produces an
+// unreadable zip when run under vitest+jsdom. The stub captures the input map
+// so the tests can assert what we tried to bundle without depending on
+// fflate's runtime behavior here. (Production runs in a single realm and is
+// unaffected.)
+vi.mock("fflate", () => ({
+  zipSync: vi.fn(
+    (_files: Record<string, Uint8Array>) =>
+      // 22-byte empty-archive end-of-central-directory record. Just enough for
+      // downstream code to wrap it in a Blob without choking.
+      new Uint8Array([
+        0x50, 0x4b, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+      ]),
+  ),
+  strToU8: (s: string) => new TextEncoder().encode(s),
+  // Identity for the same realm-collision reason as zipSync; the GeoTIFF
+  // tests below just verify structure, not the compressed strip's contents.
+  zlibSync: (data: Uint8Array) => data,
+}));
+import { zipSync } from "fflate";
 import {
   boundsFromViewportFrame,
+  buildGeoreferencedZipBytes,
   checkExportSize,
+  exportViewportFrame,
   getMapAttributionText,
   MAX_EXPORT_DIMENSION,
   pixelsFromPaperPreset,
@@ -75,6 +128,13 @@ import {
   getSymbolImageSource,
   type MaplibreSymbolImageSource,
 } from "../symbolImageRegistry";
+import { saveBlobToLocalFile } from "@/utils/files";
+import {
+  mercatorBoundsFromLngLat,
+  serializeWorldFile,
+  WEB_MERCATOR_WKT,
+  worldFileFromMercatorBounds,
+} from "./worldFile";
 
 function fakeImageData(): ImageData {
   return { width: 8, height: 8, data: new Uint8ClampedArray(8 * 8 * 4) } as ImageData;
@@ -333,5 +393,237 @@ describe("prepopulateSymbolImages", () => {
 
     expect(source.renderImage).not.toHaveBeenCalled();
     expect(target.map.addImage).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildGeoreferencedZipBytes", () => {
+  // fflate's `Zippable` allows nested folder maps; in this codepath every
+  // value is a flat byte array, so this narrow cast keeps the test readable.
+  type ZipFileMap = Record<string, Uint8Array>;
+
+  function decode(u8: Uint8Array): string {
+    return new TextDecoder().decode(u8);
+  }
+
+  it("bundles png, pgw and PAM aux.xml entries keyed by the given base name", () => {
+    const png = new Uint8Array([137, 80, 78, 71]); // PNG magic bytes; content is opaque to the bundler.
+    vi.mocked(zipSync).mockClear();
+
+    buildGeoreferencedZipBytes(
+      png,
+      { west: -10, south: 40, east: 10, north: 50 },
+      300,
+      150,
+      "scenario",
+    );
+
+    expect(zipSync).toHaveBeenCalledTimes(1);
+    const [filesArg, options] = vi.mocked(zipSync).mock.calls[0];
+    const files = filesArg as ZipFileMap;
+    expect(Object.keys(files).sort()).toEqual([
+      "scenario.pgw",
+      "scenario.png",
+      "scenario.png.aux.xml",
+    ]);
+    expect(files["scenario.png"]).toBe(png);
+    // PAM sidecar must wrap the WKT in <PAMDataset><SRS>…</SRS></PAMDataset>
+    // with the GDAL ≥ 3.0 axis-mapping attribute, otherwise QGIS/GDAL won't
+    // pick up the CRS from a raster.
+    const auxXml = decode(files["scenario.png.aux.xml"]);
+    expect(auxXml).toContain("<PAMDataset>");
+    expect(auxXml).toContain('dataAxisToSRSAxisMapping="1,2"');
+    expect(auxXml).toContain(WEB_MERCATOR_WKT);
+    // Store-only: PNG is already compressed and the sidecars are tiny.
+    expect(options).toMatchObject({ level: 0 });
+  });
+
+  it("embeds a world file derived from the supplied bounds and pixel size", () => {
+    vi.mocked(zipSync).mockClear();
+
+    buildGeoreferencedZipBytes(
+      new Uint8Array(0),
+      { west: -10, south: 40, east: 10, north: 50 },
+      300,
+      150,
+      "scenario",
+    );
+
+    const expectedWorldFile = serializeWorldFile(
+      worldFileFromMercatorBounds(
+        mercatorBoundsFromLngLat({ west: -10, south: 40, east: 10, north: 50 }),
+        300,
+        150,
+      ),
+    );
+    const [filesArg] = vi.mocked(zipSync).mock.calls[0];
+    expect(decode((filesArg as ZipFileMap)["scenario.pgw"])).toBe(expectedWorldFile);
+  });
+});
+
+describe("exportViewportFrame (georeferenced)", () => {
+  function sourceMapForFrame() {
+    return {
+      getStyle: vi.fn(() => ({ version: 8, sources: {}, layers: [] })),
+      getZoom: vi.fn(() => 7),
+      getBearing: vi.fn(() => 0),
+      getPitch: vi.fn(() => 0),
+      unproject: vi.fn(() => ({ lng: 10, lat: 20 })),
+    } as unknown as MlMap;
+  }
+
+  it("saves the bundle under a .zip filename derived from the user's name", async () => {
+    maplibreMock.instances.length = 0;
+    vi.mocked(saveBlobToLocalFile).mockClear();
+
+    await exportViewportFrame(
+      sourceMapForFrame(),
+      { x: 0, y: 0, width: 600, height: 400 },
+      { outputFormat: "world-file-zip", fileName: "scenario" },
+    );
+
+    expect(saveBlobToLocalFile).toHaveBeenCalledTimes(1);
+    const [savedBlob, savedName] = vi.mocked(saveBlobToLocalFile).mock.calls[0];
+    expect(savedName).toBe("scenario.zip");
+    expect(savedBlob).toBeInstanceOf(Blob);
+    expect((savedBlob as Blob).type).toBe("application/zip");
+  });
+
+  it("strips a .png suffix from the user-supplied name before adding .zip", async () => {
+    maplibreMock.instances.length = 0;
+    vi.mocked(saveBlobToLocalFile).mockClear();
+
+    await exportViewportFrame(
+      sourceMapForFrame(),
+      { x: 0, y: 0, width: 600, height: 400 },
+      { outputFormat: "world-file-zip", fileName: "scenario.png" },
+    );
+
+    const [, savedName] = vi.mocked(saveBlobToLocalFile).mock.calls[0];
+    expect(savedName).toBe("scenario.zip");
+  });
+
+  it("forces north-up rendering (bearing/pitch zero) when georeferenced", async () => {
+    maplibreMock.instances.length = 0;
+    const sourceMap = {
+      getStyle: vi.fn(() => ({ version: 8, sources: {}, layers: [] })),
+      getZoom: vi.fn(() => 7),
+      getBearing: vi.fn(() => 45),
+      getPitch: vi.fn(() => 30),
+      unproject: vi.fn(() => ({ lng: 10, lat: 20 })),
+    } as unknown as MlMap;
+
+    await exportViewportFrame(
+      sourceMap,
+      { x: 0, y: 0, width: 600, height: 400 },
+      { outputFormat: "world-file-zip", resetRotation: false, fileName: "scenario" },
+    );
+
+    expect(maplibreMock.instances[0].options.bearing).toBe(0);
+    expect(maplibreMock.instances[0].options.pitch).toBe(0);
+  });
+});
+
+describe("exportViewportFrame (geotiff)", () => {
+  // The GeoTIFF path copies the rendered canvas into an offscreen 2D canvas to
+  // read RGBA bytes. jsdom doesn't ship a 2D context, so stub the relevant
+  // methods just for these tests.
+  let canvasGetContextSpy: ReturnType<typeof vi.spyOn> | null = null;
+  beforeAll(() => {
+    const proto = HTMLCanvasElement.prototype;
+    const original = proto.getContext;
+    canvasGetContextSpy = vi
+      .spyOn(proto, "getContext")
+      .mockImplementation(function (this: HTMLCanvasElement, type: string, ...rest) {
+        if (type === "2d") {
+          return {
+            drawImage: () => {},
+            getImageData: (_x: number, _y: number, w: number, h: number) => ({
+              width: w,
+              height: h,
+              data: new Uint8ClampedArray(w * h * 4),
+              colorSpace: "srgb" as const,
+            }),
+          } as unknown as CanvasRenderingContext2D;
+        }
+        return original.call(this, type, ...rest);
+      });
+  });
+  afterAll(() => canvasGetContextSpy?.mockRestore());
+
+  function sourceMapForFrame() {
+    return {
+      getStyle: vi.fn(() => ({ version: 8, sources: {}, layers: [] })),
+      getZoom: vi.fn(() => 7),
+      getBearing: vi.fn(() => 0),
+      getPitch: vi.fn(() => 0),
+      unproject: vi.fn(() => ({ lng: 10, lat: 20 })),
+    } as unknown as MlMap;
+  }
+
+  async function bytesOf(blob: Blob): Promise<Uint8Array> {
+    if (typeof blob.arrayBuffer === "function") {
+      return new Uint8Array(await blob.arrayBuffer());
+    }
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(new Uint8Array(reader.result as ArrayBuffer));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsArrayBuffer(blob);
+    });
+  }
+
+  it("saves a .tif with image/tiff mime type", async () => {
+    maplibreMock.instances.length = 0;
+    vi.mocked(saveBlobToLocalFile).mockClear();
+
+    await exportViewportFrame(
+      sourceMapForFrame(),
+      { x: 0, y: 0, width: 600, height: 400 },
+      { outputFormat: "geotiff", fileName: "scenario" },
+    );
+
+    expect(saveBlobToLocalFile).toHaveBeenCalledTimes(1);
+    const [savedBlob, savedName] = vi.mocked(saveBlobToLocalFile).mock.calls[0];
+    expect(savedName).toBe("scenario.tif");
+    expect(savedBlob).toBeInstanceOf(Blob);
+    expect((savedBlob as Blob).type).toBe("image/tiff");
+  });
+
+  it("emits a little-endian TIFF whose first IFD sits at offset 8", async () => {
+    maplibreMock.instances.length = 0;
+    vi.mocked(saveBlobToLocalFile).mockClear();
+
+    await exportViewportFrame(
+      sourceMapForFrame(),
+      { x: 0, y: 0, width: 600, height: 400 },
+      { outputFormat: "geotiff", fileName: "scenario" },
+    );
+
+    const [savedBlob] = vi.mocked(saveBlobToLocalFile).mock.calls[0];
+    const bytes = await bytesOf(savedBlob as Blob);
+    const dv = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    expect(dv.getUint16(0, true)).toBe(0x4949); // "II" little-endian
+    expect(dv.getUint16(2, true)).toBe(42); // TIFF magic
+    expect(dv.getUint32(4, true)).toBe(8); // first IFD immediately follows the header
+  });
+
+  it("forces north-up rendering when GeoTIFF is selected", async () => {
+    maplibreMock.instances.length = 0;
+    const sourceMap = {
+      getStyle: vi.fn(() => ({ version: 8, sources: {}, layers: [] })),
+      getZoom: vi.fn(() => 7),
+      getBearing: vi.fn(() => 45),
+      getPitch: vi.fn(() => 30),
+      unproject: vi.fn(() => ({ lng: 10, lat: 20 })),
+    } as unknown as MlMap;
+
+    await exportViewportFrame(
+      sourceMap,
+      { x: 0, y: 0, width: 600, height: 400 },
+      { outputFormat: "geotiff", resetRotation: false, fileName: "scenario" },
+    );
+
+    expect(maplibreMock.instances[0].options.bearing).toBe(0);
+    expect(maplibreMock.instances[0].options.pitch).toBe(0);
   });
 });

--- a/src/modules/maplibreview/imageExport/mapLibreExport.ts
+++ b/src/modules/maplibreview/imageExport/mapLibreExport.ts
@@ -3,6 +3,7 @@ import maplibregl, {
   type Map as MlMap,
   type StyleImage,
 } from "maplibre-gl";
+import { strToU8, zipSync } from "fflate";
 import { saveBlobToLocalFile } from "@/utils/files";
 import {
   getSymbolImageSource,
@@ -10,7 +11,34 @@ import {
 } from "@/modules/maplibreview/symbolImageRegistry";
 import { isUnitLayerId } from "@/geo/engines/maplibre/unitLayer";
 import { drawMapDecorations } from "@/modules/maplibreview/imageExport/mapDecorations";
+import {
+  mercatorBoundsFromLngLat,
+  serializePamAuxXml,
+  serializeWorldFile,
+  WEB_MERCATOR_WKT,
+  worldFileFromMercatorBounds,
+} from "@/modules/maplibreview/imageExport/worldFile";
+import { encodeGeoTiff } from "@/modules/maplibreview/imageExport/geotiffEncoder";
 import type { MeasurementUnit } from "@/composables/geoMeasurement";
+
+/**
+ * How the rendered raster is delivered to the user.
+ *
+ * - `png`: a plain PNG, no CRS metadata.
+ * - `world-file-zip`: a `.zip` bundling the PNG with a `.pgw` (world file) and
+ *   a `.png.aux.xml` (GDAL PAM CRS sidecar) — broad GIS support, two files.
+ * - `geotiff`: a single self-describing `.tif` with embedded GeoTIFF tags
+ *   (EPSG:3857). Larger file than a PNG but no sidecars.
+ *
+ * The two georeferenced formats both force north-up axis alignment (the
+ * embedded affine assumes bearing = pitch = 0), so a rotated or tilted live
+ * view will export a different visible area than the viewfinder shows.
+ */
+export type ExportFormat = "png" | "world-file-zip" | "geotiff";
+
+export function isGeoreferencedFormat(format: ExportFormat | undefined): boolean {
+  return format === "world-file-zip" || format === "geotiff";
+}
 
 export const MAX_EXPORT_DIMENSION = 16384;
 export const MAX_EXPORT_PIXELS = 64_000_000;
@@ -73,6 +101,13 @@ function ensureFileName(name: string | undefined, fallback = "map.png"): string 
   return /\.(png|jpe?g)$/i.test(trimmed) ? trimmed : `${trimmed}.png`;
 }
 
+/** Filename with any known export extension stripped — for sidecar bundles. */
+function stripExportExtension(name: string | undefined, fallback = "map"): string {
+  const trimmed = (name ?? "").trim();
+  if (!trimmed) return fallback;
+  return trimmed.replace(/\.(png|jpe?g|zip|tiff?)$/i, "") || fallback;
+}
+
 async function canvasToBlob(
   canvas: HTMLCanvasElement,
   mimeType = "image/png",
@@ -115,6 +150,8 @@ export type ViewportExportOptions = {
    * as they will appear in the export. Defaults to this render's own size.
    */
   decorationReferenceShortSide?: number;
+  /** See {@link ExportFormat}. Defaults to `png`. */
+  outputFormat?: ExportFormat;
   fileName?: string;
 };
 
@@ -171,6 +208,8 @@ export type BoundsExportOptions = {
   decorations?: MapDecorations;
   /** See {@link ViewportExportOptions.decorationReferenceShortSide}. */
   decorationReferenceShortSide?: number;
+  /** See {@link ExportFormat}. Defaults to `png`. */
+  outputFormat?: ExportFormat;
   fileName?: string;
 };
 
@@ -199,6 +238,14 @@ export async function renderViewportFrameToBlob(
   frame: ViewportFrame,
   options: ViewportExportOptions = {},
 ): Promise<Blob | null> {
+  return (await renderViewportFrame(map, frame, options))?.blob ?? null;
+}
+
+async function renderViewportFrame(
+  map: MlMap,
+  frame: ViewportFrame,
+  options: ViewportExportOptions,
+): Promise<HiddenMapRender | null> {
   const outputScale = Math.max(1, Math.round(options.outputScale ?? 1));
   const frameWidth = Math.max(1, Math.round(frame.width));
   const frameHeight = Math.max(1, Math.round(frame.height));
@@ -211,15 +258,22 @@ export async function renderViewportFrameToBlob(
   ];
   const center = map.unproject(centerPoint);
 
+  // Both georeferenced formats embed an axis-aligned affine, which is only
+  // valid when bearing and pitch are zero. Force resetRotation in those cases.
+  const resetRotation = isGeoreferencedFormat(options.outputFormat)
+    ? true
+    : !!options.resetRotation;
+
   return renderViaHiddenMap(map, {
     width: frameWidth,
     height: frameHeight,
     outputScale,
     symbolPixelRatio: outputScale,
     symbolDisplayScale: 1,
-    resetRotation: options.resetRotation,
+    resetRotation,
     decorations: options.decorations,
     decorationReferenceShortSide: options.decorationReferenceShortSide,
+    produceRgba: options.outputFormat === "geotiff",
     camera: { center: [center.lng, center.lat], zoom: map.getZoom() },
   });
 }
@@ -229,14 +283,12 @@ export async function exportViewportFrame(
   frame: ViewportFrame,
   options: ViewportExportOptions = {},
 ): Promise<void> {
-  const fileName = ensureFileName(options.fileName, "map.png");
-  const blob = await renderViewportFrameToBlob(map, frame, {
-    outputScale: options.outputScale,
-    resetRotation: options.resetRotation,
-    decorations: options.decorations,
+  const render = await renderViewportFrame(map, frame, options);
+  if (!render) return;
+  await saveRenderedExport(render, {
+    fileName: options.fileName,
+    outputFormat: options.outputFormat ?? "png",
   });
-  if (!blob) return;
-  await saveBlobToLocalFile(blob, fileName);
 }
 
 type HiddenMapCamera = {
@@ -246,9 +298,30 @@ type HiddenMapCamera = {
 };
 
 /**
+ * Result of a hidden-map render: the PNG blob plus the geographic bounds and
+ * actual canvas pixel size the map settled on. Bounds and pixel size are read
+ * directly from the hidden map after it idles, so they reflect any MapLibre
+ * adjustments (fitBounds padding, canvas-size clamping) rather than the values
+ * the caller requested. Both are needed to derive a correct world file.
+ */
+export type HiddenMapRender = {
+  blob: Blob | null;
+  /**
+   * Tightly-packed 8-bit RGBA copied off the hidden map's canvas. Populated
+   * only when the caller asked for it (the GeoTIFF path); null otherwise to
+   * avoid a 4-bytes-per-pixel allocation on the PNG path.
+   */
+  rgba: Uint8Array | null;
+  bounds: { west: number; south: number; east: number; north: number };
+  widthPx: number;
+  heightPx: number;
+};
+
+/**
  * Shared core for the bounds and viewport exports: render the source map's style
  * through a hidden MapLibre map (so the visible map is untouched) at the given
- * base size and output scale, and return the PNG blob.
+ * base size and output scale, and return the PNG blob alongside the rendered
+ * bounds / pixel dimensions.
  *
  * The blob is `width*outputScale` by `height*outputScale`. The map renders at a
  * device pixel ratio of `outputScale`, so every layer — basemap, labels and
@@ -266,9 +339,15 @@ async function renderViaHiddenMap(
     resetRotation?: boolean;
     decorations?: MapDecorations;
     decorationReferenceShortSide?: number;
+    /**
+     * When true, also copy the rendered WebGL canvas into a 2D canvas and
+     * extract its RGBA bytes. Only the GeoTIFF path needs this; PNG and
+     * world-file paths skip it to avoid an extra full-image allocation.
+     */
+    produceRgba?: boolean;
     camera: HiddenMapCamera;
   },
-): Promise<Blob | null> {
+): Promise<HiddenMapRender | null> {
   const {
     width,
     height,
@@ -278,6 +357,7 @@ async function renderViaHiddenMap(
     resetRotation,
     decorations,
     decorationReferenceShortSide,
+    produceRgba,
     camera,
   } = options;
 
@@ -345,13 +425,18 @@ async function renderViaHiddenMap(
 
     const canvas = hiddenMap.getCanvas();
     if (!(canvas instanceof HTMLCanvasElement)) return null;
+    const renderedBounds = readMapBounds(hiddenMap);
+    const renderedSize = { widthPx: canvas.width, heightPx: canvas.height };
+
+    // Build a single "final" image: either the bare WebGL canvas, or a 2D
+    // copy with decorations composited on top. Both blob and rgba derive
+    // from this so a GeoTIFF caller never silently loses decorations.
+    let finalCanvas: HTMLCanvasElement = canvas;
     if (
       decorations &&
       (decorations.scaleBar || decorations.northArrow || decorations.credits)
     ) {
-      // Composite the furniture onto a 2D copy: the live backing canvas is
-      // WebGL, so it has no 2D context to draw scale bar / arrow / credits on.
-      return await composeDecoratedBlob(canvas, {
+      const decorated = buildDecoratedCanvas(canvas, {
         width,
         height,
         referenceShortSide: decorationReferenceShortSide,
@@ -362,14 +447,50 @@ async function renderViaHiddenMap(
         northArrow: !!decorations.northArrow,
         credits: decorations.credits ? getMapAttributionText(sourceMap) : undefined,
       });
+      if (decorated) finalCanvas = decorated;
     }
-    // The backing canvas is already width*outputScale × height*outputScale; emit
-    // it directly so symbols keep every pixel they were rendered with.
-    return await canvasToBlob(canvas, "image/png");
+
+    // PNG encoding is expensive (~1-3s at 4K); skip when the caller only
+    // wants RGBA (the GeoTIFF path).
+    const blob = produceRgba ? null : await canvasToBlob(finalCanvas, "image/png");
+    const rgba = produceRgba ? extractCanvasRgba(finalCanvas) : null;
+    return { blob, rgba, bounds: renderedBounds, ...renderedSize };
   } finally {
     hiddenMap?.remove();
     container.remove();
   }
+}
+
+/**
+ * Copy a canvas through a same-size 2D canvas and read its RGBA back as
+ * tightly-packed bytes. Production canvases always have a 2D context;
+ * `byteOffset`/`byteLength` are forwarded so polyfills that pack ImageData
+ * into a larger or offset buffer still yield the right bytes.
+ */
+function extractCanvasRgba(canvas: HTMLCanvasElement): Uint8Array | null {
+  const copy = document.createElement("canvas");
+  copy.width = canvas.width;
+  copy.height = canvas.height;
+  const ctx = copy.getContext("2d");
+  if (!ctx) return null;
+  ctx.drawImage(canvas, 0, 0);
+  const image = ctx.getImageData(0, 0, copy.width, copy.height);
+  return new Uint8Array(image.data.buffer, image.data.byteOffset, image.data.byteLength);
+}
+
+function readMapBounds(map: MlMap): {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+} {
+  const b = map.getBounds();
+  return {
+    west: b.getWest(),
+    south: b.getSouth(),
+    east: b.getEast(),
+    north: b.getNorth(),
+  };
 }
 
 /**
@@ -380,6 +501,13 @@ export async function renderBoundsToBlob(
   sourceMap: MlMap,
   options: Omit<BoundsExportOptions, "fileName">,
 ): Promise<Blob | null> {
+  return (await renderBounds(sourceMap, options))?.blob ?? null;
+}
+
+async function renderBounds(
+  sourceMap: MlMap,
+  options: Omit<BoundsExportOptions, "fileName">,
+): Promise<HiddenMapRender | null> {
   const outputScale = Math.max(1, Math.round(options.outputScale ?? 1));
   // Validate the final dimensions (base × scale) so an oversized export fails
   // with a clear message instead of silently producing a blank/clamped canvas.
@@ -389,15 +517,22 @@ export async function renderBoundsToBlob(
   );
   if (sizeError) throw new Error(sizeError);
 
+  // Both georeferenced formats embed an axis-aligned affine — see notes on
+  // renderViewportFrame.
+  const resetRotation = isGeoreferencedFormat(options.outputFormat)
+    ? true
+    : !!options.resetRotation;
+
   return renderViaHiddenMap(sourceMap, {
     width: options.width,
     height: options.height,
     outputScale,
     symbolPixelRatio: options.symbolPixelRatio,
     symbolDisplayScale: options.symbolDisplayScale,
-    resetRotation: options.resetRotation,
+    resetRotation,
     decorations: options.decorations,
     decorationReferenceShortSide: options.decorationReferenceShortSide,
+    produceRgba: options.outputFormat === "geotiff",
     camera: { bounds: options.bounds },
   });
 }
@@ -415,7 +550,8 @@ function metersPerCssPixel(map: MlMap, width: number, height: number): number {
 /**
  * Copy the rendered WebGL canvas into a 2D canvas of the same size and draw the
  * requested decorations on top. The 2D context is scaled so {@link
- * drawMapDecorations} can work in CSS pixels.
+ * drawMapDecorations} can work in CSS pixels. Returns null when a 2D context
+ * is unavailable (jsdom etc.) — caller falls back to the bare WebGL canvas.
  *
  * The scale is derived from the *actual* backing-canvas size rather than the
  * requested output scale: MapLibre may clamp the canvas (maxCanvasSize / GPU
@@ -423,7 +559,7 @@ function metersPerCssPixel(map: MlMap, width: number, height: number): number {
  * scale would place the edge-anchored furniture (scale bar, credits, north
  * arrow) off the real canvas and make it vanish.
  */
-async function composeDecoratedBlob(
+function buildDecoratedCanvas(
   source: HTMLCanvasElement,
   opts: {
     width: number;
@@ -436,12 +572,12 @@ async function composeDecoratedBlob(
     northArrow: boolean;
     credits?: string;
   },
-): Promise<Blob | null> {
+): HTMLCanvasElement | null {
   const out = document.createElement("canvas");
   out.width = source.width;
   out.height = source.height;
   const ctx = out.getContext("2d");
-  if (!ctx) return canvasToBlob(source, "image/png");
+  if (!ctx) return null;
   ctx.drawImage(source, 0, 0);
   const pixelRatio = opts.width > 0 ? source.width / opts.width : 1;
   ctx.save();
@@ -459,7 +595,7 @@ async function composeDecoratedBlob(
     credits: opts.credits,
   });
   ctx.restore();
-  return canvasToBlob(out, "image/png");
+  return out;
 }
 
 /** Strip HTML markup from an attribution string, collapsing whitespace. */
@@ -540,11 +676,101 @@ export async function exportMapByBounds(
   sourceMap: MlMap,
   options: BoundsExportOptions,
 ): Promise<void> {
-  const { fileName: rawFileName, ...renderOptions } = options;
-  const fileName = ensureFileName(rawFileName, "map.png");
-  const blob = await renderBoundsToBlob(sourceMap, renderOptions);
-  if (!blob) return;
-  await saveBlobToLocalFile(blob, fileName);
+  const { fileName, outputFormat, ...renderOptions } = options;
+  const render = await renderBounds(sourceMap, { ...renderOptions, outputFormat });
+  if (!render) return;
+  await saveRenderedExport(render, {
+    fileName,
+    outputFormat: outputFormat ?? "png",
+  });
+}
+
+/**
+ * Save a hidden-map render to disk. Routes by output format: plain PNG, a
+ * `.zip` bundle of PNG + `.pgw` + `.png.aux.xml` sidecars, or a
+ * self-describing GeoTIFF `.tif`.
+ */
+async function saveRenderedExport(
+  render: HiddenMapRender,
+  options: { fileName?: string; outputFormat: ExportFormat },
+): Promise<void> {
+  if (options.outputFormat === "geotiff") {
+    if (!render.rgba) {
+      throw new Error(
+        "GeoTIFF export requires pixel access to the rendered canvas, which is not available in this environment.",
+      );
+    }
+    const baseName = stripExportExtension(options.fileName, "map");
+    const tiffBytes = encodeGeoTiff({
+      width: render.widthPx,
+      height: render.heightPx,
+      rgba: render.rgba,
+      bounds: mercatorBoundsFromLngLat(render.bounds),
+      epsgCode: 3857,
+      citation: "WGS 84 / Pseudo-Mercator",
+    });
+    await saveBlobToLocalFile(
+      new Blob([new Uint8Array(tiffBytes)], { type: "image/tiff" }),
+      `${baseName}.tif`,
+    );
+    return;
+  }
+  if (!render.blob) return;
+  if (options.outputFormat === "world-file-zip") {
+    const baseName = stripExportExtension(options.fileName, "map");
+    const pngBytes = new Uint8Array(await render.blob.arrayBuffer());
+    const zipBytes = buildGeoreferencedZipBytes(
+      pngBytes,
+      render.bounds,
+      render.widthPx,
+      render.heightPx,
+      baseName,
+    );
+    await saveBlobToLocalFile(
+      // Wrap in a fresh Uint8Array so the BlobPart signature accepts it (the
+      // upstream type carries an ArrayBufferLike template that may include
+      // SharedArrayBuffer).
+      new Blob([new Uint8Array(zipBytes)], { type: "application/zip" }),
+      `${baseName}.zip`,
+    );
+    return;
+  }
+  await saveBlobToLocalFile(render.blob, ensureFileName(options.fileName, "map.png"));
+}
+
+/**
+ * Build a `.zip` (store-only — PNG is already compressed) containing the
+ * render's PNG plus a `.pgw` (world file) and a `.png.aux.xml` (GDAL PAM CRS)
+ * sidecar describing it as an EPSG:3857 raster. The world file is derived
+ * from the hidden map's actual settled bounds and canvas pixel dimensions so
+ * the affine matches the bytes.
+ *
+ * Exported so the byte content can be verified without round-tripping through
+ * a Blob (jsdom's Blob does not always preserve binary content).
+ */
+export function buildGeoreferencedZipBytes(
+  pngBytes: Uint8Array,
+  bounds: { west: number; south: number; east: number; north: number },
+  widthPx: number,
+  heightPx: number,
+  baseName: string,
+): Uint8Array {
+  const mercator = mercatorBoundsFromLngLat(bounds);
+  const worldFile = serializeWorldFile(
+    worldFileFromMercatorBounds(mercator, widthPx, heightPx),
+  );
+  const zipBytes = zipSync(
+    {
+      [`${baseName}.png`]: pngBytes,
+      [`${baseName}.pgw`]: strToU8(worldFile),
+      [`${baseName}.png.aux.xml`]: strToU8(serializePamAuxXml(WEB_MERCATOR_WKT)),
+    },
+    { level: 0 },
+  );
+  // fflate types its byte arrays with an ArrayBufferLike template that can
+  // include SharedArrayBuffer; copy into a plain Uint8Array so downstream
+  // BlobPart/ArrayBuffer signatures are happy.
+  return new Uint8Array(zipBytes);
 }
 
 /**

--- a/src/modules/maplibreview/imageExport/worldFile.test.ts
+++ b/src/modules/maplibreview/imageExport/worldFile.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import {
+  lngLatToMercator,
+  mercatorBoundsFromLngLat,
+  serializePamAuxXml,
+  serializeWorldFile,
+  WEB_MERCATOR_WKT,
+  worldFileFromMercatorBounds,
+} from "@/modules/maplibreview/imageExport/worldFile";
+
+describe("lngLatToMercator", () => {
+  it("maps the origin to (0, 0)", () => {
+    const p = lngLatToMercator({ lng: 0, lat: 0 });
+    expect(p.x).toBeCloseTo(0, 6);
+    expect(p.y).toBeCloseTo(0, 6);
+  });
+
+  it("matches EPSG:3857 for a known reference point (Greenwich Observatory)", () => {
+    // Reference values from epsg.io transform 4326 → 3857.
+    const p = lngLatToMercator({ lng: -0.0014, lat: 51.4779 });
+    expect(p.x).toBeCloseTo(-155.85, 1);
+    expect(p.y).toBeCloseTo(6706268.07, 1);
+  });
+
+  it("clamps latitudes outside the mercator domain", () => {
+    const north = lngLatToMercator({ lng: 0, lat: 90 });
+    const south = lngLatToMercator({ lng: 0, lat: -90 });
+    expect(Number.isFinite(north.y)).toBe(true);
+    expect(Number.isFinite(south.y)).toBe(true);
+    expect(north.y).toBeGreaterThan(0);
+    expect(south.y).toBeLessThan(0);
+  });
+});
+
+describe("mercatorBoundsFromLngLat", () => {
+  it("converts a lng/lat envelope to a mercator bbox", () => {
+    const b = mercatorBoundsFromLngLat({
+      west: -10,
+      south: 40,
+      east: 10,
+      north: 50,
+    });
+    expect(b.minX).toBeLessThan(b.maxX);
+    expect(b.minY).toBeLessThan(b.maxY);
+    expect(b.minX).toBeCloseTo(-1113194.91, 1);
+    expect(b.maxX).toBeCloseTo(1113194.91, 1);
+  });
+});
+
+describe("worldFileFromMercatorBounds", () => {
+  const bounds = { minX: 0, minY: 0, maxX: 1000, maxY: 500 };
+
+  it("derives positive pixel size in X and negative in Y", () => {
+    const p = worldFileFromMercatorBounds(bounds, 100, 50);
+    expect(p.pixelSizeX).toBe(10);
+    expect(p.pixelSizeY).toBe(-10);
+  });
+
+  it("anchors UL to the centre of the upper-left pixel (half-pixel offset)", () => {
+    const p = worldFileFromMercatorBounds(bounds, 100, 50);
+    // UL pixel corner is (minX, maxY) = (0, 500); centre is half a pixel in.
+    expect(p.upperLeftX).toBe(5);
+    expect(p.upperLeftY).toBe(495);
+  });
+
+  it("keeps the rotation terms at zero for axis-aligned rasters", () => {
+    const p = worldFileFromMercatorBounds(bounds, 100, 50);
+    expect(p.rotationX).toBe(0);
+    expect(p.rotationY).toBe(0);
+  });
+
+  it("rejects non-positive pixel dimensions", () => {
+    expect(() => worldFileFromMercatorBounds(bounds, 0, 50)).toThrow();
+    expect(() => worldFileFromMercatorBounds(bounds, 100, 0)).toThrow();
+  });
+});
+
+describe("serializeWorldFile", () => {
+  it("writes the six parameters in A/D/B/E/C/F order, one per line", () => {
+    const text = serializeWorldFile({
+      pixelSizeX: 10,
+      rotationY: 0,
+      rotationX: 0,
+      pixelSizeY: -10,
+      upperLeftX: 5,
+      upperLeftY: 495,
+    });
+    expect(text.split("\n")).toEqual(["10", "0", "0", "-10", "5", "495"]);
+  });
+
+  it("preserves enough precision to round-trip a sub-millimetre pixel size", () => {
+    const text = serializeWorldFile({
+      pixelSizeX: 0.0000123456789,
+      rotationY: 0,
+      rotationX: 0,
+      pixelSizeY: -0.0000123456789,
+      upperLeftX: -155.85,
+      upperLeftY: 6711386.92,
+    });
+    const [a] = text.split("\n");
+    expect(Number(a)).toBeCloseTo(0.0000123456789, 12);
+  });
+});
+
+describe("WEB_MERCATOR_WKT", () => {
+  it("declares EPSG:3857 with metre units", () => {
+    expect(WEB_MERCATOR_WKT).toContain('AUTHORITY["EPSG","3857"]');
+    expect(WEB_MERCATOR_WKT).toContain('UNIT["metre",1');
+    expect(WEB_MERCATOR_WKT).toContain("Pseudo-Mercator");
+  });
+});
+
+describe("serializePamAuxXml", () => {
+  it("wraps the WKT in a PAMDataset/SRS element with GDAL ≥ 3.0 axis mapping", () => {
+    const xml = serializePamAuxXml(WEB_MERCATOR_WKT);
+    expect(xml).toContain("<PAMDataset>");
+    expect(xml).toContain("</PAMDataset>");
+    expect(xml).toContain('<SRS dataAxisToSRSAxisMapping="1,2">');
+    expect(xml).toContain(WEB_MERCATOR_WKT);
+  });
+});

--- a/src/modules/maplibreview/imageExport/worldFile.ts
+++ b/src/modules/maplibreview/imageExport/worldFile.ts
@@ -1,0 +1,147 @@
+/**
+ * Build a world file (".pgw" sidecar) for a Web Mercator (EPSG:3857) raster.
+ *
+ * A world file is six lines of plain-text affine coefficients that tell GIS
+ * tools where a raster sits in the world. Only valid for axis-aligned,
+ * north-up exports: the export pipeline enforces `bearing = pitch = 0` when
+ * georeferencing is enabled, which keeps the D/B rotation terms at zero.
+ */
+
+/** Semi-major axis of WGS 84 — also the Web Mercator sphere radius. */
+const EARTH_RADIUS_M = 6378137;
+
+/** Web Mercator clamps latitude to roughly ±85.05113° to keep y finite. */
+const MERCATOR_MAX_LAT = 85.05112877980659;
+
+export type LngLat = { lng: number; lat: number };
+
+export type MercatorPoint = { x: number; y: number };
+
+export type MercatorBounds = {
+  minX: number;
+  minY: number;
+  maxX: number;
+  maxY: number;
+};
+
+export type WorldFileParams = {
+  /** Pixel size in X (CRS units per pixel). */
+  pixelSizeX: number;
+  /** Rotation about the Y axis. Zero for axis-aligned rasters. */
+  rotationY: number;
+  /** Rotation about the X axis. Zero for axis-aligned rasters. */
+  rotationX: number;
+  /** Pixel size in Y (negative because rows increase downward). */
+  pixelSizeY: number;
+  /** X coordinate of the centre of the upper-left pixel. */
+  upperLeftX: number;
+  /** Y coordinate of the centre of the upper-left pixel. */
+  upperLeftY: number;
+};
+
+/** Project a WGS 84 lng/lat to Web Mercator (EPSG:3857) metres. */
+export function lngLatToMercator({ lng, lat }: LngLat): MercatorPoint {
+  const clampedLat = Math.max(-MERCATOR_MAX_LAT, Math.min(MERCATOR_MAX_LAT, lat));
+  const x = (EARTH_RADIUS_M * lng * Math.PI) / 180;
+  const y =
+    EARTH_RADIUS_M * Math.log(Math.tan(Math.PI / 4 + (clampedLat * Math.PI) / 360));
+  return { x, y };
+}
+
+/**
+ * Web Mercator bounds derived from a lng/lat envelope. Because the projection
+ * is monotonic on both axes, the bbox extents map one-to-one.
+ */
+export function mercatorBoundsFromLngLat(env: {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+}): MercatorBounds {
+  const sw = lngLatToMercator({ lng: env.west, lat: env.south });
+  const ne = lngLatToMercator({ lng: env.east, lat: env.north });
+  return { minX: sw.x, minY: sw.y, maxX: ne.x, maxY: ne.y };
+}
+
+/**
+ * Build the six world-file parameters for a raster of `widthPx × heightPx`
+ * pixels covering the given mercator bounds. The C/F values are offset by half
+ * a pixel because the world-file convention anchors them to the *centre* of
+ * the upper-left pixel rather than its corner.
+ */
+export function worldFileFromMercatorBounds(
+  bounds: MercatorBounds,
+  widthPx: number,
+  heightPx: number,
+): WorldFileParams {
+  if (widthPx < 1 || heightPx < 1) {
+    throw new Error("World file requires positive pixel dimensions.");
+  }
+  const pixelSizeX = (bounds.maxX - bounds.minX) / widthPx;
+  const pixelSizeY = -(bounds.maxY - bounds.minY) / heightPx;
+  return {
+    pixelSizeX,
+    rotationY: 0,
+    rotationX: 0,
+    pixelSizeY,
+    upperLeftX: bounds.minX + pixelSizeX / 2,
+    upperLeftY: bounds.maxY + pixelSizeY / 2,
+  };
+}
+
+/**
+ * Serialise world-file params as six newline-separated decimal lines, in the
+ * canonical A/D/B/E/C/F order. Full float precision keeps round-trips into
+ * QGIS/ArcGIS lossless.
+ */
+export function serializeWorldFile(p: WorldFileParams): string {
+  return [
+    p.pixelSizeX,
+    p.rotationY,
+    p.rotationX,
+    p.pixelSizeY,
+    p.upperLeftX,
+    p.upperLeftY,
+  ]
+    .map((n) => n.toString())
+    .join("\n");
+}
+
+/**
+ * Canonical EPSG:3857 (WGS 84 / Pseudo-Mercator) WKT. Wrapped in a PAM
+ * `.aux.xml` sidecar by `serializePamAuxXml` for raster CRS declaration.
+ */
+export const WEB_MERCATOR_WKT =
+  'PROJCS["WGS 84 / Pseudo-Mercator",' +
+  'GEOGCS["WGS 84",' +
+  'DATUM["WGS_1984",' +
+  'SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],' +
+  'AUTHORITY["EPSG","6326"]],' +
+  'PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],' +
+  'UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],' +
+  'AUTHORITY["EPSG","4326"]],' +
+  'PROJECTION["Mercator_1SP"],' +
+  'PARAMETER["central_meridian",0],' +
+  'PARAMETER["scale_factor",1],' +
+  'PARAMETER["false_easting",0],' +
+  'PARAMETER["false_northing",0],' +
+  'UNIT["metre",1,AUTHORITY["EPSG","9001"]],' +
+  'AXIS["X",EAST],AXIS["Y",NORTH],' +
+  'AUTHORITY["EPSG","3857"]]';
+
+/**
+ * Serialise a GDAL PAM (Persistent Auxiliary Metadata) sidecar declaring the
+ * raster's CRS — the format GDAL/QGIS read for raster georeferencing, written
+ * as `<image>.aux.xml`.
+ *
+ * The `dataAxisToSRSAxisMapping="1,2"` attribute pins GDAL ≥ 3.0's axis order
+ * to (x, y) so the WKT's `AXIS["X",EAST],AXIS["Y",NORTH]` is honoured rather
+ * than swapped under traditional CRS conventions.
+ */
+export function serializePamAuxXml(wkt: string): string {
+  return (
+    '<PAMDataset>\n' +
+    `  <SRS dataAxisToSRSAxisMapping="1,2">${wkt}</SRS>\n` +
+    '</PAMDataset>\n'
+  );
+}


### PR DESCRIPTION
## Summary

- Adds a three-way **Output format** select to the image export tool: plain PNG, a `.zip` bundle of PNG + `.pgw` world file + `.png.aux.xml` (GDAL PAM CRS) sidecars, or a self-describing **GeoTIFF** (`.tif`) with embedded EPSG:3857 metadata.
- New `worldFile.ts` covers lng/lat → Web Mercator projection, world-file affine math, the canonical WGS 84 / Pseudo-Mercator WKT, and a PAM `.aux.xml` serializer (the format GDAL/QGIS actually read for raster CRS — `.prj` is shapefile-only).
- New `geotiffEncoder.ts` is a minimal hand-rolled TIFF/GeoTIFF writer: single IFD, DEFLATE-compressed RGBA strip, `ModelPixelScale` / `ModelTiepoint`, and a `GeoKeyDirectory` pointing at `ProjectedCSTypeGeoKey` 3857.
- Pipeline threads `outputFormat` through `renderViaHiddenMap`; georeferenced paths force north-up (bearing = pitch = 0) so the embedded affine matches the bytes, and skip live decorations — decorations are computed at submit time and composited onto a 2D canvas used as the shared source for both the PNG blob and the GeoTIFF RGBA, so the two outputs never diverge.