### PR TITLE
Rename SymbologyStandard values to "2525d" and "app6d" (scenario v3.3.0)

### DIFF
--- a/public/scenarios/falkland82.json
+++ b/public/scenarios/falkland82.json
@@ -1,16 +1,16 @@
 {
   "id": "demo-falklands82",
   "type": "ORBAT-mapper",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "meta": {
     "createdDate": "2024-02-04T14:33:50.335Z",
-    "lastModifiedDate": "2026-04-25T15:08:02.020Z"
+    "lastModifiedDate": "2026-06-06T14:15:09.743Z"
   },
   "name": "The Falklands War",
   "startTime": "1982-03-11T10:00:00-04:00",
   "timeZone": "Atlantic/Stanley",
   "description": "The Falklands War (1982) was a 74-day military conflict between Argentina and the UK over the Falkland Islands, South Georgia, and South Sandwich Islands in the South Atlantic. \n\nArgentina invaded the Falkland Islands on April 2, 1982, and the UK responded by sending a task force to retake the islands. The war ended on June 14, 1982, with Argentina's surrender and the islands' return to British control, resulting in the deaths of 649 Argentine, 255 British military personnel, and three Falkland Islanders. ",
-  "symbologyStandard": "app6",
+  "symbologyStandard": "app6d",
   "sides": [
     {
       "name": "Great Britain",

--- a/public/scenarios/narvik40.json
+++ b/public/scenarios/narvik40.json
@@ -1,16 +1,16 @@
 {
   "id": "demo-narvik40",
   "type": "ORBAT-mapper",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "meta": {
     "createdDate": "2024-04-01T17:14:51.567Z",
-    "lastModifiedDate": "2026-04-25T14:33:50.325Z"
+    "lastModifiedDate": "2026-06-06T14:16:07.082Z"
   },
   "name": "Battles of Narvik",
   "startTime": "1940-04-09T01:00:00+02:00",
   "timeZone": "Europe/Oslo",
   "description": "The Battles of Narvik were a series of naval and land engagements fought between German and Allied forces from April to June 1940. The battles marked the first Allied victory against Germany in the war.",
-  "symbologyStandard": "app6",
+  "symbologyStandard": "app6d",
   "sides": [
     {
       "id": "gjNibxLX9gQrtAiX9fv_F",

--- a/src/composables/symbolData.test.ts
+++ b/src/composables/symbolData.test.ts
@@ -10,8 +10,8 @@ const standardLoaders = vi.hoisted(() => ({
 
 vi.mock("@/symbology/standards", () => ({
   symbologyStandards: {
-    "2525": { load: standardLoaders.milstd2525 },
-    app6: { load: standardLoaders.app6 },
+    "2525d": { load: standardLoaders.milstd2525 },
+    app6d: { load: standardLoaders.app6 },
   },
 }));
 
@@ -83,7 +83,7 @@ describe("useSymbologyData", () => {
     const { loadData, symbology } = useSymbologyData();
     await loadData();
 
-    settingsStore.symbologyStandard = "app6";
+    settingsStore.symbologyStandard = "app6d";
     await nextTick();
     await vi.waitFor(() => expect(symbology.value).toBe(app6));
 
@@ -103,7 +103,7 @@ describe("useSymbologyData", () => {
     const { loadData, symbology, isLoaded } = useSymbologyData();
     const oldLoad = loadData();
 
-    settingsStore.symbologyStandard = "app6";
+    settingsStore.symbologyStandard = "app6d";
     const latestLoad = loadData();
     pendingApp6.resolve(app6);
     await latestLoad;
@@ -127,9 +127,9 @@ describe("useSymbologyData", () => {
     const { loadData, symbology, isLoaded } = useSymbologyData();
     await loadData();
 
-    settingsStore.symbologyStandard = "app6";
+    settingsStore.symbologyStandard = "app6d";
     const obsoleteLoad = loadData();
-    settingsStore.symbologyStandard = "2525";
+    settingsStore.symbologyStandard = "2525d";
     await loadData();
 
     pendingApp6.resolve(app6);

--- a/src/config/constants.ts
+++ b/src/config/constants.ts
@@ -1,6 +1,6 @@
 import type { ScenarioVersion } from "@/types/scenarioModels";
 
-export const SCENARIO_FILE_VERSION: ScenarioVersion = "3.2.0";
+export const SCENARIO_FILE_VERSION: ScenarioVersion = "3.3.0";
 export const LOCALSTORAGE_KEY = "orbat-scenario4";
 export const SHARE_HISTORY_LOCALSTORAGE_KEY = "orbat-share-history";
 

--- a/src/modules/scenarioeditor/NewScenarioView.vue
+++ b/src/modules/scenarioeditor/NewScenarioView.vue
@@ -49,7 +49,7 @@ interface NewScenarioForm extends ScenarioInfo {
 const noInitialOrbat = ref(false);
 
 const newScenario = ref(
-  createEmptyScenario({ addGroups: true, symbologyStandard: "app6" }),
+  createEmptyScenario({ addGroups: true, symbologyStandard: "app6d" }),
 );
 const timeZone = ref(newScenario.value.timeZone || "UTC");
 const { year, month, day, hour, minute, resDateTime } = useYMDElements({

--- a/src/modules/scenarioeditor/ScenarioEditorWrapper.test.ts
+++ b/src/modules/scenarioeditor/ScenarioEditorWrapper.test.ts
@@ -34,7 +34,7 @@ function createScenario(id: string, name = "Scenario"): Scenario {
     description: "",
     startTime,
     timeZone: "UTC",
-    symbologyStandard: "2525",
+    symbologyStandard: "2525d",
     sides: [],
     events: [],
     layerStack: [{ id: "layer-1", kind: "overlay", name: "Features", items: [] }],

--- a/src/modules/scenarioeditor/ScenarioInfoDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioInfoDetails.vue
@@ -44,7 +44,7 @@ const form = ref<ScenarioInfo>({
   description: "",
   startTime: 0,
   timeZone: "UTC",
-  symbologyStandard: "2525",
+  symbologyStandard: "2525d",
 });
 
 watch(

--- a/src/scenariostore/io.saveModel.test.ts
+++ b/src/scenariostore/io.saveModel.test.ts
@@ -22,7 +22,7 @@ const {
 }));
 
 vi.mock("@/stores/settingsStore", () => ({
-  useSymbolSettingsStore: () => ({ symbologyStandard: "2525" }),
+  useSymbolSettingsStore: () => ({ symbologyStandard: "2525d" }),
 }));
 
 vi.mock("@/composables/notifications", () => ({

--- a/src/scenariostore/io.test.ts
+++ b/src/scenariostore/io.test.ts
@@ -8,7 +8,7 @@ import "@/dayjs";
 
 // Mock the stores that might be used
 vi.mock("@/stores/settingsStore", () => ({
-  useSymbolSettingsStore: () => ({ symbologyStandard: "2525" }),
+  useSymbolSettingsStore: () => ({ symbologyStandard: "2525d" }),
 }));
 
 function createMinimalState(overrides: Partial<ScenarioState> = {}): ScenarioState {
@@ -21,7 +21,7 @@ function createMinimalState(overrides: Partial<ScenarioState> = {}): ScenarioSta
       description: "",
       startTime: 0,
       timeZone: "UTC",
-      symbologyStandard: "2525",
+      symbologyStandard: "2525d",
     },
     sides: [],
     events: [],
@@ -69,7 +69,7 @@ describe("Scenario IO", () => {
   it("creates empty scenarios with items[] layers", () => {
     const scenario = createEmptyScenario();
 
-    expect(scenario.version).toBe("3.2.0");
+    expect(scenario.version).toBe("3.3.0");
     expect(getOverlayLayers(scenario)[0]).toHaveProperty("items");
     expect(getOverlayLayers(scenario)[0]).not.toHaveProperty("features");
     expect((getOverlayLayers(scenario)[0] as any).items).toEqual([]);
@@ -253,7 +253,7 @@ describe("Scenario IO", () => {
     const { serializeToObject } = useScenarioIO(storeRef);
     const serialized = serializeToObject();
 
-    expect(serialized.version).toBe("3.2.0");
+    expect(serialized.version).toBe("3.3.0");
     expect(getOverlayLayers(serialized)[0]).not.toHaveProperty("features");
     expect(getOverlayLayers(serialized)[0].items).toEqual([
       {

--- a/src/scenariostore/io.ts
+++ b/src/scenariostore/io.ts
@@ -493,7 +493,7 @@ export function useScenarioIO(store: ShallowRef<NewScenarioStore>) {
       sessionRevision.value += 1;
       bindMutationTracking();
       settingsStore.symbologyStandard =
-        store.value.state.info.symbologyStandard || "2525";
+        store.value.state.info.symbologyStandard || "2525d";
       return true;
     } catch (e) {
       send({

--- a/src/scenariostore/localdb.test.ts
+++ b/src/scenariostore/localdb.test.ts
@@ -34,7 +34,7 @@ function createScenario(id: string, name = "Scenario"): Scenario {
     description: "",
     startTime,
     timeZone: "UTC",
-    symbologyStandard: "2525",
+    symbologyStandard: "2525d",
     sides: [],
     events: [],
     layerStack: [{ id: "layer-1", kind: "overlay", name: "Features", items: [] }],

--- a/src/scenariostore/upgrade.ts
+++ b/src/scenariostore/upgrade.ts
@@ -466,6 +466,30 @@ function upgradeGeometryLayerItemsToSharedBase(scenario: Scenario): Scenario {
   return upgradedScenario;
 }
 
+function upgradeSymbologyStandardNames(scenario: Scenario): Scenario {
+  const symbologyStandardMap: Record<string, string> = { "2525": "2525d", app6: "app6d" };
+  const upgradedScenario = { ...scenario };
+  if (upgradedScenario.symbologyStandard != null) {
+    upgradedScenario.symbologyStandard =
+      (symbologyStandardMap[upgradedScenario.symbologyStandard] as typeof upgradedScenario.symbologyStandard) ??
+      upgradedScenario.symbologyStandard;
+  }
+  upgradedScenario.layerStack = upgradedScenario.layerStack.map((layer) => {
+    if (layer.kind !== "overlay") return layer;
+    return {
+      ...layer,
+      items: layer.items.map((item) => {
+        if (item.kind !== "tacticalGraphic") return item;
+        const tg = item as TacticalGraphicLayerItem;
+        if (tg.standard == null) return tg;
+        const upgraded = symbologyStandardMap[tg.standard];
+        return upgraded ? { ...tg, standard: upgraded as TacticalGraphicLayerItem["standard"] } : tg;
+      }),
+    };
+  });
+  return upgradedScenario;
+}
+
 export function upgradeScenarioIfNecessary(
   scenario: LoadableScenario | Scenario,
 ): Scenario {
@@ -477,6 +501,9 @@ export function upgradeScenarioIfNecessary(
   }
   if (compareVersions(canonicalScenario.version, "3.2.0", "<")) {
     canonicalScenario = upgradeGeometryLayerItemsToSharedBase(canonicalScenario);
+  }
+  if (compareVersions(canonicalScenario.version, "3.3.0", "<")) {
+    canonicalScenario = upgradeSymbologyStandardNames(canonicalScenario);
   }
   return canonicalScenario;
 }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -25,7 +25,7 @@ export const useSymbolExportSettingsStore = defineStore("symbolExportSettings", 
 export const useSymbolSettingsStore = defineStore("symbolSettings", {
   state() {
     return {
-      symbologyStandard: "2525" as SymbologyStandard,
+      symbologyStandard: "2525d" as SymbologyStandard,
       simpleStatusModifier: useLocalStorage("simpleStatusModifier", false),
     };
   },

--- a/src/symbology/standards.test.ts
+++ b/src/symbology/standards.test.ts
@@ -7,24 +7,24 @@ import { describe, expect, it } from "vitest";
 
 describe("symbology standards registry", () => {
   it("exposes only standards supported by the current SIDC model", () => {
-    expect(Object.keys(symbologyStandards)).toEqual(["2525", "app6"]);
+    expect(Object.keys(symbologyStandards)).toEqual(["2525d", "app6d"]);
     expect(symbologyStandardOptions).toEqual([
       {
-        value: "2525",
+        value: "2525d",
         name: "MIL-STD-2525D",
         description: "US version",
       },
       {
-        value: "app6",
-        name: "APP-6",
+        value: "app6d",
+        name: "APP-6D",
         description: "NATO version",
       },
     ]);
   });
 
   it("resolves display names from the same registry", () => {
-    expect(getSymbologyStandardName("2525")).toBe("MIL-STD-2525D");
-    expect(getSymbologyStandardName("app6")).toBe("APP-6");
+    expect(getSymbologyStandardName("2525d")).toBe("MIL-STD-2525D");
+    expect(getSymbologyStandardName("app6d")).toBe("APP-6D");
     expect(getSymbologyStandardName()).toBe("");
   });
 });

--- a/src/symbology/standards.ts
+++ b/src/symbology/standards.ts
@@ -9,8 +9,8 @@ export interface SymbologyStandardDefinition {
 }
 
 export const symbologyStandards = {
-  "2525": {
-    value: "2525",
+  "2525d": {
+    value: "2525d",
     name: "MIL-STD-2525D",
     description: "US version",
     load: async () => {
@@ -18,9 +18,9 @@ export const symbologyStandards = {
       return ms2525d;
     },
   },
-  app6: {
-    value: "app6",
-    name: "APP-6",
+  app6d: {
+    value: "app6d",
+    name: "APP-6D",
     description: "NATO version",
     load: async () => {
       const { app6d } = await import("@/symbology/standards/app6d");

--- a/src/types/scenarioLayerItems.ts
+++ b/src/types/scenarioLayerItems.ts
@@ -185,7 +185,7 @@ export interface TacticalGraphicLayerItemState {
 
 export interface TacticalGraphicLayerItem extends ScenarioLayerItemBase {
   kind: "tacticalGraphic";
-  standard?: "2525" | "app6";
+  standard?: "2525d" | "app6d";
   graphicCode: string;
   controlPoints: Position[];
   modifiers?: Record<string, string | number | boolean>;

--- a/src/types/scenarioModels.ts
+++ b/src/types/scenarioModels.ts
@@ -266,8 +266,9 @@ export interface ScenarioInfo {
   symbologyStandard?: SymbologyStandard;
 }
 
-export type SymbologyStandard = "2525" | "app6";
+export type SymbologyStandard = "2525d" | "app6d";
 export type ScenarioVersion =
+  | "3.3.0"
   | "3.2.0"
   | "3.1.0"
   | "3.0.0"


### PR DESCRIPTION
## Summary

- Renames the `SymbologyStandard` union values from `"2525"`/`"app6"` to `"2525d"`/`"app6d"` to match the actual standard names (MIL-STD-2525D and APP-6D)
- Bumps `SCENARIO_FILE_VERSION` to `3.3.0`
- Adds `upgradeSymbologyStandardNames()` migration in `upgrade.ts` that rewrites old values in `scenario.symbologyStandard` and any `TacticalGraphicLayerItem.standard` fields when loading pre-3.3.0 scenario files