### PR TITLE
Fix feature delete key in MapLibre mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed the Delete key not removing selected scenario features in MapLibre mode.
 - Improved MapLibre feature selection with a click hit tolerance and better shift+click handling.
 - Improved MapLibre draw and modify snapping.
 - Improved MapLibre geometry editing on touch devices.

--- a/src/modules/scenarioeditor/KeyboardScenarioActions.vue
+++ b/src/modules/scenarioeditor/KeyboardScenarioActions.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { GlobalEvents } from "vue-global-events";
-import { computed, inject, watch } from "vue";
+import { computed, inject } from "vue";
 import { useUiStore } from "@/stores/uiStore";
 import { inputEventFilter } from "@/components/helpers";
 import { injectStrict } from "@/utils";
@@ -13,7 +13,7 @@ import { useActiveUnitStore } from "@/stores/dragStore";
 import { useScenarioFeatureActions, useUnitActions } from "@/composables/scenarioActions";
 import { UnitActions } from "@/types/constants";
 import type { FeatureId } from "@/types/scenarioGeoModels";
-import { useGeoStore, useUnitSettingsStore } from "@/stores/geoStore";
+import { useUnitSettingsStore } from "@/stores/geoStore";
 import { useSelectedItems } from "@/stores/selectedStore";
 import { useSelectedWaypoints } from "@/stores/selectedWaypoints";
 import { usePlaybackStore } from "@/stores/playbackStore";
@@ -37,13 +37,14 @@ const {
   activeScenarioEventId,
 } = useSelectedItems();
 const { onUnitAction } = useUnitActions();
-const geoStore = useGeoStore();
 const shortcutsEnabled = computed(() => !uiStore.modalOpen);
 const unitSettings = useUnitSettingsStore();
 const playback = usePlaybackStore();
 const recordingStore = useRecordingStore();
 const { selectedWaypointIds } = useSelectedWaypoints();
-let featureActions: ReturnType<typeof useScenarioFeatureActions> | null = null;
+// Resolve map-dependent utils (zoom/pan) lazily so that engine-agnostic actions
+// like delete work regardless of the active map engine (OpenLayers or MapLibre).
+const featureActions = useScenarioFeatureActions({ activeScenario });
 
 const selectedUnits = computed(() =>
   [...selectedUnitIds.value].map((id) => getUnitById(id)),
@@ -53,19 +54,11 @@ const activeUnit = computed(
   () => (activeUnitId.value && getUnitById(activeUnitId.value)) || null,
 );
 
-watch(
-  () => geoStore.olMap,
-  (olMap) => {
-    featureActions = olMap ? useScenarioFeatureActions({ activeScenario, olMap }) : null;
-  },
-  { immediate: true },
-);
-
 function onFeatureAction(
   featureOrFeaturesId: FeatureId | FeatureId[],
   action: "zoom" | "pan" | "delete" | string,
 ) {
-  featureActions?.onFeatureAction(featureOrFeaturesId, action);
+  featureActions.onFeatureAction(featureOrFeaturesId, action);
 }
 
 const createNewUnit = () => {


### PR DESCRIPTION
## Summary

The Delete key did not remove selected scenario features in MapLibre mode (units worked, and feature delete worked in OpenLayers mode).

The keyboard handler in `KeyboardScenarioActions.vue` created its `featureActions` only inside a watcher gated on `geoStore.olMap`. That computed only returns a value when the native map is an OpenLayers `Map`, so in MapLibre mode it is always `null` — leaving `featureActions = null` and making the Delete handler a no-op for features. Units were unaffected because they go through a separate `onUnitAction` path.

The delete action itself (`geo.deleteFeature`) needs no map; only zoom/pan do, and `useScenarioFeatureActions` already resolves those map utils lazily. Other delete entry points (layers panel, feature details panel) call it directly and already worked in MapLibre — only the keyboard handler had this gate.

## Changes

- Create `featureActions` unconditionally at setup instead of inside an `olMap`-gated watcher.
- Remove the now-dead watcher and unused `geoStore` import.
- Add a CHANGELOG entry.

Type-check passes.