### PR TITLE
Extract unit-resource handling into one module

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,6 +37,24 @@ only its meaningful fields). `LoadableGeometryLayerMeta` is the **loose**
 counterpart used for data still being loaded, upgraded, or partially patched,
 where the kind and its extra fields cannot yet be guaranteed to line up.
 
+### Unit resources
+
+**Unit resource**:
+A counted thing a unit holds, drawn from a catalog: **equipment**, **personnel**,
+or **supplies**. These three are the **resource kinds**. Internally every per-unit
+entry shares one shape — a catalog `id`, a `count`, and an optional `onHand` — so
+the apply and name↔id round-trip logic is written once (`unitResources.ts`) rather
+than per kind.
+_Avoid_: treating equipment/personnel/supplies as three unrelated features at the
+entry level. They diverge only at the **catalog** layer (supplies adds a supply
+class and a unit of measure; equipment and personnel are flat).
+
+**update vs diff** (on a timed unit state):
+An **update** replaces fields on matching resource entries (matched by `id`) — used
+for reorganization. A **diff** accumulates an `onHand` delta on matching entries
+(`onHand = (onHand ?? count) + delta`) — used for attrition and resupply. `diff`
+only ever touches `onHand`.
+
 ## Example dialogue
 
 > **Dev:** The circle isn't rendering after reload.

--- a/src/scenariostore/io.ts
+++ b/src/scenariostore/io.ts
@@ -23,6 +23,7 @@ import {
 } from "./newScenarioStore";
 import { useSymbolSettingsStore } from "@/stores/settingsStore";
 import { isLoading } from "@/scenariostore/index";
+import { entriesToExternal } from "@/scenariostore/unitResources";
 import {
   INTERNAL_NAMES,
   type NState,
@@ -198,88 +199,41 @@ export function serializeUnit(
 }
 
 function serializeToeStuff(nUnit: NUnit, scnState: ScenarioState) {
-  let equipment = nUnit.equipment?.map(({ id, count, onHand }) => {
-    const { name } = scnState.equipmentMap[id];
-    return { name, count, onHand };
-  });
-  if (equipment?.length === 0) equipment = undefined;
-  let personnel = nUnit.personnel?.map(({ id, count, onHand }) => {
-    const { name } = scnState.personnelMap[id];
-    return { name, count, onHand };
-  });
-  if (personnel?.length === 0) personnel = undefined;
-
-  let supplies = nUnit.supplies?.map(({ id, count, onHand }) => {
-    const { name } = scnState.supplyCategoryMap[id];
-    return { name, count, onHand };
-  });
-  if (supplies?.length === 0) supplies = undefined;
-
-  return { equipment, personnel, supplies };
+  const orEmptyUndefined = <T,>(entries: T[] | undefined) =>
+    entries?.length ? entries : undefined;
+  return {
+    equipment: orEmptyUndefined(
+      entriesToExternal(nUnit.equipment, (id) => scnState.equipmentMap[id].name),
+    ),
+    personnel: orEmptyUndefined(
+      entriesToExternal(nUnit.personnel, (id) => scnState.personnelMap[id].name),
+    ),
+    supplies: orEmptyUndefined(
+      entriesToExternal(nUnit.supplies, (id) => scnState.supplyCategoryMap[id].name),
+    ),
+  };
 }
 
 function serializeState(s: NState, scnState: ScenarioState) {
-  let diffEquipment, diffPersonnel, diffSupplies;
   const c = klona(s) as State;
 
-  if (s.diff) {
-    if (s.diff.equipment) {
-      diffEquipment = s.diff.equipment.map(({ id, count, onHand }) => {
-        return { name: scnState.equipmentMap[id]?.name ?? id, count, onHand };
-      });
-    }
+  const resourceBlockToExternal = (block: NState["update"]) => ({
+    equipment: entriesToExternal(
+      block?.equipment,
+      (id) => scnState.equipmentMap[id]?.name ?? id,
+    ),
+    personnel: entriesToExternal(
+      block?.personnel,
+      (id) => scnState.personnelMap[id]?.name ?? id,
+    ),
+    supplies: entriesToExternal(
+      block?.supplies,
+      (id) => scnState.supplyCategoryMap[id]?.name ?? id,
+    ),
+  });
 
-    if (s.diff?.personnel) {
-      diffPersonnel = s.diff.personnel.map(({ id, count, onHand }) => {
-        return { name: scnState.personnelMap[id]?.name ?? id, count, onHand };
-      });
-    }
-
-    if (s.diff?.supplies) {
-      diffSupplies = s.diff.supplies.map(({ id, count, onHand }) => {
-        return {
-          name: scnState.supplyCategoryMap[id]?.name ?? id,
-          count,
-          onHand,
-        };
-      });
-    }
-    c.diff = {
-      equipment: diffEquipment,
-      personnel: diffPersonnel,
-      supplies: diffSupplies,
-    };
-  }
-
-  if (s.update) {
-    let updateEquipment, updatePersonnel, updateSupplies;
-
-    if (s.update.equipment) {
-      updateEquipment = s.update.equipment.map(({ id, count, onHand }) => {
-        return { name: scnState.equipmentMap[id]?.name ?? id, count, onHand };
-      });
-    }
-    if (s.update.personnel) {
-      updatePersonnel = s.update.personnel.map(({ id, count, onHand }) => {
-        return { name: scnState.personnelMap[id]?.name ?? id, count, onHand };
-      });
-    }
-
-    if (s.update.supplies) {
-      updateSupplies = s.update.supplies.map(({ id, count, onHand }) => {
-        return {
-          name: scnState.supplyCategoryMap[id]?.name ?? id,
-          count,
-          onHand,
-        };
-      });
-    }
-    c.update = {
-      equipment: updateEquipment,
-      personnel: updatePersonnel,
-      supplies: updateSupplies,
-    };
-  }
+  if (s.diff) c.diff = resourceBlockToExternal(s.diff);
+  if (s.update) c.update = resourceBlockToExternal(s.update);
 
   if (s.status) {
     c.status = scnState.unitStatusMap[s.status]?.name;

--- a/src/scenariostore/newScenarioStore.ts
+++ b/src/scenariostore/newScenarioStore.ts
@@ -44,6 +44,7 @@ import type {
   NUnitSupply,
 } from "@/types/internalModels";
 import { useScenarioTime } from "./time";
+import { entriesToInternal } from "@/scenariostore/unitResources";
 import type {
   FeatureId,
   RangeRing,
@@ -269,42 +270,32 @@ export function prepareScenario(newScenario: Scenario | LoadableScenario): Scena
       });
     unit._state = null;
 
+    const resourceBlockToInternal = (block: State["update"]) =>
+      block
+        ? {
+            equipment: entriesToInternal(
+              block.equipment,
+              (name) => tempEquipmentIdMap[name] ?? name,
+            ),
+            personnel: entriesToInternal(
+              block.personnel,
+              (name) => tempPersonnelIdMap[name] ?? name,
+            ),
+            supplies: entriesToInternal(
+              block.supplies,
+              (name) => tempSuppliesIdMap[name] ?? name,
+            ),
+          }
+        : undefined;
+
     const newState: NState[] = unit.state.map((s) => {
       const { update, diff, ...rest } = s;
       checkFillColor(s);
-      const newUpdate = update
-        ? {
-            equipment: update.equipment?.map((e) => {
-              const { name, ...rest } = e;
-              return { id: tempEquipmentIdMap[name] ?? name, ...rest };
-            }),
-            personnel: update.personnel?.map((p) => {
-              const { name, ...rest } = p;
-              return { id: tempPersonnelIdMap[name] ?? name, ...rest };
-            }),
-            supplies: update.supplies?.map((s) => {
-              const { name, ...rest } = s;
-              return { id: tempSuppliesIdMap[name] ?? name, ...rest };
-            }),
-          }
-        : undefined;
-      const newDiff = diff
-        ? {
-            equipment: diff.equipment?.map((e) => {
-              const { name, ...rest } = e;
-              return { id: tempEquipmentIdMap[name] ?? name, ...rest };
-            }),
-            personnel: diff.personnel?.map((p) => {
-              const { name, ...rest } = p;
-              return { id: tempPersonnelIdMap[name] ?? name, ...rest };
-            }),
-            supplies: diff.supplies?.map((s) => {
-              const { name, ...rest } = s;
-              return { id: tempSuppliesIdMap[name] ?? name, ...rest };
-            }),
-          }
-        : undefined;
-      return { ...rest, update: newUpdate, diff: newDiff };
+      return {
+        ...rest,
+        update: resourceBlockToInternal(update),
+        diff: resourceBlockToInternal(diff),
+      };
     });
 
     newState.forEach((stateEntry) => {

--- a/src/scenariostore/time.ts
+++ b/src/scenariostore/time.ts
@@ -19,6 +19,11 @@ import { nanoid } from "@/utils";
 import { resolveTimeZone } from "@/utils/militaryTimeZones";
 import { syncTimedHierarchyProjection } from "@/scenariostore/hierarchy";
 import {
+  applyResourceDiff,
+  applyResourceUpdate,
+  RESOURCE_KINDS,
+} from "@/scenariostore/unitResources";
+import {
   createInitialGeometryLayerItemState,
   type CurrentGeometryLayerItemState,
   isNGeometryLayerItem,
@@ -71,73 +76,10 @@ export function updateCurrentUnitState(
   for (const s of unit.state) {
     if (s.t <= timestamp) {
       const { diff, update, ...rest } = s;
-      if (update?.equipment && currentState?.equipment) {
-        for (const e of update.equipment) {
-          const idx = currentState.equipment.findIndex((ee) => ee.id === e.id);
-          if (idx !== -1) {
-            currentState.equipment[idx] = { ...currentState.equipment[idx], ...e };
-          } else {
-            console.warn("Equipment not found", e);
-          }
-        }
-      }
-      if (update?.personnel && currentState?.personnel) {
-        for (const p of update.personnel) {
-          const idx = currentState.personnel.findIndex((pp) => pp.id === p.id);
-          if (idx !== -1) {
-            currentState.personnel[idx] = { ...currentState.personnel[idx], ...p };
-          } else {
-            console.warn("Personnel not found", p);
-          }
-        }
-      }
-
-      if (update?.supplies && currentState?.supplies) {
-        for (const p of update.supplies) {
-          const idx = currentState.supplies.findIndex((pp) => pp.id === p.id);
-          if (idx !== -1) {
-            currentState.supplies[idx] = { ...currentState.supplies[idx], ...p };
-          } else {
-            console.warn("Supplies not found", p);
-          }
-        }
-      }
-
-      if (diff?.equipment && currentState?.equipment) {
-        for (const e of diff.equipment) {
-          const idx = currentState.equipment.findIndex((ee) => ee.id === e.id);
-          if (idx !== -1) {
-            const eq = currentState.equipment[idx];
-            const onHand = (eq?.onHand ?? eq.count) + (e.onHand ?? 0);
-            currentState.equipment[idx] = { ...currentState.equipment[idx], onHand };
-          } else {
-            console.warn("Equipment not found", e);
-          }
-        }
-      }
-      if (diff?.personnel && currentState?.personnel) {
-        for (const p of diff.personnel) {
-          const idx = currentState.personnel.findIndex((pp) => pp.id === p.id);
-          if (idx !== -1) {
-            const pe = currentState.personnel[idx];
-            const onHand = (pe?.onHand ?? pe.count) + (p.onHand ?? 0);
-            currentState.personnel[idx] = { ...currentState.personnel[idx], onHand };
-          } else {
-            console.warn("Personnel not found", p);
-          }
-        }
-      }
-
-      if (diff?.supplies && currentState?.supplies) {
-        for (const p of diff.supplies) {
-          const idx = currentState.supplies.findIndex((pp) => pp.id === p.id);
-          if (idx !== -1) {
-            const pe = currentState.supplies[idx];
-            const onHand = (pe?.onHand ?? pe.count) + (p.onHand ?? 0);
-            currentState.supplies[idx] = { ...currentState.supplies[idx], onHand };
-          } else {
-            console.warn("Supplies not found", p);
-          }
+      if (update || diff) {
+        for (const kind of RESOURCE_KINDS) {
+          applyResourceUpdate(currentState?.[kind], update?.[kind], kind);
+          applyResourceDiff(currentState?.[kind], diff?.[kind], kind);
         }
       }
       currentState = { ...currentState, ...rest };

--- a/src/scenariostore/unitResources.test.ts
+++ b/src/scenariostore/unitResources.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  applyResourceDiff,
+  applyResourceUpdate,
+  entriesToExternal,
+  entriesToInternal,
+  type ResourceEntry,
+} from "./unitResources";
+
+describe("applyResourceUpdate", () => {
+  it("replaces fields on the entry matched by id", () => {
+    const target = [
+      { id: "a", count: 10, onHand: 10 },
+      { id: "b", count: 5, onHand: 5 },
+    ];
+    applyResourceUpdate(target, [{ id: "b", count: 8 }], "equipment");
+    expect(target).toEqual([
+      { id: "a", count: 10, onHand: 10 },
+      { id: "b", count: 8, onHand: 5 },
+    ]);
+  });
+
+  it("warns and skips entries with no match", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const target = [{ id: "a", count: 1 }];
+    applyResourceUpdate(target, [{ id: "missing", count: 9 }], "personnel");
+    expect(target).toEqual([{ id: "a", count: 1 }]);
+    expect(warn).toHaveBeenCalledWith("personnel not found", { id: "missing", count: 9 });
+    warn.mockRestore();
+  });
+
+  it("is a no-op when target or updates are undefined", () => {
+    expect(() => applyResourceUpdate(undefined, [{ id: "a" }], "supplies")).not.toThrow();
+    const target = [{ id: "a", count: 1 }];
+    applyResourceUpdate(target, undefined, "supplies");
+    expect(target).toEqual([{ id: "a", count: 1 }]);
+  });
+});
+
+describe("applyResourceDiff", () => {
+  it("accumulates an onHand delta on the matched entry", () => {
+    const target = [{ id: "a", count: 10, onHand: 10 }];
+    applyResourceDiff(target, [{ id: "a", onHand: -3 }], "equipment");
+    applyResourceDiff(target, [{ id: "a", onHand: 1 }], "equipment");
+    expect(target).toEqual([{ id: "a", count: 10, onHand: 8 }]);
+  });
+
+  it("defaults onHand to count before the first delta", () => {
+    const target: ResourceEntry[] = [{ id: "a", count: 12 }];
+    applyResourceDiff(target, [{ id: "a", onHand: -2 }], "supplies");
+    expect(target).toEqual([{ id: "a", count: 12, onHand: 10 }]);
+  });
+
+  it("treats a missing delta as zero", () => {
+    const target = [{ id: "a", count: 4, onHand: 4 }];
+    applyResourceDiff(target, [{ id: "a" }], "personnel");
+    expect(target).toEqual([{ id: "a", count: 4, onHand: 4 }]);
+  });
+});
+
+describe("name↔id round-trip", () => {
+  it("maps name→id and back, preserving other fields", () => {
+    const external = [{ name: "Rifle", count: 30, onHand: 28 }];
+    const nameToId = (name: string) => ({ Rifle: "eq-1" })[name] ?? name;
+    const idToName = (id: string) => ({ "eq-1": "Rifle" })[id] ?? id;
+
+    const internal = entriesToInternal(external, nameToId);
+    expect(internal).toEqual([{ id: "eq-1", count: 30, onHand: 28 }]);
+
+    const back = entriesToExternal(internal, idToName);
+    expect(back).toEqual(external);
+  });
+
+  it("falls back to the raw key when the catalog has no entry", () => {
+    expect(entriesToInternal([{ name: "x", count: 1 }], (n) => n)).toEqual([
+      { id: "x", count: 1 },
+    ]);
+    expect(entriesToExternal([{ id: "x", count: 1 }], (id) => id)).toEqual([
+      { name: "x", count: 1 },
+    ]);
+  });
+
+  it("passes undefined through", () => {
+    expect(entriesToInternal(undefined, (n) => n)).toBeUndefined();
+    expect(entriesToExternal(undefined, (id) => id)).toBeUndefined();
+  });
+});

--- a/src/scenariostore/unitResources.ts
+++ b/src/scenariostore/unitResources.ts
@@ -1,0 +1,80 @@
+/**
+ * Unit resources — the counted things a unit holds (equipment, personnel, supplies),
+ * each drawn from a catalog. See CONTEXT.md › Unit resources.
+ *
+ * The three kinds share one per-entry shape (`id`, `count`, optional `onHand`) and one
+ * set of timeline semantics, so the apply and name↔id round-trip logic lives here once
+ * instead of being copied per kind across time.ts, newScenarioStore.ts, and io.ts.
+ */
+
+/** The three resource kinds a unit holds. Order is not significant. */
+export const RESOURCE_KINDS = ["equipment", "personnel", "supplies"] as const;
+export type ResourceKind = (typeof RESOURCE_KINDS)[number];
+
+/** A counted thing a unit holds, resolved to a catalog id. */
+export interface ResourceEntry {
+  id: string;
+  count: number;
+  onHand?: number;
+}
+
+/**
+ * `update` semantics — replace fields on matching entries (matched by `id`).
+ * Mutates `target` in place; entries with no match are warned and skipped using
+ * `label` (e.g. the resource kind) for diagnostics.
+ */
+export function applyResourceUpdate<T extends ResourceEntry>(
+  target: T[] | undefined,
+  updates: Partial<T>[] | undefined,
+  label: string,
+): void {
+  if (!updates || !target) return;
+  for (const u of updates) {
+    const idx = target.findIndex((e) => e.id === u.id);
+    if (idx === -1) {
+      console.warn(`${label} not found`, u);
+      continue;
+    }
+    target[idx] = { ...target[idx], ...u };
+  }
+}
+
+/**
+ * `diff` semantics — accumulate an `onHand` delta on matching entries (matched by `id`).
+ * `onHand` defaults to `count` when unset before the first delta is applied.
+ * Mutates `target` in place; entries with no match are warned and skipped using
+ * `label` (e.g. the resource kind) for diagnostics.
+ */
+export function applyResourceDiff<T extends ResourceEntry>(
+  target: T[] | undefined,
+  diffs: Partial<T>[] | undefined,
+  label: string,
+): void {
+  if (!diffs || !target) return;
+  for (const d of diffs) {
+    const idx = target.findIndex((e) => e.id === d.id);
+    if (idx === -1) {
+      console.warn(`${label} not found`, d);
+      continue;
+    }
+    const cur = target[idx];
+    const onHand = (cur.onHand ?? cur.count) + (d.onHand ?? 0);
+    target[idx] = { ...cur, onHand };
+  }
+}
+
+/** External → internal: map each entry's `name` to a catalog `id`, preserving other fields. */
+export function entriesToInternal<E extends { name: string }>(
+  entries: E[] | undefined,
+  nameToId: (name: string) => string,
+): (Omit<E, "name"> & { id: string })[] | undefined {
+  return entries?.map(({ name, ...rest }) => ({ id: nameToId(name), ...rest }));
+}
+
+/** Internal → external: map each entry's catalog `id` back to a `name`, preserving other fields. */
+export function entriesToExternal<E extends { id: string }>(
+  entries: E[] | undefined,
+  idToName: (id: string) => string,
+): (Omit<E, "id"> & { name: string })[] | undefined {
+  return entries?.map(({ id, ...rest }) => ({ name: idToName(id), ...rest }));
+}

--- a/src/scenariostore/unitResources.ts
+++ b/src/scenariostore/unitResources.ts
@@ -25,7 +25,7 @@ export interface ResourceEntry {
  */
 export function applyResourceUpdate<T extends ResourceEntry>(
   target: T[] | undefined,
-  updates: Partial<T>[] | undefined,
+  updates: (Partial<T> & { id: string })[] | undefined,
   label: string,
 ): void {
   if (!updates || !target) return;
@@ -47,7 +47,7 @@ export function applyResourceUpdate<T extends ResourceEntry>(
  */
 export function applyResourceDiff<T extends ResourceEntry>(
   target: T[] | undefined,
-  diffs: Partial<T>[] | undefined,
+  diffs: (Partial<T> & { id: string })[] | undefined,
   label: string,
 ): void {
   if (!diffs || !target) return;


### PR DESCRIPTION
Equipment, personnel, and supplies share one per-unit entry shape (`id`, `count`, optional `onHand`) and one set of timeline semantics, but the apply and name↔id round-trip logic was copy-pasted once per kind across `time.ts`, `newScenarioStore.ts`, and `io.ts` (six near-identical loops in `updateCurrentUnitState` alone).

This collapses the per-kind copies into a single tested module, `src/scenariostore/unitResources.ts`.

## What changed

- **`applyResourceUpdate` / `applyResourceDiff`** replace the six update/diff loops in `updateCurrentUnitState` with one `RESOURCE_KINDS` loop. `diff`'s "accumulate `onHand` delta" rule (`onHand = (onHand ?? count) + delta`) is now stated once instead of implicitly in three places.
- **`entriesToInternal` / `entriesToExternal`** own the name↔id translation used by `prepareUnit` (in) and `serializeState` / `serializeToeStuff` (out) — a pair of inverses pinned by a round-trip test.
- The hot loop short-circuits (`if (update || diff)`) so timeline-scrub frames that change no resources skip the kind loop.

Net `+~85 / −177` lines across the three call sites.

## Scope

The **catalog layer is deliberately left untouched**: supplies diverges there (supply class + unit of measure) where equipment and personnel are flat. The seam is drawn at the per-unit entry, which is uniform across all three kinds. Other id→name sites (`unitManipulations` expand, `unitStateManipulations` cleanup) are candidate follow-ups, not in this change.

Adds a `unitResources` test (11 cases) and a `Unit resources` section to `CONTEXT.md`.

`pnpm type-check` clean; `pnpm test:unit` for `src/scenariostore/` green (83 tests).