### PR TITLE
Route base unit resources through the ScenarioCodec

### DIFF
--- a/src/importexport/convertUtils.ts
+++ b/src/importexport/convertUtils.ts
@@ -1,19 +1,16 @@
 import type { Unit, UnitStatus } from "@/types/scenarioModels";
 import type { TScenario } from "@/scenariostore";
 import type { EntityId } from "@/types/base";
-import type {
-  NState,
-  NUnitAdd,
-  NUnitEquipment,
-  NUnitPersonnel,
-  NUnitSupply,
-} from "@/types/internalModels";
+import type { NState, NUnitAdd } from "@/types/internalModels";
 import { createNameToIdMapObject, nanoid } from "@/utils";
 import {
   convertStateToInternalFormat,
   type ScenarioState,
 } from "@/scenariostore/newScenarioStore";
-import { unitStateToInternal } from "@/scenariostore/scenarioCodec";
+import {
+  unitResourcesToInternal,
+  unitStateToInternal,
+} from "@/scenariostore/scenarioCodec";
 import type { RangeRing } from "@/types/scenarioGeoModels";
 import { getCustomSymbolId, setSid } from "@/symbology/helpers.ts";
 import { klona } from "klona";
@@ -94,10 +91,7 @@ export function addUnitHierarchy(
       parentId: EntityId,
       depth: number = 0,
     ): EntityId | undefined {
-      const equipment: NUnitEquipment[] = [];
-      const personnel: NUnitPersonnel[] = [];
       const rangeRings: RangeRing[] = [];
-      const supplies: NUnitSupply[] = [];
       const customSymbolId = getCustomSymbolId(unit.sidc);
       if (customSymbolId) {
         sourceCustomSymbolIds.add(customSymbolId);
@@ -110,31 +104,21 @@ export function addUnitHierarchy(
             sourceCustomSymbolIds.add(csidc);
           }
         });
-      unit.equipment?.forEach(({ name, count, onHand }) => {
-        const { id } =
-          s.equipmentMap[name] ||
-          unitActions.addEquipment({ id: name, name }, { noUndo, s });
-        equipment.push({ id, count, onHand });
-      });
-      unit.personnel?.forEach(({ name, count, onHand }) => {
-        const { id } =
-          s.personnelMap[name] ||
-          unitActions.addPersonnel({ id: name, name }, { noUndo, s });
-        personnel.push({ id, count, onHand });
-      });
 
-      unit.supplies?.forEach((unitSupply) => {
+      // Resolve a supply name to a catalog id, minting it (and any uom / supply class it
+      // brings from the source scenario) into the target catalog when absent. Keyed purely
+      // off the name the codec resolver passes; the per-entry count/onHand are preserved by
+      // unitResourcesToInternal.
+      const resolveSupplyId = (name: string): string => {
         // use existing one if it exists. For new supplies we use the name as id
-        let supplyId =
-          supplyNameToIdMap[unitSupply.name] ??
-          s.supplyCategoryMap[unitSupply.name ?? ""]?.id;
+        let supplyId = supplyNameToIdMap[name] ?? s.supplyCategoryMap[name]?.id;
         if (!supplyId) {
           // the supply category does not exist, create it. Use the source state if available
           const newSupplyCategory = sourceState?.supplyCategoryMap[
-            sourceSupplyNameToIdMap[unitSupply.name]
+            sourceSupplyNameToIdMap[name]
           ] ?? {
-            id: unitSupply.name,
-            name: unitSupply.name,
+            id: name,
+            name: name,
           };
 
           let uomId: string | undefined = undefined;
@@ -172,7 +156,19 @@ export function addUnitHierarchy(
           }
         }
 
-        supplies.push({ ...unitSupply, id: supplyId });
+        return supplyId as string;
+      };
+
+      const { equipment, personnel, supplies } = unitResourcesToInternal(unit, {
+        equipment: (name) =>
+          (s.equipmentMap[name] || unitActions.addEquipment({ id: name, name }, { noUndo, s }))
+            .id,
+        personnel: (name) =>
+          (
+            s.personnelMap[name] ||
+            unitActions.addPersonnel({ id: name, name }, { noUndo, s })
+          ).id,
+        supplies: resolveSupplyId,
       });
 
       unit.rangeRings?.forEach((rr) => {

--- a/src/scenariostore/newScenarioStore.ts
+++ b/src/scenariostore/newScenarioStore.ts
@@ -19,7 +19,7 @@ import type {
 import type { BBox } from "geojson";
 import dayjs from "dayjs";
 import { nanoid } from "@/utils";
-import { unitStateToInternal } from "./scenarioCodec";
+import { unitResourcesToInternal, unitStateToInternal } from "./scenarioCodec";
 import { walkSide } from "@/stores/scenarioStore";
 import { klona } from "klona";
 import type { EntityId } from "@/types/base";
@@ -39,10 +39,7 @@ import type {
   NSupplyUoM,
   NSymbolFillColor,
   NUnit,
-  NUnitEquipment,
-  NUnitPersonnel,
   NUnitStatus,
-  NUnitSupply,
 } from "@/types/internalModels";
 import { useScenarioTime } from "./time";
 import type {
@@ -220,25 +217,16 @@ export function prepareScenario(newScenario: Scenario | LoadableScenario): Scena
     unit._isOpen = false;
     unit._gid = sideGroup?.id;
     unit._sid = side.id;
-    const equipment: NUnitEquipment[] = [];
-    const personnel: NUnitPersonnel[] = [];
-    const supplies: NUnitSupply[] = [];
     const rangeRings: RangeRing[] = [];
 
-    unit.equipment?.forEach(({ name, count }) => {
-      const id = tempEquipmentIdMap[name] || addEquipment({ name });
-      equipment.push({ id, count });
-    });
-
-    unit.personnel?.forEach(({ name, count }) => {
-      const id = tempPersonnelIdMap[name] || addPersonnel({ name });
-      personnel.push({ id, count });
-    });
-
-    unit.supplies?.forEach((s) => {
-      const { count, onHand, name } = s;
-      const id = tempSuppliesIdMap[s.name] || addSupplyCategory(s);
-      supplies.push({ id, count, onHand });
+    const { equipment, personnel, supplies } = unitResourcesToInternal(unit, {
+      equipment: (name) => tempEquipmentIdMap[name] || addEquipment({ name }),
+      personnel: (name) => tempPersonnelIdMap[name] || addPersonnel({ name }),
+      // A fresh-load supply entry doubles as its own catalog definition (carries
+      // supplyClass / uom), so the mint path looks the whole entry back up by name.
+      supplies: (name) =>
+        tempSuppliesIdMap[name] ||
+        addSupplyCategory(unit.supplies!.find((s) => s.name === name)!),
     });
 
     unit.rangeRings?.forEach((rr) => {

--- a/src/scenariostore/scenarioCodec.test.ts
+++ b/src/scenariostore/scenarioCodec.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   type ResourceNameToIdMaps,
+  type ResourceResolvers,
+  unitResourcesToInternal,
   unitStateToExternal,
   unitStateToInternal,
 } from "./scenarioCodec";
 import type { ScenarioState } from "./newScenarioStore";
-import type { State } from "@/types/scenarioModels";
+import type { State, Unit } from "@/types/scenarioModels";
 
 // The codec is the single home for the unit-state external⇄internal mapping. These tests
 // pin the round-trip invariant: external --toInternal--> internal --toExternal--> external
@@ -112,5 +114,61 @@ describe("ScenarioCodec unit-state round-trip", () => {
       t: 4000,
       location: [10, 20],
     });
+  });
+});
+
+describe("ScenarioCodec base-unit resources (unitResourcesToInternal)", () => {
+  // Resolver that mirrors a simple name→id catalog, falling back to the name itself.
+  const resolvers: ResourceResolvers = {
+    equipment: (name) => nameToId.equipment[name] ?? name,
+    personnel: (name) => nameToId.personnel[name] ?? name,
+    supplies: (name) => nameToId.supplies[name] ?? name,
+  };
+
+  it("translates base equipment/personnel/supplies names to ids", () => {
+    const unit: Pick<Unit, "equipment" | "personnel" | "supplies"> = {
+      equipment: [{ name: "Rifle", count: 5 }],
+      personnel: [{ name: "Officer", count: 2 }],
+      supplies: [{ name: "Ammo", count: 100 }],
+    };
+    const internal = unitResourcesToInternal(unit, resolvers);
+    expect(internal.equipment).toEqual([{ id: "eq-1", count: 5 }]);
+    expect(internal.personnel).toEqual([{ id: "pe-1", count: 2 }]);
+    expect(internal.supplies).toEqual([{ id: "su-1", count: 100 }]);
+  });
+
+  it("preserves onHand on base equipment and personnel (regression: fresh load dropped it)", () => {
+    // prepareScenario used to build base equipment/personnel as { id, count }, silently
+    // discarding onHand while supplies and the paste path kept it. Routing all three kinds
+    // through this helper closes that gap.
+    const unit: Pick<Unit, "equipment" | "personnel" | "supplies"> = {
+      equipment: [{ name: "Rifle", count: 5, onHand: 3 }],
+      personnel: [{ name: "Officer", count: 2, onHand: 1 }],
+      supplies: [{ name: "Ammo", count: 100, onHand: 80 }],
+    };
+    const internal = unitResourcesToInternal(unit, resolvers);
+    expect(internal.equipment).toEqual([{ id: "eq-1", count: 5, onHand: 3 }]);
+    expect(internal.personnel).toEqual([{ id: "pe-1", count: 2, onHand: 1 }]);
+    expect(internal.supplies).toEqual([{ id: "su-1", count: 100, onHand: 80 }]);
+  });
+
+  it("returns empty arrays for missing resource kinds and mints via the resolver", () => {
+    const minted: string[] = [];
+    const mintingResolvers: ResourceResolvers = {
+      equipment: (name) => {
+        minted.push(name);
+        return `eq-${minted.length}`;
+      },
+      personnel: () => "unused",
+      supplies: () => "unused",
+    };
+    const internal = unitResourcesToInternal(
+      { equipment: [{ name: "New gear", count: 1 }] },
+      mintingResolvers,
+    );
+    expect(internal.equipment).toEqual([{ id: "eq-1", count: 1 }]);
+    expect(internal.personnel).toEqual([]);
+    expect(internal.supplies).toEqual([]);
+    expect(minted).toEqual(["New gear"]);
   });
 });

--- a/src/scenariostore/scenarioCodec.ts
+++ b/src/scenariostore/scenarioCodec.ts
@@ -12,7 +12,12 @@
 // `unitStateToExternal` (io.ts delegates to them).
 
 import type { State, Unit } from "@/types/scenarioModels";
-import type { NState } from "@/types/internalModels";
+import type {
+  NState,
+  NUnitEquipment,
+  NUnitPersonnel,
+  NUnitSupply,
+} from "@/types/internalModels";
 import type { ScenarioState } from "@/scenariostore/newScenarioStore";
 import type { EntityId } from "@/types/base";
 import { nanoid } from "@/utils";
@@ -92,6 +97,43 @@ export function unitStateToInternal(state: State, maps: ResourceNameToIdMaps): N
     ...rest,
     update: update ? toeGroupToInternal(update, maps) : undefined,
     diff: diff ? toeGroupToInternal(diff, maps) : undefined,
+  };
+}
+
+/**
+ * Per-kind name→id resolvers for a unit's *base* equipment/personnel/supplies entries.
+ * Unlike the state-block path (`ResourceNameToIdMaps`, a static lookup that falls back to
+ * the name), the base path may need to *mint* a catalog entry when a name is unseen — so
+ * the policy is a function the caller owns, not a map. The codec only fans the three kinds
+ * through it and preserves `count`/`onHand`; where ids come from (nanoid vs name-as-id,
+ * closed-world vs grafting into an existing catalog) stays with the caller.
+ */
+export interface ResourceResolvers {
+  equipment: (name: string) => string;
+  personnel: (name: string) => string;
+  supplies: (name: string) => string;
+}
+
+export interface InternalUnitResources {
+  equipment: NUnitEquipment[];
+  personnel: NUnitPersonnel[];
+  supplies: NUnitSupply[];
+}
+
+/**
+ * Forward: translate a unit's base equipment/personnel/supplies from names to ids,
+ * preserving `count` and `onHand`. Shared by `prepareScenario` (fresh load) and
+ * `addUnitHierarchy` (paste/import) so the two cannot drift — and so neither can drop
+ * `onHand`, which the hand-rolled fresh-load loop previously did for equipment/personnel.
+ */
+export function unitResourcesToInternal(
+  unit: Pick<Unit, "equipment" | "personnel" | "supplies">,
+  resolvers: ResourceResolvers,
+): InternalUnitResources {
+  return {
+    equipment: entriesToInternal(unit.equipment, resolvers.equipment) ?? [],
+    personnel: entriesToInternal(unit.personnel, resolvers.personnel) ?? [],
+    supplies: entriesToInternal(unit.supplies, resolvers.supplies) ?? [],
   };
 }
 

--- a/src/scenariostore/unitManipulations.test.ts
+++ b/src/scenariostore/unitManipulations.test.ts
@@ -859,3 +859,28 @@ describe("unitManipulations timed hierarchy recording", () => {
     );
   });
 });
+
+describe("fresh load preserves base resource onHand", () => {
+  // Regression: prepareScenario used to build base equipment/personnel as { id, count },
+  // silently dropping onHand on a fresh load while the paste path kept it. Both paths now
+  // route base resources through the ScenarioCodec, so onHand survives the load.
+  it("keeps onHand on base equipment and personnel through a fresh load", () => {
+    const scenario = createScenario();
+    scenario.sides[0].groups[0].subUnits[0].equipment = [
+      { name: "Rifle", count: 5, onHand: 3 },
+    ];
+    scenario.sides[0].groups[0].subUnits[0].personnel = [
+      { name: "Officer", count: 2, onHand: 1 },
+    ];
+
+    const store = useNewScenarioStore(scenario);
+    const unit = store.state.unitMap["unit-1"];
+
+    expect(unit.equipment?.[0]).toEqual(
+      expect.objectContaining({ count: 5, onHand: 3 }),
+    );
+    expect(unit.personnel?.[0]).toEqual(
+      expect.objectContaining({ count: 2, onHand: 1 }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

The forward (external→internal) name→id translation of a unit's base equipment/personnel/supplies was hand-rolled in two import paths that could drift independently — `prepareScenario` (fresh load) and `addUnitHierarchy` (paste/import). The reverse direction already lived in the codec (`unitToExternal`), so this finishes that round-trip.

- Adds `unitResourcesToInternal(unit, resolvers)` to `scenarioCodec.ts`. The codec owns the structure — fan the three resource kinds through the existing `entriesToInternal`, preserving `count`/`onHand` — while each caller keeps its own mint policy (nanoid vs name-as-id, closed-world vs grafting into an existing catalog) in a resolver closure.
- Both `prepareScenario` and `addUnitHierarchy` now route base resources through it, replacing three hand-rolled `forEach`/push loops.
- `rangeRings` and `status` stay caller-side on purpose: they don't share the counted-entry shape and the two sites mint them differently — consistent with how the reverse path already separates them.

## Bug fix

`prepareScenario` built base equipment and personnel as `{ id, count }`, **silently dropping `onHand` on every fresh load**, while supplies and the paste path kept it. Routing all three kinds through `entriesToInternal` (which spreads the rest of each entry) preserves `onHand` by construction. Pinned by a regression test at both the codec and the store-load level.