### PR TITLE
Add ScenarioCodec for the external⇄internal round-trip

### DIFF
--- a/src/importexport/convertUtils.ts
+++ b/src/importexport/convertUtils.ts
@@ -13,6 +13,7 @@ import {
   convertStateToInternalFormat,
   type ScenarioState,
 } from "@/scenariostore/newScenarioStore";
+import { unitStateToInternal } from "@/scenariostore/scenarioCodec";
 import type { RangeRing } from "@/types/scenarioGeoModels";
 import { getCustomSymbolId, setSid } from "@/symbology/helpers.ts";
 import { klona } from "klona";
@@ -204,46 +205,13 @@ export function addUnitHierarchy(
           s.status = tempUnitStatusIdMap[s.status!] || addUnitStatus({ name: s.status! });
         });
 
-      const internalUnitState: NState[] = unitState.map((s) => {
-        const { update, diff, ...rest } = s;
-        const newUpdate = update
-          ? {
-              equipment: update.equipment?.map((e) => {
-                const { name, ...rest } = e;
-                return { id: equipmentNameToIdMap[name] ?? name, ...rest };
-              }),
-              personnel: update.personnel?.map((p) => {
-                const { name, ...rest } = p;
-                return { id: personnelNameToIdMap[name] ?? name, ...rest };
-              }),
-              supplies: update.supplies?.map((s) => {
-                const { name, ...rest } = s;
-                return { id: supplyNameToIdMap[name] ?? name, ...rest };
-              }),
-            }
-          : undefined;
-        const newDiff = diff
-          ? {
-              equipment: diff.equipment?.map((e) => {
-                const { name, ...rest } = e;
-                return { id: equipmentNameToIdMap[name] ?? name, ...rest };
-              }),
-              personnel: diff.personnel?.map((p) => {
-                const { name, ...rest } = p;
-                return { id: personnelNameToIdMap[name] ?? name, ...rest };
-              }),
-              supplies: diff.supplies?.map((s) => {
-                const { name, ...rest } = s;
-                return { id: supplyNameToIdMap[name] ?? name, ...rest };
-              }),
-            }
-          : undefined;
-        return {
-          ...rest,
-          update: newUpdate,
-          diff: newDiff,
-        };
-      });
+      const internalUnitState: NState[] = unitState.map((s) =>
+        unitStateToInternal(s, {
+          equipment: equipmentNameToIdMap,
+          personnel: personnelNameToIdMap,
+          supplies: supplyNameToIdMap,
+        }),
+      );
 
       let status = undefined;
       if (unit.status) {

--- a/src/scenariostore/io.ts
+++ b/src/scenariostore/io.ts
@@ -8,11 +8,9 @@ import type {
   ScenarioInfo,
   Side,
   SideGroup,
-  State,
   SupplyCategory,
   SupplyClass,
   SymbologyStandard,
-  Unit,
   UnitOfMeasure,
   UnitStatus,
 } from "@/types/scenarioModels";
@@ -21,15 +19,10 @@ import {
   type ScenarioState,
   useNewScenarioStore,
 } from "./newScenarioStore";
+import { type SerializeUnitOptions, unitToExternal } from "./scenarioCodec";
 import { useSymbolSettingsStore } from "@/stores/settingsStore";
 import { isLoading } from "@/scenariostore/index";
-import { entriesToExternal } from "@/scenariostore/unitResources";
-import {
-  INTERNAL_NAMES,
-  type NState,
-  type NUnit,
-  TIMESTAMP_NAMES,
-} from "@/types/internalModels";
+import { INTERNAL_NAMES, TIMESTAMP_NAMES } from "@/types/internalModels";
 import dayjs from "dayjs";
 import { resolveTimeZone } from "@/utils/militaryTimeZones";
 import type { RangeRingGroup, ScenarioMapLayer } from "@/types/scenarioGeoModels";
@@ -140,7 +133,7 @@ function getSides(state: ScenarioState): Side[] {
     return {
       ...rest,
       subUnits: (_baseSubUnits ?? group.subUnits).map((unitId) =>
-        serializeUnit(unitId, state),
+        unitToExternal(unitId, state),
       ),
     };
   }
@@ -154,92 +147,16 @@ function getSides(state: ScenarioState): Side[] {
         groups: nSide.groups.map((groupId) => getSideGroup(groupId)),
         subUnits: (_baseSubUnits ?? nSide.subUnits).length
           ? (_baseSubUnits ?? nSide.subUnits).map((unitId) =>
-              serializeUnit(unitId, state),
+              unitToExternal(unitId, state),
             )
           : undefined,
       };
     });
 }
 
-export type SerializeUnitOptions = {
-  newId?: boolean;
-  includeSubUnits?: boolean;
-};
-
-export function serializeUnit(
-  unitId: EntityId,
-  scnState: ScenarioState,
-  options: SerializeUnitOptions = {},
-): Unit {
-  const { newId = false, includeSubUnits = true } = options;
-  const nUnit = scnState.unitMap[unitId];
-  const { equipment, personnel, supplies } = serializeToeStuff(nUnit, scnState);
-  let rangeRings = nUnit.rangeRings?.map(({ group, ...rest }) => {
-    return group ? { group: scnState.rangeRingGroupMap[group].name, ...rest } : rest;
-  });
-
-  if (rangeRings?.length === 0) rangeRings = undefined;
-  const { id, state, _basePid, _baseSubUnits, ...rest } = nUnit;
-
-  return {
-    id: newId ? nanoid() : id,
-    ...rest,
-    status: nUnit.status ? scnState.unitStatusMap[nUnit.status]?.name : undefined,
-    subUnits: includeSubUnits
-      ? (_baseSubUnits ?? nUnit.subUnits).map((subUnitId) =>
-          serializeUnit(subUnitId, scnState, options),
-        )
-      : [],
-    equipment,
-    personnel,
-    supplies,
-    rangeRings,
-    state: state ? state.map((s) => serializeState(s, scnState)) : undefined,
-  };
-}
-
-function serializeToeStuff(nUnit: NUnit, scnState: ScenarioState) {
-  const orEmptyUndefined = <T,>(entries: T[] | undefined) =>
-    entries?.length ? entries : undefined;
-  return {
-    equipment: orEmptyUndefined(
-      entriesToExternal(nUnit.equipment, (id) => scnState.equipmentMap[id].name),
-    ),
-    personnel: orEmptyUndefined(
-      entriesToExternal(nUnit.personnel, (id) => scnState.personnelMap[id].name),
-    ),
-    supplies: orEmptyUndefined(
-      entriesToExternal(nUnit.supplies, (id) => scnState.supplyCategoryMap[id].name),
-    ),
-  };
-}
-
-function serializeState(s: NState, scnState: ScenarioState) {
-  const c = klona(s) as State;
-
-  const resourceBlockToExternal = (block: NState["update"]) => ({
-    equipment: entriesToExternal(
-      block?.equipment,
-      (id) => scnState.equipmentMap[id]?.name ?? id,
-    ),
-    personnel: entriesToExternal(
-      block?.personnel,
-      (id) => scnState.personnelMap[id]?.name ?? id,
-    ),
-    supplies: entriesToExternal(
-      block?.supplies,
-      (id) => scnState.supplyCategoryMap[id]?.name ?? id,
-    ),
-  });
-
-  if (s.diff) c.diff = resourceBlockToExternal(s.diff);
-  if (s.update) c.update = resourceBlockToExternal(s.update);
-
-  if (s.status) {
-    c.status = scnState.unitStatusMap[s.status]?.name;
-  }
-  return c;
-}
+// Unit/state serialization (internal → external) lives in the ScenarioCodec so the
+// round-trip invariant has a single home. Re-exported here for existing import sites.
+export { unitToExternal as serializeUnit, type SerializeUnitOptions };
 
 function getStoredOverlayLayers(state: ScenarioState): ScenarioOverlayLayer[] {
   const layers: ScenarioOverlayLayer[] = [];

--- a/src/scenariostore/newScenarioStore.ts
+++ b/src/scenariostore/newScenarioStore.ts
@@ -19,6 +19,7 @@ import type {
 import type { BBox } from "geojson";
 import dayjs from "dayjs";
 import { nanoid } from "@/utils";
+import { unitStateToInternal } from "./scenarioCodec";
 import { walkSide } from "@/stores/scenarioStore";
 import { klona } from "klona";
 import type { EntityId } from "@/types/base";
@@ -44,7 +45,6 @@ import type {
   NUnitSupply,
 } from "@/types/internalModels";
 import { useScenarioTime } from "./time";
-import { entriesToInternal } from "@/scenariostore/unitResources";
 import type {
   FeatureId,
   RangeRing,
@@ -270,32 +270,13 @@ export function prepareScenario(newScenario: Scenario | LoadableScenario): Scena
       });
     unit._state = null;
 
-    const resourceBlockToInternal = (block: State["update"]) =>
-      block
-        ? {
-            equipment: entriesToInternal(
-              block.equipment,
-              (name) => tempEquipmentIdMap[name] ?? name,
-            ),
-            personnel: entriesToInternal(
-              block.personnel,
-              (name) => tempPersonnelIdMap[name] ?? name,
-            ),
-            supplies: entriesToInternal(
-              block.supplies,
-              (name) => tempSuppliesIdMap[name] ?? name,
-            ),
-          }
-        : undefined;
-
     const newState: NState[] = unit.state.map((s) => {
-      const { update, diff, ...rest } = s;
       checkFillColor(s);
-      return {
-        ...rest,
-        update: resourceBlockToInternal(update),
-        diff: resourceBlockToInternal(diff),
-      };
+      return unitStateToInternal(s, {
+        equipment: tempEquipmentIdMap,
+        personnel: tempPersonnelIdMap,
+        supplies: tempSuppliesIdMap,
+      });
     });
 
     newState.forEach((stateEntry) => {

--- a/src/scenariostore/scenarioCodec.test.ts
+++ b/src/scenariostore/scenarioCodec.test.ts
@@ -72,8 +72,10 @@ describe("ScenarioCodec unit-state round-trip", () => {
       scnState,
     );
 
-    expect(roundTripped.update).toEqual(external.update);
-    expect(roundTripped.diff).toEqual(external.diff);
+    // toStrictEqual (not toEqual) so an omitted toe kind cannot regress to an explicit
+    // `{ supplies: undefined }` key — those compare equal under toEqual but not here.
+    expect(roundTripped.update).toStrictEqual(external.update);
+    expect(roundTripped.diff).toStrictEqual(external.diff);
     expect(roundTripped.id).toEqual(external.id);
     expect(roundTripped.t).toEqual(external.t);
   });
@@ -97,7 +99,7 @@ describe("ScenarioCodec unit-state round-trip", () => {
     expect(internal.update?.equipment).toEqual([{ id: "Unmapped widget", count: 7 }]);
 
     const roundTripped = unitStateToExternal(internal, scnState);
-    expect(roundTripped.update).toEqual(external.update);
+    expect(roundTripped.update).toStrictEqual(external.update);
   });
 
   it("leaves states without toe groups untouched", () => {

--- a/src/scenariostore/scenarioCodec.test.ts
+++ b/src/scenariostore/scenarioCodec.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  type ResourceNameToIdMaps,
+  unitStateToExternal,
+  unitStateToInternal,
+} from "./scenarioCodec";
+import type { ScenarioState } from "./newScenarioStore";
+import type { State } from "@/types/scenarioModels";
+
+// The codec is the single home for the unit-state external⇄internal mapping. These tests
+// pin the round-trip invariant: external --toInternal--> internal --toExternal--> external
+// must return the same names, counts and onHand values for update/diff toe groups + status.
+
+const nameToId: ResourceNameToIdMaps = {
+  equipment: { Rifle: "eq-1", Radio: "eq-2" },
+  personnel: { Officer: "pe-1" },
+  supplies: { Ammo: "su-1" },
+};
+
+// A minimal ScenarioState carrying only the lookup maps the reverse direction reads.
+const scnState = {
+  equipmentMap: {
+    "eq-1": { id: "eq-1", name: "Rifle" },
+    "eq-2": { id: "eq-2", name: "Radio" },
+  },
+  personnelMap: { "pe-1": { id: "pe-1", name: "Officer" } },
+  supplyCategoryMap: { "su-1": { id: "su-1", name: "Ammo" } },
+  unitStatusMap: { "st-1": { id: "st-1", name: "Dug in" } },
+} as unknown as ScenarioState;
+
+describe("ScenarioCodec unit-state round-trip", () => {
+  it("translates update/diff names to ids on the way in", () => {
+    const external: State = {
+      id: "s1",
+      t: 1000,
+      update: {
+        equipment: [{ name: "Rifle", count: 5, onHand: 3 }],
+        personnel: [{ name: "Officer", count: 2 }],
+      },
+      diff: {
+        supplies: [{ name: "Ammo", count: 100, onHand: 80 }],
+      },
+    };
+
+    const internal = unitStateToInternal(external, nameToId);
+
+    expect(internal.update?.equipment).toEqual([{ id: "eq-1", count: 5, onHand: 3 }]);
+    expect(internal.update?.personnel).toEqual([{ id: "pe-1", count: 2 }]);
+    expect(internal.diff?.supplies).toEqual([{ id: "su-1", count: 100, onHand: 80 }]);
+  });
+
+  it("round-trips update/diff toe groups back to the original external shape", () => {
+    // The codec owns the toe name↔id mapping. (Status name↔id is the caller's job on the
+    // way in, so it is exercised in the reverse-only test below, not here.)
+    const external: State = {
+      id: "s2",
+      t: 2000,
+      update: {
+        equipment: [
+          { name: "Rifle", count: 5, onHand: 3 },
+          { name: "Radio", count: 1 },
+        ],
+        supplies: [{ name: "Ammo", count: 50 }],
+      },
+      diff: {
+        personnel: [{ name: "Officer", count: -1 }],
+      },
+    };
+
+    const roundTripped = unitStateToExternal(
+      unitStateToInternal(external, nameToId),
+      scnState,
+    );
+
+    expect(roundTripped.update).toEqual(external.update);
+    expect(roundTripped.diff).toEqual(external.diff);
+    expect(roundTripped.id).toEqual(external.id);
+    expect(roundTripped.t).toEqual(external.t);
+  });
+
+  it("reverses an internal status id back to its external name", () => {
+    const internal = unitStateToInternal({ id: "s5", t: 5000 }, nameToId);
+    internal.status = "st-1";
+    expect(unitStateToExternal(internal, scnState).status).toEqual("Dug in");
+  });
+
+  it("preserves unknown names as a name↔name fallback in both directions", () => {
+    // A toe entry whose name has no id mapping keeps the name as its id, and the reverse
+    // lookup misses the map and falls back to that same string — so the round-trip is stable.
+    const external: State = {
+      id: "s3",
+      t: 3000,
+      update: { equipment: [{ name: "Unmapped widget", count: 7 }] },
+    };
+
+    const internal = unitStateToInternal(external, nameToId);
+    expect(internal.update?.equipment).toEqual([{ id: "Unmapped widget", count: 7 }]);
+
+    const roundTripped = unitStateToExternal(internal, scnState);
+    expect(roundTripped.update).toEqual(external.update);
+  });
+
+  it("leaves states without toe groups untouched", () => {
+    const external: State = { id: "s4", t: 4000, location: [10, 20] };
+    const internal = unitStateToInternal(external, nameToId);
+    expect(internal.update).toBeUndefined();
+    expect(internal.diff).toBeUndefined();
+    expect(unitStateToExternal(internal, scnState)).toMatchObject({
+      id: "s4",
+      t: 4000,
+      location: [10, 20],
+    });
+  });
+});

--- a/src/scenariostore/scenarioCodec.ts
+++ b/src/scenariostore/scenarioCodec.ts
@@ -12,7 +12,7 @@
 // `unitStateToExternal` (io.ts delegates to them).
 
 import type { State, Unit } from "@/types/scenarioModels";
-import type { NState, NUnit } from "@/types/internalModels";
+import type { NState } from "@/types/internalModels";
 import type { ScenarioState } from "@/scenariostore/newScenarioStore";
 import type { EntityId } from "@/types/base";
 import { nanoid } from "@/utils";
@@ -47,20 +47,30 @@ function toeGroupToInternal(
   };
 }
 
-function toeGroupToExternal(group: InternalToeGroup, scnState: ScenarioState) {
+// The reverse of toeGroupToInternal: fan the three kinds back through entriesToExternal
+// against their catalogs. Shared by the state-block path (update/diff) and the base-unit
+// path. `stripEmpty` drops empty arrays to undefined, which the base-unit serialization
+// wants but the state-block round-trip does not. A dangling id falls back to itself.
+function toeToExternal<
+  Eq extends { id: string },
+  Pe extends { id: string },
+  Su extends { id: string },
+>(
+  toe: { equipment?: Eq[]; personnel?: Pe[]; supplies?: Su[] },
+  scnState: ScenarioState,
+  { stripEmpty = false }: { stripEmpty?: boolean } = {},
+) {
+  const convert = <E extends { id: string }>(
+    entries: E[] | undefined,
+    catalog: Record<string, { name: string }>,
+  ) => {
+    const out = entriesToExternal(entries, (id) => catalog[id]?.name ?? id);
+    return stripEmpty && !out?.length ? undefined : out;
+  };
   return {
-    equipment: entriesToExternal(
-      group.equipment,
-      (id) => scnState.equipmentMap[id]?.name ?? id,
-    ),
-    personnel: entriesToExternal(
-      group.personnel,
-      (id) => scnState.personnelMap[id]?.name ?? id,
-    ),
-    supplies: entriesToExternal(
-      group.supplies,
-      (id) => scnState.supplyCategoryMap[id]?.name ?? id,
-    ),
+    equipment: convert(toe.equipment, scnState.equipmentMap),
+    personnel: convert(toe.personnel, scnState.personnelMap),
+    supplies: convert(toe.supplies, scnState.supplyCategoryMap),
   };
 }
 
@@ -90,28 +100,11 @@ export function unitStateToExternal(s: NState, scnState: ScenarioState): State {
   const { update, diff, status, ...rest } = s;
   const c = klona(rest) as State;
 
-  if (diff) c.diff = toeGroupToExternal(diff, scnState);
-  if (update) c.update = toeGroupToExternal(update, scnState);
+  if (diff) c.diff = toeToExternal(diff, scnState);
+  if (update) c.update = toeToExternal(update, scnState);
   if (status) c.status = scnState.unitStatusMap[status]?.name;
 
   return c;
-}
-
-/** Reverse: an internal unit's base toe arrays back to external name-keyed form. */
-function unitToeToExternal(nUnit: NUnit, scnState: ScenarioState) {
-  const orEmptyUndefined = <T,>(entries: T[] | undefined) =>
-    entries?.length ? entries : undefined;
-  return {
-    equipment: orEmptyUndefined(
-      entriesToExternal(nUnit.equipment, (id) => scnState.equipmentMap[id].name),
-    ),
-    personnel: orEmptyUndefined(
-      entriesToExternal(nUnit.personnel, (id) => scnState.personnelMap[id].name),
-    ),
-    supplies: orEmptyUndefined(
-      entriesToExternal(nUnit.supplies, (id) => scnState.supplyCategoryMap[id].name),
-    ),
-  };
 }
 
 export type SerializeUnitOptions = {
@@ -127,7 +120,9 @@ export function unitToExternal(
 ): Unit {
   const { newId = false, includeSubUnits = true } = options;
   const nUnit = scnState.unitMap[unitId];
-  const { equipment, personnel, supplies } = unitToeToExternal(nUnit, scnState);
+  const { equipment, personnel, supplies } = toeToExternal(nUnit, scnState, {
+    stripEmpty: true,
+  });
   let rangeRings = nUnit.rangeRings?.map(({ group, ...rest }) => {
     return group ? { group: scnState.rangeRingGroupMap[group].name, ...rest } : rest;
   });

--- a/src/scenariostore/scenarioCodec.ts
+++ b/src/scenariostore/scenarioCodec.ts
@@ -51,6 +51,8 @@ function toeGroupToInternal(
 // against their catalogs. Shared by the state-block path (update/diff) and the base-unit
 // path. `stripEmpty` drops empty arrays to undefined, which the base-unit serialization
 // wants but the state-block round-trip does not. A dangling id falls back to itself.
+// Keys whose converted value is undefined are omitted entirely (rather than emitted as
+// `{ personnel: undefined }`), so the state-block round-trip matches the original shape.
 function toeToExternal<
   Eq extends { id: string },
   Pe extends { id: string },
@@ -67,10 +69,13 @@ function toeToExternal<
     const out = entriesToExternal(entries, (id) => catalog[id]?.name ?? id);
     return stripEmpty && !out?.length ? undefined : out;
   };
+  const equipment = convert(toe.equipment, scnState.equipmentMap);
+  const personnel = convert(toe.personnel, scnState.personnelMap);
+  const supplies = convert(toe.supplies, scnState.supplyCategoryMap);
   return {
-    equipment: convert(toe.equipment, scnState.equipmentMap),
-    personnel: convert(toe.personnel, scnState.personnelMap),
-    supplies: convert(toe.supplies, scnState.supplyCategoryMap),
+    ...(equipment !== undefined && { equipment }),
+    ...(personnel !== undefined && { personnel }),
+    ...(supplies !== undefined && { supplies }),
   };
 }
 

--- a/src/scenariostore/scenarioCodec.ts
+++ b/src/scenariostore/scenarioCodec.ts
@@ -1,0 +1,153 @@
+// ScenarioCodec — the single seam for the unit/state external ⇄ internal round-trip.
+//
+// The external Scenario format (scenarioModels.ts) refers to equipment, personnel and
+// supplies by *name*; the internal ScenarioState (internalModels.ts) refers to them by
+// *id*. That name↔id translation used to be re-implemented in three places that drifted
+// independently:
+//   - newScenarioStore.prepareScenario   (external → internal, fresh load)
+//   - convertUtils.addUnitHierarchy       (external → internal, paste / import)
+//   - io.ts serializeUnit / serializeState (internal → external, export)
+// This module owns that invariant. The forward direction is shared by both import paths
+// via `unitStateToInternal`; the reverse direction lives here as `unitToExternal` /
+// `unitStateToExternal` (io.ts delegates to them).
+
+import type { State, Unit } from "@/types/scenarioModels";
+import type { NState, NUnit } from "@/types/internalModels";
+import type { ScenarioState } from "@/scenariostore/newScenarioStore";
+import type { EntityId } from "@/types/base";
+import { nanoid } from "@/utils";
+import { entriesToExternal, entriesToInternal } from "@/scenariostore/unitResources";
+import { klona } from "klona";
+
+/**
+ * Name→id maps for the three resource kinds, used when translating an external unit's
+ * `update`/`diff` toe groups into internal form. A name with no entry falls back to the
+ * name itself (matching the historical `?? name` behaviour), which lets a later pass
+ * resolve or mint the id.
+ */
+export interface ResourceNameToIdMaps {
+  equipment: Record<string, string>;
+  personnel: Record<string, string>;
+  supplies: Record<string, string>;
+}
+
+type ExternalToeGroup = NonNullable<State["update"]>;
+type InternalToeGroup = NonNullable<NState["update"]>;
+
+// The per-entry name↔id mapping lives in unitResources (shared with time.ts apply logic);
+// the codec composes it across the three resource kinds of a state's update/diff block.
+function toeGroupToInternal(
+  group: ExternalToeGroup,
+  maps: ResourceNameToIdMaps,
+): InternalToeGroup {
+  return {
+    equipment: entriesToInternal(group.equipment, (name) => maps.equipment[name] ?? name),
+    personnel: entriesToInternal(group.personnel, (name) => maps.personnel[name] ?? name),
+    supplies: entriesToInternal(group.supplies, (name) => maps.supplies[name] ?? name),
+  };
+}
+
+function toeGroupToExternal(group: InternalToeGroup, scnState: ScenarioState) {
+  return {
+    equipment: entriesToExternal(
+      group.equipment,
+      (id) => scnState.equipmentMap[id]?.name ?? id,
+    ),
+    personnel: entriesToExternal(
+      group.personnel,
+      (id) => scnState.personnelMap[id]?.name ?? id,
+    ),
+    supplies: entriesToExternal(
+      group.supplies,
+      (id) => scnState.supplyCategoryMap[id]?.name ?? id,
+    ),
+  };
+}
+
+/**
+ * Forward: translate one external `State` into an internal `NState`, rewriting the
+ * `update`/`diff` toe groups from names to ids. Every other field is passed through
+ * untouched — callers are expected to have already internalized timestamps and status.
+ *
+ * Shared by `prepareScenario` and `addUnitHierarchy` so the two import paths cannot drift.
+ */
+export function unitStateToInternal(state: State, maps: ResourceNameToIdMaps): NState {
+  const { update, diff, ...rest } = state;
+  return {
+    ...rest,
+    update: update ? toeGroupToInternal(update, maps) : undefined,
+    diff: diff ? toeGroupToInternal(diff, maps) : undefined,
+  };
+}
+
+/**
+ * Reverse: translate one internal `NState` back into an external `State`, rewriting the
+ * `update`/`diff` toe groups and `status` from ids to names.
+ */
+export function unitStateToExternal(s: NState, scnState: ScenarioState): State {
+  // Clone only the fields we keep verbatim; update/diff/status are rebuilt below, so
+  // cloning their (toe-array-heavy) subtrees would be wasted work.
+  const { update, diff, status, ...rest } = s;
+  const c = klona(rest) as State;
+
+  if (diff) c.diff = toeGroupToExternal(diff, scnState);
+  if (update) c.update = toeGroupToExternal(update, scnState);
+  if (status) c.status = scnState.unitStatusMap[status]?.name;
+
+  return c;
+}
+
+/** Reverse: an internal unit's base toe arrays back to external name-keyed form. */
+function unitToeToExternal(nUnit: NUnit, scnState: ScenarioState) {
+  const orEmptyUndefined = <T,>(entries: T[] | undefined) =>
+    entries?.length ? entries : undefined;
+  return {
+    equipment: orEmptyUndefined(
+      entriesToExternal(nUnit.equipment, (id) => scnState.equipmentMap[id].name),
+    ),
+    personnel: orEmptyUndefined(
+      entriesToExternal(nUnit.personnel, (id) => scnState.personnelMap[id].name),
+    ),
+    supplies: orEmptyUndefined(
+      entriesToExternal(nUnit.supplies, (id) => scnState.supplyCategoryMap[id].name),
+    ),
+  };
+}
+
+export type SerializeUnitOptions = {
+  newId?: boolean;
+  includeSubUnits?: boolean;
+};
+
+/** Reverse: an internal unit (and, by default, its subtree) back to external form. */
+export function unitToExternal(
+  unitId: EntityId,
+  scnState: ScenarioState,
+  options: SerializeUnitOptions = {},
+): Unit {
+  const { newId = false, includeSubUnits = true } = options;
+  const nUnit = scnState.unitMap[unitId];
+  const { equipment, personnel, supplies } = unitToeToExternal(nUnit, scnState);
+  let rangeRings = nUnit.rangeRings?.map(({ group, ...rest }) => {
+    return group ? { group: scnState.rangeRingGroupMap[group].name, ...rest } : rest;
+  });
+
+  if (rangeRings?.length === 0) rangeRings = undefined;
+  const { id, state, _basePid, _baseSubUnits, ...rest } = nUnit;
+
+  return {
+    id: newId ? nanoid() : id,
+    ...rest,
+    status: nUnit.status ? scnState.unitStatusMap[nUnit.status]?.name : undefined,
+    subUnits: includeSubUnits
+      ? (_baseSubUnits ?? nUnit.subUnits).map((subUnitId) =>
+          unitToExternal(subUnitId, scnState, options),
+        )
+      : [],
+    equipment,
+    personnel,
+    supplies,
+    rangeRings,
+    state: state ? state.map((s) => unitStateToExternal(s, scnState)) : undefined,
+  };
+}


### PR DESCRIPTION
## Summary

Introduces `src/scenariostore/scenarioCodec.ts` as the single home for the unit/state **external ⇄ internal** round-trip. Previously the name↔id mapping for a unit's state `update`/`diff` toe groups was implemented independently in three places that could drift:

- `newScenarioStore.prepareScenario` (external → internal, fresh load)
- `convertUtils.addUnitHierarchy` (external → internal, paste / import)
- `io.ts` serialization (internal → external, export)

The codec composes on the per-entry `entriesToInternal` / `entriesToExternal` helpers from `unitResources` (added in #599) and owns the group-, state-, and unit-level mapping in both directions.

## Changes

- **`scenarioCodec.ts`** (new): the seam.
  - `unitStateToInternal(state, maps)` — shared forward `update`/`diff` name→id translation; called by both `prepareScenario` and `addUnitHierarchy`.
  - `unitToExternal` / `unitStateToExternal` — reverse mapping, moved out of `io.ts`.
- **`io.ts`**: re-exports `unitToExternal as serializeUnit`, so existing import sites (and the clipboard test mock) are unchanged.
- **`newScenarioStore.ts` / `convertUtils.ts`**: the two import paths now call `unitStateToInternal` instead of each carrying their own copy.
- **`scenarioCodec.test.ts`** (new): round-trip tests pinning the invariant, including the name↔name fallback for unmapped entries.

## Notes

- Status name→id on the *forward* path stays in the callers (they mint store-dependent ids); the codec only reverses status on the way out.
- Builds on #599 — that PR's per-entry helpers are the building block this codec calls on both sides.