### PR TITLE
Add standard identity selector to symbol browser

### DIFF
--- a/src/composables/symbolData.ts
+++ b/src/composables/symbolData.ts
@@ -8,6 +8,7 @@ import {
   HQTFDummyValues,
   leadershipValues,
   mobilityValues,
+  standardIdentityValues,
   statusValues,
   SUBSURFACE_SYMBOLSET_VALUE,
   SURFACE_SYMBOLSET_VALUE,
@@ -289,6 +290,17 @@ export function useSymbolItems(
     }));
   });
 
+  const sidItems = computed((): SymbolItem[] => {
+    // Exclude the non-standard "Custom" identities (codes 7+).
+    return standardIdentityValues
+      .filter(({ code }) => +code < 7)
+      .map(({ code, text }) => ({
+        code,
+        text,
+        sidc: buildSymbolSidc({ standardIdentity: code }),
+      }));
+  });
+
   const reinforcedReducedItems = computed((): SymbolItem[] => {
     return [
       {
@@ -417,6 +429,7 @@ export function useSymbolItems(
     iconValue,
     statusValue,
     statusItems,
+    sidItems,
     hqtfdItems,
     hqtfdValue,
     emtValue,

--- a/src/views/SymbolBrowserView.vue
+++ b/src/views/SymbolBrowserView.vue
@@ -103,6 +103,7 @@ const {
   loadData,
   isLoaded,
   sidValue,
+  sidItems,
   symbolSetValue,
   iconValue,
   statusValue,
@@ -297,12 +298,20 @@ function updateFromSidcInput(sidc: string) {
           </ComboboxRoot>
 
           <form class="mt-4 space-y-4 p-0.5" v-if="isLoaded" @submit.prevent>
-            <SymbolCodeSelect
-              v-model="symbolSetValue"
-              label="Symbol set"
-              :items="symbolSets"
-              :symbol-options="combinedSymbolOptions"
-            />
+            <div class="grid gap-4 sm:grid-cols-2">
+              <SymbolCodeSelect
+                v-model="sidValue"
+                label="Standard identity"
+                :items="sidItems"
+                :symbol-options="combinedSymbolOptions"
+              />
+              <SymbolCodeSelect
+                v-model="symbolSetValue"
+                label="Symbol set"
+                :items="symbolSets"
+                :symbol-options="combinedSymbolOptions"
+              />
+            </div>
 
             <div class="grid gap-4 sm:grid-cols-2">
               <SymbolCodeSelect


### PR DESCRIPTION
Adds a **Standard identity** selector to the Symbol Browser, which previously had no way to set the affiliation (Friend, Hostile, Neutral, etc.).

## Changes
- Add a `sidItems` computed to `useSymbolItems`, mirroring the existing `statusItems`/`hqtfdItems` pattern. Each item carries a preview SIDC built via `buildSymbolSidc`. Non-standard "Custom" identities are excluded.
- Wire up a `SymbolCodeSelect` dropdown bound to `sidValue` in `SymbolBrowserView`, sharing a row with the Symbol set dropdown on desktop (`sm:grid-cols-2`) and stacking on mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)