### PR TITLE
Fix and improve unit path editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## July 2026
+
+### Added
+
+- Added unit track editing to MapLibre mode: drag waypoints and via points to move them, drag a midpoint handle on a leg to insert a via point, and alt-click a point to delete it. The track redraws while dragging.
+- Added the unit track editing gestures to the keyboard shortcuts dialog.
+
+### Fixed
+
+- Fixed unit track editing in MapLibre mode, where dragging a waypoint or via point never committed the new position.
+- Fixed the unit jumping to the edited waypoint in OpenLayers mode, and via points losing their leg times.
+
 ## June 2026
 
 ### Added

--- a/src/components/keyboardShortcuts.ts
+++ b/src/components/keyboardShortcuts.ts
@@ -42,6 +42,18 @@ export const mapEditModeShortcuts: KeyboardCategory[] = [
     ],
   },
   {
+    label: "Unit track editing",
+    shortcuts: [
+      {
+        shortcut: [["ctrl / ⌘", "click"]],
+        description: "Add waypoint for the selected units",
+      },
+      { shortcut: [["alt", "click"]], description: "Delete a waypoint or via point" },
+      { shortcut: [["drag"]], description: "Move a waypoint or via point" },
+      { shortcut: [["drag"]], description: "Add a via point (drag a midpoint handle)" },
+    ],
+  },
+  {
     label: "Time manipulation",
     shortcuts: [
       { shortcut: [["t"]], description: "Set scenario time" },

--- a/src/composables/geoUnitHistory.test.ts
+++ b/src/composables/geoUnitHistory.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => {
   const addUnitPositionSpy = vi.fn();
   const updateUnitStateSpy = vi.fn();
   const updateUnitSpy = vi.fn();
+  const updateUnitStateViaSpy = vi.fn();
   const deleteUnitStateEntrySpy = vi.fn();
   const getUnitByIdSpy = vi.fn(() => ({ id: "unit-1", state: [{ t: 10 }] }));
   const source = {
@@ -65,6 +66,7 @@ const mocks = vi.hoisted(() => {
     addUnitPositionSpy,
     updateUnitStateSpy,
     updateUnitSpy,
+    updateUnitStateViaSpy,
     deleteUnitStateEntrySpy,
     getUnitByIdSpy,
     layers,
@@ -82,7 +84,7 @@ vi.mock("@/utils", () => ({
     },
     unitActions: {
       getUnitById: mocks.getUnitByIdSpy,
-      updateUnitStateVia: vi.fn(),
+      updateUnitStateVia: mocks.updateUnitStateViaSpy,
       deleteUnitStateEntry: mocks.deleteUnitStateEntrySpy,
       updateUnitState: mocks.updateUnitStateSpy,
       updateUnit: mocks.updateUnitSpy,
@@ -221,7 +223,12 @@ describe("useUnitHistory leg editing", () => {
   beforeEach(() => {
     mocks.addUnitPositionSpy.mockClear();
     mocks.updateUnitSpy.mockClear();
+    mocks.updateUnitStateViaSpy.mockClear();
     mocks.deleteUnitStateEntrySpy.mockClear();
+    mocks.getUnitByIdSpy.mockReturnValue({
+      id: "unit-1",
+      state: [{ t: 1000 }],
+    } as any);
   });
 
   it("moves the unit's initial location when the first waypoint is dragged", () => {
@@ -262,6 +269,33 @@ describe("useUnitHistory leg editing", () => {
 
     expect(mocks.updateUnitSpy).not.toHaveBeenCalled();
     expect(mocks.addUnitPositionSpy).toHaveBeenCalledWith("unit-1", [13, 63], 1000);
+  });
+
+  it("adds a via point when a new vertex is dragged out of a leg", () => {
+    const { historyModify } = useUnitHistory({} as any);
+    const leg = createLegFeature([
+      [10, 60, INITIAL_TIME],
+      [11, 61, 1000],
+    ]);
+    const event = createModifyEvent(leg.feature);
+
+    (historyModify as any).emit("modifystart", event);
+    // OpenLayers inserts the new vertex with its M ordinate padded to 0, which
+    // is how the leg handler recognises it as a via point.
+    leg.setCoordinates([
+      [10, 60, INITIAL_TIME],
+      [10.5, 60.5, 0],
+      [11, 61, 1000],
+    ]);
+    (historyModify as any).emit("modifyend", event);
+
+    expect(mocks.updateUnitStateViaSpy).toHaveBeenCalledWith(
+      "unit-1",
+      "add",
+      0,
+      0,
+      [10.5, 60.5],
+    );
   });
 
   it("does not delete a state entry when the initial waypoint is removed", () => {

--- a/src/composables/geoUnitHistory.test.ts
+++ b/src/composables/geoUnitHistory.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ref } from "vue";
 import { useUnitHistory } from "@/composables/geoUnitHistory";
 
 const mocks = vi.hoisted(() => {
   const addUnitPositionSpy = vi.fn();
   const updateUnitStateSpy = vi.fn();
+  const updateUnitSpy = vi.fn();
+  const deleteUnitStateEntrySpy = vi.fn();
   const getUnitByIdSpy = vi.fn(() => ({ id: "unit-1", state: [{ t: 10 }] }));
   const source = {
     clear: vi.fn(),
@@ -62,6 +64,8 @@ const mocks = vi.hoisted(() => {
   return {
     addUnitPositionSpy,
     updateUnitStateSpy,
+    updateUnitSpy,
+    deleteUnitStateEntrySpy,
     getUnitByIdSpy,
     layers,
     selectedFeatures,
@@ -79,8 +83,9 @@ vi.mock("@/utils", () => ({
     unitActions: {
       getUnitById: mocks.getUnitByIdSpy,
       updateUnitStateVia: vi.fn(),
-      deleteUnitStateEntry: vi.fn(),
+      deleteUnitStateEntry: mocks.deleteUnitStateEntrySpy,
       updateUnitState: mocks.updateUnitStateSpy,
+      updateUnit: mocks.updateUnitSpy,
     },
     store: {
       onUndoRedo: vi.fn(),
@@ -126,6 +131,7 @@ vi.mock("@/stores/routingStore", () => ({
 
 vi.mock("@/geo/history", () => ({
   VIA_TIME: -1337,
+  INITIAL_TIME: Number.MIN_SAFE_INTEGER,
   labelStyle: { getText: () => ({ setText: vi.fn() }) },
   selectedWaypointStyle: {},
   createUnitHistoryLayers: () => mocks.layers,
@@ -172,6 +178,113 @@ vi.mock("ol/sphere", () => ({
 vi.mock("@/utils/convert", () => ({
   convertSpeedToMetric: vi.fn(() => 1),
 }));
+
+const INITIAL_TIME = Number.MIN_SAFE_INTEGER;
+
+// A leg feature as drawn by the history layer: an XYM line string where M is the
+// time of each waypoint (INITIAL_TIME for the unit's own location).
+function createLegFeature(initialCoordinates: number[][]) {
+  let coordinates = initialCoordinates;
+  const geometry = {
+    getType: () => "LineString",
+    getCoordinates: () => coordinates,
+    setCoordinates: (updated: number[][]) => {
+      coordinates = updated;
+    },
+    clone: () => {
+      const snapshot = coordinates.map((c) => [...c]);
+      return { getType: () => "LineString", getCoordinates: () => snapshot };
+    },
+  };
+  return {
+    feature: {
+      getGeometry: () => geometry,
+      get: (key: string) => (key === "unitId" ? "unit-1" : undefined),
+    },
+    setCoordinates: (updated: number[][]) => {
+      coordinates = updated;
+    },
+  };
+}
+
+function createModifyEvent(feature: unknown) {
+  return {
+    features: { item: () => feature },
+    mapBrowserEvent: {
+      coordinate: [0, 0],
+      originalEvent: { metaKey: false, ctrlKey: false, shiftKey: false, altKey: false },
+    },
+  };
+}
+
+describe("useUnitHistory leg editing", () => {
+  beforeEach(() => {
+    mocks.addUnitPositionSpy.mockClear();
+    mocks.updateUnitSpy.mockClear();
+    mocks.deleteUnitStateEntrySpy.mockClear();
+  });
+
+  it("moves the unit's initial location when the first waypoint is dragged", () => {
+    const { historyModify } = useUnitHistory({} as any);
+    const leg = createLegFeature([
+      [10, 60, INITIAL_TIME],
+      [11, 61, 1000],
+    ]);
+    const event = createModifyEvent(leg.feature);
+
+    (historyModify as any).emit("modifystart", event);
+    leg.setCoordinates([
+      [12, 62, INITIAL_TIME],
+      [11, 61, 1000],
+    ]);
+    (historyModify as any).emit("modifyend", event);
+
+    // Adding a state entry at INITIAL_TIME instead would make every
+    // interpolation start there, pinning the unit to the dragged waypoint.
+    expect(mocks.addUnitPositionSpy).not.toHaveBeenCalled();
+    expect(mocks.updateUnitSpy).toHaveBeenCalledWith("unit-1", { location: [12, 62] });
+  });
+
+  it("updates the state entry when a later waypoint is dragged", () => {
+    const { historyModify } = useUnitHistory({} as any);
+    const leg = createLegFeature([
+      [10, 60, INITIAL_TIME],
+      [11, 61, 1000],
+    ]);
+    const event = createModifyEvent(leg.feature);
+
+    (historyModify as any).emit("modifystart", event);
+    leg.setCoordinates([
+      [10, 60, INITIAL_TIME],
+      [13, 63, 1000],
+    ]);
+    (historyModify as any).emit("modifyend", event);
+
+    expect(mocks.updateUnitSpy).not.toHaveBeenCalled();
+    expect(mocks.addUnitPositionSpy).toHaveBeenCalledWith("unit-1", [13, 63], 1000);
+  });
+
+  it("does not delete a state entry when the initial waypoint is removed", () => {
+    const { historyModify } = useUnitHistory({} as any);
+    const leg = createLegFeature([
+      [10, 60, INITIAL_TIME],
+      [11, 61, 1000],
+      [12, 62, 2000],
+    ]);
+    const event = createModifyEvent(leg.feature);
+
+    (historyModify as any).emit("modifystart", event);
+    leg.setCoordinates([
+      [11, 61, 1000],
+      [12, 62, 2000],
+    ]);
+    (historyModify as any).emit("modifyend", event);
+
+    // There is no state entry for the initial location; a lookup would return
+    // -1 and splice(-1, 1) would drop the last waypoint instead.
+    expect(mocks.deleteUnitStateEntrySpy).not.toHaveBeenCalled();
+  });
+});
 
 describe("useUnitHistory", () => {
   it("recomputes unit state on waypoint modifyend but not on modifystart", () => {

--- a/src/composables/geoUnitHistory.ts
+++ b/src/composables/geoUnitHistory.ts
@@ -6,6 +6,7 @@ import { toLonLat } from "ol/proj";
 import {
   createUnitHistoryLayers,
   createUnitPathFeatures,
+  INITIAL_TIME,
   labelStyle,
   selectedWaypointStyle,
   VIA_TIME,
@@ -324,13 +325,26 @@ export function useUnitHistory(
         llChangedCoords,
       );
     } else {
+      const t = changedCoords?.[2];
       if (action === "remove") {
+        // The initial waypoint is the unit's own location, not a state entry.
+        if (preCoordinates[elementIndex][2] === INITIAL_TIME) return;
         const index = unit?.state?.findIndex(
           (s) => s.t === preCoordinates[elementIndex][2],
         );
-        if (index !== undefined) unitActions.deleteUnitStateEntry(unitId, index);
+        if (index !== undefined && index >= 0) {
+          unitActions.deleteUnitStateEntry(unitId, index);
+        }
       } else if (action === "modify") {
-        geo.addUnitPosition(unitId, llChangedCoords, changedCoords[2]);
+        if (t === INITIAL_TIME) {
+          // Moving the initial waypoint moves the unit's initial location.
+          // Adding a state entry at INITIAL_TIME instead would make every
+          // interpolation start from t = Number.MIN_SAFE_INTEGER, pinning the
+          // unit to that waypoint for the whole scenario.
+          unitActions.updateUnit(unitId, { location: llChangedCoords });
+        } else {
+          geo.addUnitPosition(unitId, llChangedCoords, t);
+        }
       }
     }
   }

--- a/src/composables/maplibreDrawInteraction.ts
+++ b/src/composables/maplibreDrawInteraction.ts
@@ -16,10 +16,9 @@ import type { FeatureId } from "@/types/scenarioGeoModels";
 import type { DrawType } from "@/composables/geoEditing";
 import { unwrapPositionRelative } from "@/geo/longitude";
 import {
-  isGlobeProjection,
-  latitudeToMercatorY,
-  mercatorYToLatitude,
-} from "@/geo/mercator";
+  getRenderedMidpoint as getMapLibreRenderedMidpoint,
+  midpoint,
+} from "@/geo/maplibreMidpoint";
 import {
   createTouchDoubleTapTracker,
   normalizePathCoordinates,
@@ -626,20 +625,7 @@ export function useMapLibreDrawInteraction(
   }
 
   function getRenderedMidpoint(a: Position, b: Position): Position {
-    if (isGlobeProjection(mlMap)) {
-      return projectedMercatorSegmentMidpoint(mlMap, a, b);
-    }
-    try {
-      const projectedA = mlMap.project(a as [number, number]);
-      const projectedB = mlMap.project(b as [number, number]);
-      const renderedMidpoint = mlMap.unproject([
-        (projectedA.x + projectedB.x) / 2,
-        (projectedA.y + projectedB.y) / 2,
-      ]);
-      return [renderedMidpoint.lng, renderedMidpoint.lat];
-    } catch {
-      return midpoint(a, b);
-    }
+    return getMapLibreRenderedMidpoint(mlMap, a, b);
   }
 
   function suspendMapDragInteractions(): MapDragInteractionState {
@@ -973,73 +959,6 @@ function visitGeometryEdges(
       });
     });
   }
-}
-
-function midpoint(a: Position, b: Position): Position {
-  return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
-}
-
-function projectedMercatorSegmentMidpoint(
-  map: MlMap,
-  a: Position,
-  b: Position,
-): Position {
-  try {
-    const coordinates = sampleMercatorSegmentCoordinates(a, b);
-    const projected = coordinates.map((coordinate) => ({
-      coordinate,
-      point: map.project(coordinate as [number, number]),
-    }));
-    const lengths: number[] = [];
-    let totalLength = 0;
-
-    for (let index = 0; index < projected.length - 1; index++) {
-      const start = projected[index]!.point;
-      const end = projected[index + 1]!.point;
-      const length = Math.hypot(end.x - start.x, end.y - start.y);
-      lengths.push(length);
-      totalLength += length;
-    }
-
-    if (totalLength === 0) return midpoint(a, b);
-
-    let remaining = totalLength / 2;
-    for (let index = 0; index < lengths.length; index++) {
-      const length = lengths[index]!;
-      if (remaining > length) {
-        remaining -= length;
-        continue;
-      }
-      const start = projected[index]!.coordinate;
-      const end = projected[index + 1]!.coordinate;
-      const ratio = length === 0 ? 0 : remaining / length;
-      return unwrapPositionRelative(a, [
-        start[0] + (end[0] - start[0]) * ratio,
-        start[1] + (end[1] - start[1]) * ratio,
-      ]);
-    }
-
-    return coordinates[Math.floor(coordinates.length / 2)]!;
-  } catch {
-    return midpoint(a, b);
-  }
-}
-
-function sampleMercatorSegmentCoordinates(a: Position, b: Position): Position[] {
-  const end = unwrapPositionRelative(a, b);
-  const startY = latitudeToMercatorY(a[1]);
-  const endY = latitudeToMercatorY(end[1]);
-  const coordinates: Position[] = [];
-
-  for (let index = 0; index <= 64; index++) {
-    const ratio = index / 64;
-    coordinates.push([
-      a[0] + (end[0] - a[0]) * ratio,
-      mercatorYToLatitude(startY + (endY - startY) * ratio),
-    ]);
-  }
-
-  return coordinates;
 }
 
 function getVertexAtPath(geometry: Geometry, path: number[]): Position | undefined {

--- a/src/composables/maplibreUnitHistory.test.ts
+++ b/src/composables/maplibreUnitHistory.test.ts
@@ -1,0 +1,234 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useMaplibreUnitHistory } from "@/composables/maplibreUnitHistory";
+import { useSelectedItems } from "@/stores/selectedStore";
+import { useUnitSettingsStore } from "@/stores/geoStore";
+
+const UNIT_ID = "unit-1";
+const WAYPOINT_ID = "V1StGXR8Z5jdHi6BmyT"; // nanoid, not parseable as an integer
+
+function createUnit() {
+  return {
+    id: UNIT_ID,
+    name: "Unit 1",
+    location: [10, 20],
+    state: [
+      { id: WAYPOINT_ID, t: 2000, location: [11, 21] },
+      { id: "aBcDeFgHiJkLmNoPqRsT", t: 3000, location: [12, 22] },
+    ] as { id: string; t: number; location: number[]; via?: number[][] }[],
+    _state: { t: 0, location: [10, 20] },
+  };
+}
+
+function createHarness() {
+  const handlers = new Map<string, Function[]>();
+  const layerHandlers = new Map<string, Function[]>();
+  const sources = new Map<string, any>();
+  const layers = new Map<string, any>();
+
+  const mlMap = {
+    on: vi.fn((name: string, layerIdOrHandler: any, maybeHandler?: Function) => {
+      const isDelegated = typeof layerIdOrHandler === "string";
+      const key = isDelegated ? `${name}:${layerIdOrHandler}` : name;
+      const target = isDelegated ? layerHandlers : handlers;
+      const handler = isDelegated ? maybeHandler! : layerIdOrHandler;
+      target.set(key, [...(target.get(key) ?? []), handler]);
+    }),
+    off: vi.fn(),
+    once: vi.fn((name: string, handler: Function) => {
+      handlers.set(name, [...(handlers.get(name) ?? []), handler]);
+    }),
+    addSource: vi.fn((id: string, source: any) => {
+      sources.set(id, {
+        spec: source,
+        data: source.data,
+        setData: vi.fn((data: unknown) => {
+          sources.get(id)!.data = data;
+        }),
+      });
+    }),
+    getSource: vi.fn((id: string) => sources.get(id)),
+    addLayer: vi.fn((spec: any) => layers.set(spec.id, spec)),
+    getLayer: vi.fn((id: string) => layers.get(id)),
+    setLayoutProperty: vi.fn(),
+    setPaintProperty: vi.fn(),
+    setFeatureState: vi.fn(),
+    removeFeatureState: vi.fn(),
+    queryRenderedFeatures: vi.fn(() => []),
+    getCanvas: () => ({ style: { cursor: "" } }),
+  } as any;
+
+  const unit = createUnit();
+  const addUnitPosition = vi.fn();
+  const unitActions = {
+    deleteUnitStateEntry: vi.fn(),
+    updateUnit: vi.fn(),
+    updateUnitState: vi.fn(),
+    updateUnitStateVia: vi.fn(),
+  };
+  const activeScenario = {
+    geo: { addUnitPosition },
+    unitActions,
+    helpers: { getUnitById: (id: string) => (id === UNIT_ID ? unit : undefined) },
+    store: { state: { unitStateCounter: 0 }, onUndoRedo: vi.fn() },
+  } as any;
+
+  const history = useMaplibreUnitHistory(mlMap, activeScenario);
+
+  function trigger(key: string, event: any) {
+    for (const handler of layerHandlers.get(key) ?? handlers.get(key) ?? []) {
+      handler(event);
+    }
+  }
+
+  return { mlMap, sources, history, addUnitPosition, unitActions, trigger, unit };
+}
+
+function createEvent(lng: number, lat: number, features?: any[]) {
+  return {
+    lngLat: { lng, lat },
+    point: { x: lng, y: lat },
+    features,
+    preventDefault: vi.fn(),
+    originalEvent: { preventDefault: vi.fn(), stopPropagation: vi.fn() },
+  } as any;
+}
+
+describe("useMaplibreUnitHistory", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    useSelectedItems().selectedUnitIds.value.clear();
+  });
+
+  it("promotes the waypoint id from a property", () => {
+    // MapLibre coerces top-level GeoJSON feature ids with parseInt, which would
+    // turn our nanoid waypoint ids into NaN.
+    const { sources, history } = createHarness();
+    history.setupUnitHistoryLayers();
+    expect(sources.get("unitHistoryWaypointSource").spec.promoteId).toBe("waypointId");
+  });
+
+  it("renders waypoints with the waypoint id as a property", () => {
+    const { sources, history } = createHarness();
+    history.setupUnitHistoryLayers();
+    useSelectedItems().selectedUnitIds.value.add(UNIT_ID);
+    history.drawHistory();
+
+    const features = sources.get("unitHistoryWaypointSource").data.features;
+    expect(features.map((f: any) => f.properties.waypointId)).toContain(WAYPOINT_ID);
+  });
+
+  it("moves the dragged waypoint instead of appending a position", () => {
+    const { history, trigger, addUnitPosition, sources } = createHarness();
+    history.setupUnitHistoryLayers();
+    useSelectedItems().selectedUnitIds.value.add(UNIT_ID);
+    useUnitSettingsStore().editHistory = true;
+    history.drawHistory();
+
+    const feature = {
+      // Mirrors what MapLibre hands back: the top-level id is unusable.
+      id: NaN,
+      properties: { unitId: UNIT_ID, waypointId: WAYPOINT_ID, t: 2000, isInitial: false },
+    };
+    trigger("mousedown:unitHistoryWaypointLayer", createEvent(11, 21, [feature]));
+    trigger("mousemove", createEvent(30, 40));
+
+    const dragged = sources
+      .get("unitHistoryWaypointSource")
+      .data.features.find((f: any) => f.properties.waypointId === WAYPOINT_ID);
+    expect(dragged.geometry.coordinates).toEqual([30, 40]);
+
+    trigger("mouseup", createEvent(30, 40));
+    expect(addUnitPosition).toHaveBeenCalledWith(UNIT_ID, [30, 40], 2000);
+  });
+
+  it("moves the unit's initial location when the first waypoint is dragged", () => {
+    const { history, trigger, addUnitPosition, unitActions } = createHarness();
+    history.setupUnitHistoryLayers();
+    useSelectedItems().selectedUnitIds.value.add(UNIT_ID);
+    useUnitSettingsStore().editHistory = true;
+    history.drawHistory();
+
+    const feature = {
+      id: undefined,
+      properties: {
+        unitId: UNIT_ID,
+        t: Number.MIN_SAFE_INTEGER,
+        isInitial: true,
+        stateIndex: -1,
+      },
+    };
+    trigger("mousedown:unitHistoryWaypointLayer", createEvent(10, 20, [feature]));
+    trigger("mouseup", createEvent(15, 25));
+
+    expect(addUnitPosition).not.toHaveBeenCalled();
+    expect(unitActions.updateUnit).toHaveBeenCalledWith(UNIT_ID, { location: [15, 25] });
+  });
+
+  it("moves a via point when it is dragged", () => {
+    const { history, trigger, sources, unitActions, unit } = createHarness();
+    unit.state[0].via = [[11.5, 21.5]];
+    history.setupUnitHistoryLayers();
+    useSelectedItems().selectedUnitIds.value.add(UNIT_ID);
+    useUnitSettingsStore().editHistory = true;
+    history.drawHistory();
+
+    const viaFeatures = sources.get("unitHistoryViaSource").data.features;
+    expect(viaFeatures).toHaveLength(1);
+    const { unitId, stateIndex, viaIndex } = viaFeatures[0].properties;
+    expect(unitId).toBe(UNIT_ID);
+
+    trigger(
+      "mousedown:unitHistoryViaLayer",
+      createEvent(11.5, 21.5, [{ properties: { unitId, stateIndex, viaIndex } }]),
+    );
+    trigger("mousemove", createEvent(30, 40));
+    expect(
+      sources.get("unitHistoryViaSource").data.features[0].geometry.coordinates,
+    ).toEqual([30, 40]);
+
+    trigger("mouseup", createEvent(30, 40));
+    expect(unitActions.updateUnitStateVia).toHaveBeenCalledWith(
+      UNIT_ID,
+      "modify",
+      stateIndex,
+      viaIndex,
+      [30, 40],
+    );
+  });
+
+  it("ignores via drags while path editing is disabled", () => {
+    const { history, trigger, unitActions, unit } = createHarness();
+    unit.state[0].via = [[11.5, 21.5]];
+    history.setupUnitHistoryLayers();
+    useSelectedItems().selectedUnitIds.value.add(UNIT_ID);
+    useUnitSettingsStore().editHistory = false;
+    history.drawHistory();
+
+    trigger(
+      "mousedown:unitHistoryViaLayer",
+      createEvent(11.5, 21.5, [
+        { properties: { unitId: UNIT_ID, stateIndex: 0, viaIndex: 0 } },
+      ]),
+    );
+    trigger("mouseup", createEvent(30, 40));
+    expect(unitActions.updateUnitStateVia).not.toHaveBeenCalled();
+  });
+
+  it("ignores waypoint drags while path editing is disabled", () => {
+    const { history, trigger, addUnitPosition } = createHarness();
+    history.setupUnitHistoryLayers();
+    useSelectedItems().selectedUnitIds.value.add(UNIT_ID);
+    useUnitSettingsStore().editHistory = false;
+    history.drawHistory();
+
+    const feature = {
+      id: NaN,
+      properties: { unitId: UNIT_ID, waypointId: WAYPOINT_ID, t: 2000, isInitial: false },
+    };
+    trigger("mousedown:unitHistoryWaypointLayer", createEvent(11, 21, [feature]));
+    trigger("mouseup", createEvent(30, 40));
+    expect(addUnitPosition).not.toHaveBeenCalled();
+  });
+});

--- a/src/composables/maplibreUnitHistory.test.ts
+++ b/src/composables/maplibreUnitHistory.test.ts
@@ -65,7 +65,24 @@ function createHarness() {
     deleteUnitStateEntry: vi.fn(),
     updateUnit: vi.fn(),
     updateUnitState: vi.fn(),
-    updateUnitStateVia: vi.fn(),
+    // Mirrors the store action so a redraw after an edit reflects the change.
+    updateUnitStateVia: vi.fn(
+      (
+        id: string,
+        action: string,
+        stateIndex: number,
+        viaIndex: number,
+        data: number[],
+      ) => {
+        if (id !== UNIT_ID) return;
+        const entry = unit.state[stateIndex];
+        if (!entry) return;
+        if (!entry.via) entry.via = [];
+        if (action === "add") entry.via.splice(viaIndex, 0, data);
+        else if (action === "modify") entry.via[viaIndex] = data;
+        else if (action === "remove") entry.via.splice(viaIndex, 1);
+      },
+    ),
   };
   const activeScenario = {
     geo: { addUnitPosition },
@@ -85,13 +102,22 @@ function createHarness() {
   return { mlMap, sources, history, addUnitPosition, unitActions, trigger, unit };
 }
 
-function createEvent(lng: number, lat: number, features?: any[]) {
+function createEvent(
+  lng: number,
+  lat: number,
+  features?: any[],
+  originalEvent: Record<string, unknown> = {},
+) {
   return {
     lngLat: { lng, lat },
     point: { x: lng, y: lat },
     features,
     preventDefault: vi.fn(),
-    originalEvent: { preventDefault: vi.fn(), stopPropagation: vi.fn() },
+    originalEvent: {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      ...originalEvent,
+    },
   } as any;
 }
 
@@ -214,6 +240,185 @@ describe("useMaplibreUnitHistory", () => {
     );
     trigger("mouseup", createEvent(30, 40));
     expect(unitActions.updateUnitStateVia).not.toHaveBeenCalled();
+  });
+
+  function setupEditing(harness: ReturnType<typeof createHarness>) {
+    harness.history.setupUnitHistoryLayers();
+    useSelectedItems().selectedUnitIds.value.add(UNIT_ID);
+    useUnitSettingsStore().editHistory = true;
+    harness.history.drawHistory();
+  }
+
+  const LEG_FEATURE = [{ properties: { unitId: UNIT_ID } }];
+
+  // Makes the via layer report a hit at the queried point.
+  function stubViaHit(harness: ReturnType<typeof createHarness>) {
+    harness.mlMap.queryRenderedFeatures = vi.fn(
+      (_point: unknown, options: { layers: string[] }) =>
+        options.layers[0] === "unitHistoryViaLayer"
+          ? [
+              {
+                layer: { id: "unitHistoryViaLayer" },
+                properties: { unitId: UNIT_ID, stateIndex: 0, viaIndex: 0 },
+              },
+            ]
+          : [],
+    );
+  }
+
+  it("annotates leg segments with the via insertion position", () => {
+    const harness = createHarness();
+    harness.unit.state[0].via = [
+      [10.4, 20.4],
+      [10.8, 20.8],
+    ];
+    setupEditing(harness);
+
+    const leg = harness.sources.get("unitHistoryLegSource").data.features[0];
+    expect(leg.geometry.coordinates).toHaveLength(5);
+    // The initial waypoint has no state entry, so the first segments belong to
+    // the state entry at the end of the leg they precede.
+    expect(leg.properties.segments).toEqual([
+      { stateIndex: 0, viaIndex: 0 },
+      { stateIndex: 0, viaIndex: 1 },
+      { stateIndex: 0, viaIndex: 2 },
+      { stateIndex: 1, viaIndex: 0 },
+    ]);
+  });
+
+  it("adds a via point when the segment from the initial location is grabbed", () => {
+    const harness = createHarness();
+    setupEditing(harness);
+
+    harness.trigger(
+      "mousedown:unitHistoryLegLayer",
+      createEvent(10.5, 20.5, LEG_FEATURE),
+    );
+
+    expect(harness.unitActions.updateUnitStateVia).toHaveBeenCalledWith(
+      UNIT_ID,
+      "add",
+      0,
+      0,
+      [10.5, 20.5],
+    );
+  });
+
+  it("adds a via point between two existing via points", () => {
+    const harness = createHarness();
+    harness.unit.state[0].via = [
+      [10.4, 20.4],
+      [10.8, 20.8],
+    ];
+    setupEditing(harness);
+
+    harness.trigger(
+      "mousedown:unitHistoryLegLayer",
+      createEvent(10.6, 20.6, LEG_FEATURE),
+    );
+
+    expect(harness.unitActions.updateUnitStateVia).toHaveBeenCalledWith(
+      UNIT_ID,
+      "add",
+      0,
+      1,
+      [10.6, 20.6],
+    );
+  });
+
+  it("drags the newly added via point", () => {
+    const harness = createHarness();
+    setupEditing(harness);
+
+    // Midway on the leg between the two state entries.
+    harness.trigger(
+      "mousedown:unitHistoryLegLayer",
+      createEvent(11.5, 21.5, LEG_FEATURE),
+    );
+    expect(harness.unitActions.updateUnitStateVia).toHaveBeenCalledWith(
+      UNIT_ID,
+      "add",
+      1,
+      0,
+      [11.5, 21.5],
+    );
+
+    harness.trigger("mousemove", createEvent(30, 40));
+    const viaFeatures = harness.sources.get("unitHistoryViaSource").data.features;
+    expect(viaFeatures).toHaveLength(1);
+    expect(viaFeatures[0].geometry.coordinates).toEqual([30, 40]);
+
+    harness.trigger("mouseup", createEvent(30, 40));
+    expect(harness.unitActions.updateUnitStateVia).toHaveBeenCalledWith(
+      UNIT_ID,
+      "modify",
+      1,
+      0,
+      [30, 40],
+    );
+  });
+
+  it("does not add via points while path editing is disabled", () => {
+    const harness = createHarness();
+    harness.history.setupUnitHistoryLayers();
+    useSelectedItems().selectedUnitIds.value.add(UNIT_ID);
+    useUnitSettingsStore().editHistory = false;
+    harness.history.drawHistory();
+
+    harness.trigger(
+      "mousedown:unitHistoryLegLayer",
+      createEvent(11.5, 21.5, LEG_FEATURE),
+    );
+    harness.trigger("mouseup", createEvent(30, 40));
+    expect(harness.unitActions.updateUnitStateVia).not.toHaveBeenCalled();
+  });
+
+  it("removes a via point on alt-click without dragging it", () => {
+    const harness = createHarness();
+    harness.unit.state[0].via = [[11.5, 21.5]];
+    setupEditing(harness);
+    stubViaHit(harness);
+
+    // Alt-mousedown must not start a drag that would commit a move.
+    harness.trigger(
+      "mousedown:unitHistoryViaLayer",
+      createEvent(
+        11.5,
+        21.5,
+        [{ properties: { unitId: UNIT_ID, stateIndex: 0, viaIndex: 0 } }],
+        {
+          altKey: true,
+        },
+      ),
+    );
+    harness.trigger("mouseup", createEvent(11.5, 21.5, undefined, { altKey: true }));
+    expect(harness.unitActions.updateUnitStateVia).not.toHaveBeenCalled();
+
+    const consumed = harness.history.handleMapClick(
+      createEvent(11.5, 21.5, undefined, { altKey: true }),
+    );
+    expect(consumed).toBe(true);
+    expect(harness.unitActions.updateUnitStateVia).toHaveBeenCalledWith(
+      UNIT_ID,
+      "remove",
+      0,
+      0,
+      [11.5, 21.5],
+    );
+    expect(harness.unit.state[0].via).toEqual([]);
+  });
+
+  it("does not remove via points while path editing is disabled", () => {
+    const harness = createHarness();
+    harness.unit.state[0].via = [[11.5, 21.5]];
+    harness.history.setupUnitHistoryLayers();
+    useSelectedItems().selectedUnitIds.value.add(UNIT_ID);
+    useUnitSettingsStore().editHistory = false;
+    harness.history.drawHistory();
+    stubViaHit(harness);
+
+    harness.history.handleMapClick(createEvent(11.5, 21.5, undefined, { altKey: true }));
+    expect(harness.unitActions.updateUnitStateVia).not.toHaveBeenCalled();
   });
 
   it("ignores waypoint drags while path editing is disabled", () => {

--- a/src/composables/maplibreUnitHistory.test.ts
+++ b/src/composables/maplibreUnitHistory.test.ts
@@ -56,6 +56,12 @@ function createHarness() {
     setFeatureState: vi.fn(),
     removeFeatureState: vi.fn(),
     queryRenderedFeatures: vi.fn(() => []),
+    // The test map is unprojected, so screen space and lng/lat coincide.
+    project: vi.fn((coordinates: [number, number]) => ({
+      x: coordinates[0],
+      y: coordinates[1],
+    })),
+    unproject: vi.fn(([x, y]: [number, number]) => ({ lng: x, lat: y })),
     getCanvas: () => ({ style: { cursor: "" } }),
   } as any;
 
@@ -356,6 +362,137 @@ describe("useMaplibreUnitHistory", () => {
       0,
       [30, 40],
     );
+  });
+
+  // Makes the midpoint handle layer report the handles it was given.
+  function stubMidpointHits(harness: ReturnType<typeof createHarness>) {
+    harness.mlMap.queryRenderedFeatures = vi.fn(
+      (_box: unknown, options: { layers: string[] }) =>
+        options.layers[0] === "unitHistoryLegMidpointLayer"
+          ? harness.sources.get("unitHistoryLegMidpointSource").data.features
+          : [],
+    );
+  }
+
+  it("draws a midpoint handle per leg segment", () => {
+    const harness = createHarness();
+    harness.unit.state[0].via = [[10.4, 20.4]];
+    setupEditing(harness);
+
+    const handles = harness.sources.get("unitHistoryLegMidpointSource").data.features;
+    // initial -> via, via -> waypoint 1, waypoint 1 -> waypoint 2
+    expect(handles).toHaveLength(3);
+    expect(handles.map((f: { properties: unknown }) => f.properties)).toEqual([
+      { unitId: UNIT_ID, stateIndex: 0, viaIndex: 0 },
+      { unitId: UNIT_ID, stateIndex: 0, viaIndex: 1 },
+      { unitId: UNIT_ID, stateIndex: 1, viaIndex: 0 },
+    ]);
+    // Placed halfway along the segment they belong to.
+    expect(handles[2].geometry.coordinates).toEqual([11.5, 21.5]);
+  });
+
+  it("draws no midpoint handles while path editing is disabled", () => {
+    const harness = createHarness();
+    harness.history.setupUnitHistoryLayers();
+    useSelectedItems().selectedUnitIds.value.add(UNIT_ID);
+    useUnitSettingsStore().editHistory = false;
+    harness.history.drawHistory();
+
+    expect(
+      harness.sources.get("unitHistoryLegMidpointSource").data.features,
+    ).toHaveLength(0);
+  });
+
+  it("adds a via point when a midpoint handle is grabbed near, not on, it", () => {
+    const harness = createHarness();
+    setupEditing(harness);
+    stubMidpointHits(harness);
+
+    // Well off the handle at [11.5, 21.5], but inside the tolerance box.
+    harness.trigger("mousedown", createEvent(11.5 + 6, 21.5 + 6));
+
+    expect(harness.unitActions.updateUnitStateVia).toHaveBeenCalledWith(
+      UNIT_ID,
+      "add",
+      1,
+      0,
+      [17.5, 27.5],
+    );
+  });
+
+  it("redraws the line while a point is dragged", () => {
+    const harness = createHarness();
+    harness.unit.state[0].via = [[10.4, 20.4]];
+    setupEditing(harness);
+
+    // The antimeridian unwind leaves floating point noise behind.
+    const round = (coordinates: number[][]) =>
+      coordinates.map((c) => c.map((n) => Math.round(n * 1e6) / 1e6));
+    const legCoordinates = () =>
+      round(
+        harness.sources.get("unitHistoryLegSource").data.features[0].geometry.coordinates,
+      );
+
+    expect(legCoordinates()).toEqual([
+      [10, 20],
+      [10.4, 20.4],
+      [11, 21],
+      [12, 22],
+    ]);
+
+    harness.trigger(
+      "mousedown:unitHistoryViaLayer",
+      createEvent(10.4, 20.4, [
+        { properties: { unitId: UNIT_ID, stateIndex: 0, viaIndex: 0 } },
+      ]),
+    );
+    harness.trigger("mousemove", createEvent(30, 40));
+
+    // The line follows the cursor, not just the dragged point.
+    expect(legCoordinates()).toEqual([
+      [10, 20],
+      [30, 40],
+      [11, 21],
+      [12, 22],
+    ]);
+    // The arc is re-interpolated through the dragged position too.
+    const arcCoordinates = round(
+      harness.sources.get("unitHistoryArcSource").data.features[0].geometry.coordinates,
+    );
+    expect(arcCoordinates).toContainEqual([30, 40]);
+  });
+
+  it("redraws the line while a waypoint is dragged", () => {
+    const harness = createHarness();
+    setupEditing(harness);
+
+    harness.trigger(
+      "mousedown:unitHistoryWaypointLayer",
+      createEvent(11, 21, [
+        {
+          properties: {
+            unitId: UNIT_ID,
+            waypointId: WAYPOINT_ID,
+            t: 2000,
+            stateIndex: 0,
+            isInitial: false,
+          },
+        },
+      ]),
+    );
+    harness.trigger("mousemove", createEvent(30, 40));
+
+    expect(
+      harness.sources
+        .get("unitHistoryLegSource")
+        .data.features[0].geometry.coordinates.map((c: number[]) =>
+          c.map((n) => Math.round(n * 1e6) / 1e6),
+        ),
+    ).toEqual([
+      [10, 20],
+      [30, 40],
+      [12, 22],
+    ]);
   });
 
   it("does not add via points while path editing is disabled", () => {

--- a/src/composables/maplibreUnitHistory.test.ts
+++ b/src/composables/maplibreUnitHistory.test.ts
@@ -420,6 +420,31 @@ describe("useMaplibreUnitHistory", () => {
     );
   });
 
+  it("leaves a ctrl-click near a midpoint handle to the waypoint handler", () => {
+    const harness = createHarness();
+    setupEditing(harness);
+    stubMidpointHits(harness);
+
+    harness.trigger(
+      "mousedown",
+      createEvent(11.5 + 6, 21.5 + 6, undefined, { ctrlKey: true }),
+    );
+
+    expect(harness.unitActions.updateUnitStateVia).not.toHaveBeenCalled();
+  });
+
+  it("leaves a ctrl-click on a leg to the waypoint handler", () => {
+    const harness = createHarness();
+    setupEditing(harness);
+
+    harness.trigger(
+      "mousedown:unitHistoryLegLayer",
+      createEvent(10.5, 20.5, LEG_FEATURE, { metaKey: true }),
+    );
+
+    expect(harness.unitActions.updateUnitStateVia).not.toHaveBeenCalled();
+  });
+
   it("redraws the line while a point is dragged", () => {
     const harness = createHarness();
     harness.unit.state[0].via = [[10.4, 20.4]];

--- a/src/composables/maplibreUnitHistory.ts
+++ b/src/composables/maplibreUnitHistory.ts
@@ -4,7 +4,7 @@ import type {
   MapMouseEvent,
   Map as MlMap,
 } from "maplibre-gl";
-import type { FeatureCollection } from "geojson";
+import type { Feature as GeoJsonFeature, FeatureCollection } from "geojson";
 import { storeToRefs } from "pinia";
 import { watch } from "vue";
 import { distanceMeters } from "@/geo/distance";
@@ -50,18 +50,34 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
   const fmt = useTimeFormatStore();
 
   const appliedWaypointStates = new Set<string>();
-  let dragState: {
-    unitId: string;
-    waypointId: string;
-    t: number;
-    isInitial: boolean;
-  } | null = null;
+  let waypointFeatureCollection: FeatureCollection = EMPTY_FC;
+  let viaFeatureCollection: FeatureCollection = EMPTY_FC;
+  type DragState = {
+    source: "waypoint" | "via";
+    // Identifies the dragged feature in the rendered collection, for the preview.
+    matches: (feature: GeoJsonFeature) => boolean;
+    commit: (lngLat: [number, number]) => void;
+  };
+  let dragState: DragState | null = null;
 
   function setupUnitHistoryLayers(beforeLayerId?: string) {
-    for (const id of [ARC_SOURCE_ID, LEG_SOURCE_ID, WAYPOINT_SOURCE_ID, VIA_SOURCE_ID]) {
+    for (const id of [ARC_SOURCE_ID, LEG_SOURCE_ID]) {
       if (!mlMap.getSource(id)) {
         mlMap.addSource(id, { type: "geojson", data: EMPTY_FC });
       }
+    }
+    if (!mlMap.getSource(WAYPOINT_SOURCE_ID)) {
+      // MapLibre coerces top-level GeoJSON feature ids with parseInt, which turns
+      // our nanoid waypoint ids into NaN. Promoting the id from a property keeps
+      // it intact for queryRenderedFeatures and feature state.
+      mlMap.addSource(WAYPOINT_SOURCE_ID, {
+        type: "geojson",
+        data: waypointFeatureCollection,
+        promoteId: "waypointId",
+      });
+    }
+    if (!mlMap.getSource(VIA_SOURCE_ID)) {
+      mlMap.addSource(VIA_SOURCE_ID, { type: "geojson", data: viaFeatureCollection });
     }
     if (!mlMap.getLayer(ARC_LAYER_ID)) {
       mlMap.addLayer(
@@ -200,6 +216,26 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     });
   }
 
+  // Keeps our own copy of the rendered points so the drag preview can rewrite a
+  // single coordinate without reading MapLibre source internals.
+  function setWaypointData(source: GeoJSONSource, features: GeoJsonFeature[]) {
+    waypointFeatureCollection = { type: "FeatureCollection", features };
+    source.setData(waypointFeatureCollection);
+  }
+
+  function setViaData(source: GeoJSONSource, features: GeoJsonFeature[]) {
+    viaFeatureCollection = { type: "FeatureCollection", features };
+    source.setData(viaFeatureCollection);
+  }
+
+  function getWaypointId(feature: {
+    id?: string | number;
+    properties?: Record<string, unknown> | null;
+  }): string | undefined {
+    const id = feature.properties?.waypointId ?? feature.id;
+    return typeof id === "string" ? id : undefined;
+  }
+
   function drawHistory() {
     const arcSource = mlMap.getSource(ARC_SOURCE_ID) as GeoJSONSource | undefined;
     const legSource = mlMap.getSource(LEG_SOURCE_ID) as GeoJSONSource | undefined;
@@ -214,8 +250,8 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     if (!showHistory.value) {
       arcSource.setData({ type: "FeatureCollection", features: [] });
       legSource.setData({ type: "FeatureCollection", features: [] });
-      waypointSource.setData({ type: "FeatureCollection", features: [] });
-      viaSource.setData({ type: "FeatureCollection", features: [] });
+      setWaypointData(waypointSource, []);
+      setViaData(viaSource, []);
       clearWaypointFeatureStates();
       return;
     }
@@ -236,8 +272,8 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
 
     arcSource.setData({ type: "FeatureCollection", features: allArcs });
     legSource.setData({ type: "FeatureCollection", features: allLegs });
-    waypointSource.setData({ type: "FeatureCollection", features: allWaypoints });
-    viaSource.setData({ type: "FeatureCollection", features: allVia });
+    setWaypointData(waypointSource, allWaypoints);
+    setViaData(viaSource, allVia);
 
     applyWaypointFeatureStates();
   }
@@ -286,7 +322,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     if (hits.length > 0) {
       const feature = hits[0];
       const unitId = feature.properties?.unitId as string | undefined;
-      const waypointId = feature.id as string | undefined;
+      const waypointId = getWaypointId(feature);
       const stateIndex = (feature.properties?.stateIndex as number) ?? -1;
       const isInitial = feature.properties?.isInitial === true;
 
@@ -312,65 +348,104 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     return false;
   }
 
-  function onWaypointMouseDown(e: MapLayerMouseEvent) {
-    if (!editHistory.value) return;
-    const feature = e.features?.[0];
-    if (!feature) return;
-    const unitId = feature.properties?.unitId as string | undefined;
-    const waypointId = feature.id as string | undefined;
-    const t = feature.properties?.t as number | undefined;
-    const isInitial = feature.properties?.isInitial === true;
-    if (!unitId || !waypointId || t === undefined) return;
-
+  function startDrag(e: MapLayerMouseEvent, drag: DragState) {
     e.preventDefault();
-    dragState = { unitId, waypointId, t, isInitial };
+    dragState = drag;
     mlMap.getCanvas().style.cursor = "grabbing";
     mlMap.on("mousemove", onDragMove);
     mlMap.once("mouseup", onDragEnd);
   }
 
+  function onWaypointMouseDown(e: MapLayerMouseEvent) {
+    if (!editHistory.value) return;
+    const feature = e.features?.[0];
+    if (!feature) return;
+    const unitId = feature.properties?.unitId as string | undefined;
+    const waypointId = getWaypointId(feature);
+    const t = feature.properties?.t as number | undefined;
+    const isInitial = feature.properties?.isInitial === true;
+    // The initial waypoint is the unit's own location, so it has no state id.
+    if (!unitId || t === undefined || (!waypointId && !isInitial)) return;
+
+    startDrag(e, {
+      source: "waypoint",
+      matches: (f) =>
+        isInitial
+          ? f.properties?.isInitial === true && f.properties?.unitId === unitId
+          : getWaypointId(f) === waypointId,
+      commit: (lngLat) => {
+        if (isInitial) {
+          unitActions.updateUnit(unitId, { location: lngLat });
+          unitActions.updateUnitState(unitId);
+        } else {
+          geo.addUnitPosition(unitId, lngLat, t);
+        }
+      },
+    });
+  }
+
+  function onViaMouseDown(e: MapLayerMouseEvent) {
+    // A waypoint drawn on top of a via point wins; its handler runs first.
+    if (!editHistory.value || dragState) return;
+    const feature = e.features?.[0];
+    if (!feature) return;
+    const unitId = feature.properties?.unitId as string | undefined;
+    const stateIndex = feature.properties?.stateIndex as number | undefined;
+    const viaIndex = feature.properties?.viaIndex as number | undefined;
+    if (!unitId || stateIndex === undefined || stateIndex < 0 || viaIndex === undefined) {
+      return;
+    }
+
+    startDrag(e, {
+      source: "via",
+      matches: (f) =>
+        f.properties?.unitId === unitId &&
+        f.properties?.stateIndex === stateIndex &&
+        f.properties?.viaIndex === viaIndex,
+      commit: (lngLat) => {
+        unitActions.updateUnitStateVia(unitId, "modify", stateIndex, viaIndex, lngLat);
+        unitActions.updateUnitState(unitId);
+      },
+    });
+  }
+
   function onDragMove(e: MapMouseEvent) {
     if (!dragState) return;
-    const waypointSource = mlMap.getSource(WAYPOINT_SOURCE_ID) as
-      | GeoJSONSource
-      | undefined;
-    if (!waypointSource) return;
-    // Visually move just the dragged waypoint by rewriting its coordinates.
-    const data = (waypointSource as any)._data as FeatureCollection | undefined;
-    if (!data) return;
-    const next: FeatureCollection = {
-      type: "FeatureCollection",
-      features: data.features.map((f) => {
-        if (f.id !== dragState!.waypointId) return f;
-        return {
-          ...f,
-          geometry: {
-            type: "Point",
-            coordinates: [e.lngLat.lng, e.lngLat.lat],
-          },
-        };
-      }),
-    };
-    waypointSource.setData(next);
+    const isVia = dragState.source === "via";
+    const sourceId = isVia ? VIA_SOURCE_ID : WAYPOINT_SOURCE_ID;
+    const source = mlMap.getSource(sourceId) as GeoJSONSource | undefined;
+    if (!source) return;
+    // Visually move just the dragged point by rewriting its coordinates.
+    const collection = isVia ? viaFeatureCollection : waypointFeatureCollection;
+    const features = collection.features.map((f) => {
+      if (!dragState!.matches(f)) return f;
+      return {
+        ...f,
+        geometry: {
+          type: "Point" as const,
+          coordinates: [e.lngLat.lng, e.lngLat.lat],
+        },
+      };
+    });
+    if (isVia) {
+      setViaData(source, features);
+    } else {
+      setWaypointData(source, features);
+    }
   }
 
   function onDragEnd(e: MapMouseEvent) {
     mlMap.off("mousemove", onDragMove);
     if (!dragState) return;
-    const { unitId, t, isInitial } = dragState;
+    const { commit } = dragState;
     dragState = null;
     mlMap.getCanvas().style.cursor = "";
-    const lngLat: [number, number] = [e.lngLat.lng, e.lngLat.lat];
-    if (isInitial) {
-      // Dragging the initial location (unit origin) is not supported.
-      drawHistory();
-      return;
-    }
-    geo.addUnitPosition(unitId, lngLat, t);
+    commit([e.lngLat.lng, e.lngLat.lat]);
     drawHistory();
   }
 
   mlMap.on("mousedown", WAYPOINT_LAYER_ID, onWaypointMouseDown);
+  mlMap.on("mousedown", VIA_LAYER_ID, onViaMouseDown);
 
   activeScenario.store.onUndoRedo?.(({ meta }) => {
     if (meta?.value && selectedUnitIds.value.has(meta.value as string)) {
@@ -394,6 +469,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
 
   function dispose() {
     mlMap.off("mousedown", WAYPOINT_LAYER_ID, onWaypointMouseDown);
+    mlMap.off("mousedown", VIA_LAYER_ID, onViaMouseDown);
     mlMap.off("mousemove", onDragMove);
     clearWaypointFeatureStates();
   }

--- a/src/composables/maplibreUnitHistory.ts
+++ b/src/composables/maplibreUnitHistory.ts
@@ -140,8 +140,8 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
       );
     }
     if (!mlMap.getLayer(MIDPOINT_LAYER_ID)) {
-      // Same look as the midpoint handles of the feature draw editor, so the
-      // gesture that adds a vertex to a line also adds a via point to a leg.
+      // Same gesture as the midpoint handles of the feature draw editor, but
+      // muted so they read as hints rather than competing with the real points.
       mlMap.addLayer(
         {
           id: MIDPOINT_LAYER_ID,
@@ -149,9 +149,11 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
           source: MIDPOINT_SOURCE_ID,
           paint: {
             "circle-radius": 4,
-            "circle-color": "#60a5fa",
-            "circle-stroke-color": "#1e3a8a",
-            "circle-stroke-width": 1.5,
+            "circle-color": "#ffffff",
+            "circle-opacity": 0.5,
+            "circle-stroke-color": "#475569",
+            "circle-stroke-width": 1,
+            "circle-stroke-opacity": 0.5,
           },
         },
         beforeLayerId,

--- a/src/composables/maplibreUnitHistory.ts
+++ b/src/composables/maplibreUnitHistory.ts
@@ -376,6 +376,15 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
       .filter((f) => f.layer?.id === layerId);
   }
 
+  /**
+   * True for the modifier combination that appends a waypoint on click. The
+   * press handlers use it to keep out of the way, so a ctrl-click near a leg
+   * does not also insert a via point.
+   */
+  function isAddWaypointModifier(e: MouseEvent): boolean {
+    return (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey;
+  }
+
   function handleCtrlClick(e: MapMouseEvent): boolean {
     if (selectedUnitIds.value.size === 0) return false;
     const lngLat: [number, number] = [e.lngLat.lng, e.lngLat.lat];
@@ -407,11 +416,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
   function handleMapClick(e: MapMouseEvent): boolean {
     if (!showHistory.value) return false;
     const originalEvent = e.originalEvent;
-    const isCtrl =
-      (originalEvent.metaKey || originalEvent.ctrlKey) &&
-      !originalEvent.shiftKey &&
-      !originalEvent.altKey;
-
+    const isCtrl = isAddWaypointModifier(originalEvent);
     const isAlt = originalEvent.altKey && !originalEvent.shiftKey;
     const hits = queryLayer(e.point, WAYPOINT_LAYER_ID);
     if (hits.length > 0) {
@@ -513,6 +518,8 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     if (!editHistory.value || dragState) return;
     // Alt-click removes the via point, so it must not start a drag.
     if (e.originalEvent.altKey) return;
+    // Ctrl-click appends a waypoint instead.
+    if (isAddWaypointModifier(e.originalEvent)) return;
     const feature = e.features?.[0];
     if (!feature) return;
     const unitId = feature.properties?.unitId as string | undefined;
@@ -544,6 +551,8 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     if (!editHistory.value || dragState) return;
     // Alt-click is reserved for deleting points.
     if (e.originalEvent.altKey) return;
+    // Ctrl-click appends a waypoint, so it must not also insert a via point.
+    if (isAddWaypointModifier(e.originalEvent)) return;
     // Existing points win over the line they are drawn on.
     if (
       queryLayer(e.point, WAYPOINT_LAYER_ID).length > 0 ||
@@ -596,6 +605,8 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
   function onMapMouseDown(e: MapMouseEvent) {
     if (!showHistory.value || !editHistory.value || dragState) return;
     if (e.originalEvent.altKey) return;
+    // Ctrl-click appends a waypoint, so it must not also insert a via point.
+    if (isAddWaypointModifier(e.originalEvent)) return;
     if (!mlMap.getLayer(MIDPOINT_LAYER_ID)) return;
     // Existing points win over the handle between them.
     if (

--- a/src/composables/maplibreUnitHistory.ts
+++ b/src/composables/maplibreUnitHistory.ts
@@ -13,7 +13,14 @@ import { storeToRefs } from "pinia";
 import { watch } from "vue";
 import { distanceMeters } from "@/geo/distance";
 import type { TScenario } from "@/scenariostore";
-import { createUnitPathGeoJson, findClosestLegSegment } from "@/geo/history";
+import type { LegSegmentMeta, LegVertexMeta } from "@/geo/history";
+import {
+  createArcCoords,
+  createUnitPathGeoJson,
+  findClosestLegSegment,
+} from "@/geo/history";
+import { unwindCoordinates, wrapLongitude } from "@/geo/longitude";
+import { getRenderedMidpoint } from "@/geo/maplibreMidpoint";
 import { useSelectedItems } from "@/stores/selectedStore";
 import { useSelectedWaypoints } from "@/stores/selectedWaypoints";
 import { useUnitSettingsStore } from "@/stores/geoStore";
@@ -24,20 +31,33 @@ const ARC_SOURCE_ID = "unitHistoryArcSource";
 const LEG_SOURCE_ID = "unitHistoryLegSource";
 const WAYPOINT_SOURCE_ID = "unitHistoryWaypointSource";
 const VIA_SOURCE_ID = "unitHistoryViaSource";
+const MIDPOINT_SOURCE_ID = "unitHistoryLegMidpointSource";
 
 const ARC_LAYER_ID = "unitHistoryArcLayer";
 const LEG_LAYER_ID = "unitHistoryLegLayer";
 const WAYPOINT_LAYER_ID = "unitHistoryWaypointLayer";
 const WAYPOINT_LABEL_LAYER_ID = "unitHistoryWaypointLabelLayer";
 const VIA_LAYER_ID = "unitHistoryViaLayer";
+const MIDPOINT_LAYER_ID = "unitHistoryLegMidpointLayer";
 
 export const UNIT_HISTORY_LAYER_IDS = [
   ARC_LAYER_ID,
   LEG_LAYER_ID,
+  MIDPOINT_LAYER_ID,
   VIA_LAYER_ID,
   WAYPOINT_LAYER_ID,
   WAYPOINT_LABEL_LAYER_ID,
 ];
+
+// The handle circles are small, so a single-pixel query is nearly impossible to
+// hit. Buffer the press into a small box, as the draw interaction does.
+const HANDLE_HIT_TOLERANCE_PX = 12;
+const TOUCH_HANDLE_HIT_TOLERANCE_PX = 26;
+
+const coarsePointerQuery =
+  typeof window !== "undefined" && typeof window.matchMedia === "function"
+    ? window.matchMedia("(pointer: coarse)")
+    : null;
 
 const EMPTY_FC: FeatureCollection = { type: "FeatureCollection", features: [] };
 
@@ -63,6 +83,8 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     source: "waypoint" | "via";
     // Identifies the dragged feature in the rendered collection, for the preview.
     matches: (feature: GeoJsonFeature) => boolean;
+    // Identifies the leg coordinate to rewrite, so the line follows the cursor.
+    matchesVertex: (vertex: LegVertexMeta) => boolean;
     commit: (lngLat: [number, number]) => void;
   };
   let dragState: DragState | null = null;
@@ -85,6 +107,9 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     }
     if (!mlMap.getSource(VIA_SOURCE_ID)) {
       mlMap.addSource(VIA_SOURCE_ID, { type: "geojson", data: viaFeatureCollection });
+    }
+    if (!mlMap.getSource(MIDPOINT_SOURCE_ID)) {
+      mlMap.addSource(MIDPOINT_SOURCE_ID, { type: "geojson", data: EMPTY_FC });
     }
     if (!mlMap.getLayer(ARC_LAYER_ID)) {
       mlMap.addLayer(
@@ -109,6 +134,24 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
           paint: {
             "line-color": "rgba(255,0,0,0.65)",
             "line-width": 2,
+          },
+        },
+        beforeLayerId,
+      );
+    }
+    if (!mlMap.getLayer(MIDPOINT_LAYER_ID)) {
+      // Same look as the midpoint handles of the feature draw editor, so the
+      // gesture that adds a vertex to a line also adds a via point to a leg.
+      mlMap.addLayer(
+        {
+          id: MIDPOINT_LAYER_ID,
+          type: "circle",
+          source: MIDPOINT_SOURCE_ID,
+          paint: {
+            "circle-radius": 4,
+            "circle-color": "#60a5fa",
+            "circle-stroke-color": "#1e3a8a",
+            "circle-stroke-width": 1.5,
           },
         },
         beforeLayerId,
@@ -192,6 +235,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     const base = showHistory.value;
     set(ARC_LAYER_ID, base);
     set(LEG_LAYER_ID, base && editHistory.value);
+    set(MIDPOINT_LAYER_ID, base && editHistory.value);
     set(VIA_LAYER_ID, base);
     set(WAYPOINT_LAYER_ID, base);
     set(WAYPOINT_LABEL_LAYER_ID, base && showWaypointTimestamps.value);
@@ -260,6 +304,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
       legSource.setData({ type: "FeatureCollection", features: [] });
       setWaypointData(waypointSource, []);
       setViaData(viaSource, []);
+      drawMidpointHandles();
       clearWaypointFeatureStates();
       return;
     }
@@ -283,8 +328,43 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     legSource.setData({ type: "FeatureCollection", features: allLegs });
     setWaypointData(waypointSource, allWaypoints);
     setViaData(viaSource, allVia);
+    drawMidpointHandles();
 
     applyWaypointFeatureStates();
+  }
+
+  /**
+   * One handle per leg segment, placed at the segment's on-screen midpoint.
+   * Dragging one inserts a via point there, mirroring how the draw interaction
+   * adds a vertex to a line.
+   */
+  function drawMidpointHandles() {
+    const source = mlMap.getSource(MIDPOINT_SOURCE_ID) as GeoJSONSource | undefined;
+    if (!source) return;
+    if (!showHistory.value || !editHistory.value || legFeatures.length === 0) {
+      source.setData(EMPTY_FC);
+      return;
+    }
+    const features: GeoJsonFeature[] = [];
+    for (const leg of legFeatures) {
+      const unitId = leg.properties?.unitId as string | undefined;
+      const segments = leg.properties?.segments as LegSegmentMeta[] | undefined;
+      const coordinates = leg.geometry?.coordinates ?? [];
+      if (!segments) continue;
+      for (let i = 0; i < coordinates.length - 1; i++) {
+        const meta = segments[i];
+        if (!meta) continue;
+        features.push({
+          type: "Feature",
+          geometry: {
+            type: "Point",
+            coordinates: getRenderedMidpoint(mlMap, coordinates[i]!, coordinates[i + 1]!),
+          },
+          properties: { unitId, stateIndex: meta.stateIndex, viaIndex: meta.viaIndex },
+        });
+      }
+    }
+    source.setData({ type: "FeatureCollection", features });
   }
 
   function queryLayer(point: MapMouseEvent["point"], layerId: string) {
@@ -386,7 +466,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     return false;
   }
 
-  function startDrag(e: MapLayerMouseEvent, drag: DragState) {
+  function startDrag(e: MapMouseEvent, drag: DragState) {
     e.preventDefault();
     dragState = drag;
     mlMap.getCanvas().style.cursor = "grabbing";
@@ -402,6 +482,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     const waypointId = getWaypointId(feature);
     const t = feature.properties?.t as number | undefined;
     const isInitial = feature.properties?.isInitial === true;
+    const stateIndex = feature.properties?.stateIndex as number | undefined;
     // The initial waypoint is the unit's own location, so it has no state id.
     if (!unitId || t === undefined || (!waypointId && !isInitial)) return;
 
@@ -411,6 +492,9 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
         isInitial
           ? f.properties?.isInitial === true && f.properties?.unitId === unitId
           : getWaypointId(f) === waypointId,
+      matchesVertex: (v) =>
+        v.viaIndex === undefined &&
+        (isInitial ? v.isInitial === true : v.stateIndex === stateIndex),
       commit: (lngLat) => {
         if (isInitial) {
           unitActions.updateUnit(unitId, { location: lngLat });
@@ -442,6 +526,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
         f.properties?.unitId === unitId &&
         f.properties?.stateIndex === stateIndex &&
         f.properties?.viaIndex === viaIndex,
+      matchesVertex: (v) => v.stateIndex === stateIndex && v.viaIndex === viaIndex,
       commit: (lngLat) => {
         unitActions.updateUnitStateVia(unitId, "modify", stateIndex, viaIndex, lngLat);
         unitActions.updateUnitState(unitId);
@@ -480,6 +565,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
         f.properties?.unitId === hitUnitId &&
         f.properties?.stateIndex === stateIndex &&
         f.properties?.viaIndex === viaIndex,
+      matchesVertex: (v) => v.stateIndex === stateIndex && v.viaIndex === viaIndex,
       commit: (position) => {
         unitActions.updateUnitStateVia(
           hitUnitId,
@@ -489,6 +575,76 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
           position,
         );
         unitActions.updateUnitState(hitUnitId);
+      },
+    });
+  }
+
+  function getHandleHitTolerance(e: MapMouseEvent): number {
+    const isTouch =
+      (e.originalEvent?.type?.startsWith("touch") ?? false) ||
+      (coarsePointerQuery?.matches ?? false);
+    return isTouch ? TOUCH_HANDLE_HIT_TOLERANCE_PX : HANDLE_HIT_TOLERANCE_PX;
+  }
+
+  /**
+   * Dragging a midpoint handle inserts a via point at that segment. Runs off a
+   * map-level mousedown so the press can be buffered into a tolerance box
+   * instead of having to land on the 4px circle exactly.
+   */
+  function onMapMouseDown(e: MapMouseEvent) {
+    if (!showHistory.value || !editHistory.value || dragState) return;
+    if (e.originalEvent.altKey) return;
+    if (!mlMap.getLayer(MIDPOINT_LAYER_ID)) return;
+    // Existing points win over the handle between them.
+    if (
+      queryLayer(e.point, WAYPOINT_LAYER_ID).length > 0 ||
+      queryLayer(e.point, VIA_LAYER_ID).length > 0
+    ) {
+      return;
+    }
+    const tolerance = getHandleHitTolerance(e);
+    const { x, y } = e.point;
+    const hits = mlMap.queryRenderedFeatures(
+      [
+        [x - tolerance, y - tolerance],
+        [x + tolerance, y + tolerance],
+      ],
+      { layers: [MIDPOINT_LAYER_ID] },
+    );
+    if (hits.length === 0) return;
+    const closest = hits.reduce((best, feature) => {
+      const distance = (f: (typeof hits)[number]) => {
+        const coordinates = (f.geometry as { coordinates?: [number, number] })
+          .coordinates;
+        if (!coordinates) return Number.POSITIVE_INFINITY;
+        const projected = mlMap.project(coordinates);
+        return Math.hypot(projected.x - x, projected.y - y);
+      };
+      return distance(feature) < distance(best) ? feature : best;
+    }, hits[0]!);
+
+    const unitId = closest.properties?.unitId as string | undefined;
+    const stateIndex = closest.properties?.stateIndex as number | undefined;
+    const viaIndex = closest.properties?.viaIndex as number | undefined;
+    if (!unitId || stateIndex === undefined || stateIndex < 0 || viaIndex === undefined) {
+      return;
+    }
+
+    const lngLat: [number, number] = [e.lngLat.lng, e.lngLat.lat];
+    unitActions.updateUnitStateVia(unitId, "add", stateIndex, viaIndex, lngLat);
+    unitActions.updateUnitState(unitId);
+    drawHistory();
+
+    startDrag(e, {
+      source: "via",
+      matches: (f) =>
+        f.properties?.unitId === unitId &&
+        f.properties?.stateIndex === stateIndex &&
+        f.properties?.viaIndex === viaIndex,
+      matchesVertex: (v) => v.stateIndex === stateIndex && v.viaIndex === viaIndex,
+      commit: (position) => {
+        unitActions.updateUnitStateVia(unitId, "modify", stateIndex, viaIndex, position);
+        unitActions.updateUnitState(unitId);
       },
     });
   }
@@ -516,6 +672,46 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     } else {
       setWaypointData(source, features);
     }
+    previewLines([e.lngLat.lng, e.lngLat.lat]);
+  }
+
+  /**
+   * Rewrites the dragged coordinate in the leg and arc lines so the whole path
+   * follows the cursor, instead of only the dragged point moving.
+   */
+  function previewLines(lngLat: [number, number]) {
+    if (!dragState) return;
+    const legSource = mlMap.getSource(LEG_SOURCE_ID) as GeoJSONSource | undefined;
+    const arcSource = mlMap.getSource(ARC_SOURCE_ID) as GeoJSONSource | undefined;
+    if (!legSource && !arcSource) return;
+
+    const previewLegs: GeoJsonFeature<GeoJsonLineString>[] = [];
+    const previewArcs: GeoJsonFeature<GeoJsonLineString>[] = [];
+    for (const leg of legFeatures) {
+      const vertices = leg.properties?.vertices as LegVertexMeta[] | undefined;
+      const coordinates = leg.geometry.coordinates.map((coordinate, index) => {
+        const vertex = vertices?.[index];
+        return vertex && dragState!.matchesVertex(vertex) ? lngLat : coordinate;
+      });
+      const unwound = unwindCoordinates(coordinates);
+      previewLegs.push({
+        ...leg,
+        geometry: { type: "LineString", coordinates: unwound },
+      });
+      previewArcs.push({
+        type: "Feature",
+        geometry: {
+          type: "LineString",
+          // The arc helper expects wrapped longitudes, as the store holds them.
+          coordinates: unwindCoordinates(
+            createArcCoords(unwound.map((c) => [wrapLongitude(c[0]!), c[1]!])),
+          ),
+        },
+        properties: { unitId: leg.properties?.unitId },
+      });
+    }
+    legSource?.setData({ type: "FeatureCollection", features: previewLegs });
+    arcSource?.setData({ type: "FeatureCollection", features: previewArcs });
   }
 
   function onDragEnd(e: MapMouseEvent) {
@@ -531,6 +727,9 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
   mlMap.on("mousedown", WAYPOINT_LAYER_ID, onWaypointMouseDown);
   mlMap.on("mousedown", VIA_LAYER_ID, onViaMouseDown);
   mlMap.on("mousedown", LEG_LAYER_ID, onLegMouseDown);
+  mlMap.on("mousedown", onMapMouseDown);
+  // The handles sit at on-screen midpoints, so they move with the camera.
+  mlMap.on("moveend", drawMidpointHandles);
 
   activeScenario.store.onUndoRedo?.(({ meta }) => {
     if (meta?.value && selectedUnitIds.value.has(meta.value as string)) {
@@ -556,6 +755,8 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     mlMap.off("mousedown", WAYPOINT_LAYER_ID, onWaypointMouseDown);
     mlMap.off("mousedown", VIA_LAYER_ID, onViaMouseDown);
     mlMap.off("mousedown", LEG_LAYER_ID, onLegMouseDown);
+    mlMap.off("mousedown", onMapMouseDown);
+    mlMap.off("moveend", drawMidpointHandles);
     mlMap.off("mousemove", onDragMove);
     clearWaypointFeatureStates();
   }

--- a/src/composables/maplibreUnitHistory.ts
+++ b/src/composables/maplibreUnitHistory.ts
@@ -4,12 +4,16 @@ import type {
   MapMouseEvent,
   Map as MlMap,
 } from "maplibre-gl";
-import type { Feature as GeoJsonFeature, FeatureCollection } from "geojson";
+import type {
+  Feature as GeoJsonFeature,
+  FeatureCollection,
+  LineString as GeoJsonLineString,
+} from "geojson";
 import { storeToRefs } from "pinia";
 import { watch } from "vue";
 import { distanceMeters } from "@/geo/distance";
 import type { TScenario } from "@/scenariostore";
-import { createUnitPathGeoJson } from "@/geo/history";
+import { createUnitPathGeoJson, findClosestLegSegment } from "@/geo/history";
 import { useSelectedItems } from "@/stores/selectedStore";
 import { useSelectedWaypoints } from "@/stores/selectedWaypoints";
 import { useUnitSettingsStore } from "@/stores/geoStore";
@@ -52,6 +56,9 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
   const appliedWaypointStates = new Set<string>();
   let waypointFeatureCollection: FeatureCollection = EMPTY_FC;
   let viaFeatureCollection: FeatureCollection = EMPTY_FC;
+  // Kept so a mousedown on a leg can be resolved to the segment that was
+  // grabbed, without reading MapLibre source internals.
+  let legFeatures: GeoJsonFeature<GeoJsonLineString>[] = [];
   type DragState = {
     source: "waypoint" | "via";
     // Identifies the dragged feature in the rendered collection, for the preview.
@@ -249,6 +256,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
 
     if (!showHistory.value) {
       arcSource.setData({ type: "FeatureCollection", features: [] });
+      legFeatures = [];
       legSource.setData({ type: "FeatureCollection", features: [] });
       setWaypointData(waypointSource, []);
       setViaData(viaSource, []);
@@ -271,11 +279,19 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     });
 
     arcSource.setData({ type: "FeatureCollection", features: allArcs });
+    legFeatures = allLegs;
     legSource.setData({ type: "FeatureCollection", features: allLegs });
     setWaypointData(waypointSource, allWaypoints);
     setViaData(viaSource, allVia);
 
     applyWaypointFeatureStates();
+  }
+
+  function queryLayer(point: MapMouseEvent["point"], layerId: string) {
+    if (!mlMap.getLayer(layerId)) return [];
+    return mlMap
+      .queryRenderedFeatures(point, { layers: [layerId] })
+      .filter((f) => f.layer?.id === layerId);
   }
 
   function handleCtrlClick(e: MapMouseEvent): boolean {
@@ -314,11 +330,8 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
       !originalEvent.shiftKey &&
       !originalEvent.altKey;
 
-    const hits = mlMap.getLayer(WAYPOINT_LAYER_ID)
-      ? mlMap
-          .queryRenderedFeatures(e.point, { layers: [WAYPOINT_LAYER_ID] })
-          .filter((f) => f.layer?.id === WAYPOINT_LAYER_ID)
-      : [];
+    const isAlt = originalEvent.altKey && !originalEvent.shiftKey;
+    const hits = queryLayer(e.point, WAYPOINT_LAYER_ID);
     if (hits.length > 0) {
       const feature = hits[0];
       const unitId = feature.properties?.unitId as string | undefined;
@@ -326,7 +339,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
       const stateIndex = (feature.properties?.stateIndex as number) ?? -1;
       const isInitial = feature.properties?.isInitial === true;
 
-      if (originalEvent.altKey && !originalEvent.shiftKey) {
+      if (isAlt) {
         if (unitId && !isInitial && stateIndex >= 0) {
           unitActions.deleteUnitStateEntry(unitId, stateIndex);
           drawHistory();
@@ -342,6 +355,31 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
         applyWaypointFeatureStates();
       }
       return true;
+    }
+
+    if (isAlt && editHistory.value) {
+      const viaHits = queryLayer(e.point, VIA_LAYER_ID);
+      const viaFeature = viaHits[0];
+      if (viaFeature) {
+        const unitId = viaFeature.properties?.unitId as string | undefined;
+        const stateIndex = viaFeature.properties?.stateIndex as number | undefined;
+        const viaIndex = viaFeature.properties?.viaIndex as number | undefined;
+        if (
+          unitId &&
+          stateIndex !== undefined &&
+          stateIndex >= 0 &&
+          viaIndex !== undefined &&
+          viaIndex >= 0
+        ) {
+          unitActions.updateUnitStateVia(unitId, "remove", stateIndex, viaIndex, [
+            e.lngLat.lng,
+            e.lngLat.lat,
+          ]);
+          unitActions.updateUnitState(unitId);
+          drawHistory();
+        }
+        return true;
+      }
     }
 
     if (isCtrl) return handleCtrlClick(e);
@@ -387,6 +425,8 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
   function onViaMouseDown(e: MapLayerMouseEvent) {
     // A waypoint drawn on top of a via point wins; its handler runs first.
     if (!editHistory.value || dragState) return;
+    // Alt-click removes the via point, so it must not start a drag.
+    if (e.originalEvent.altKey) return;
     const feature = e.features?.[0];
     if (!feature) return;
     const unitId = feature.properties?.unitId as string | undefined;
@@ -405,6 +445,50 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
       commit: (lngLat) => {
         unitActions.updateUnitStateVia(unitId, "modify", stateIndex, viaIndex, lngLat);
         unitActions.updateUnitState(unitId);
+      },
+    });
+  }
+
+  /**
+   * Grabbing the middle of a leg segment inserts a new via point there and
+   * starts dragging it, like the OpenLayers Modify interaction does.
+   */
+  function onLegMouseDown(e: MapLayerMouseEvent) {
+    if (!editHistory.value || dragState) return;
+    // Alt-click is reserved for deleting points.
+    if (e.originalEvent.altKey) return;
+    // Existing points win over the line they are drawn on.
+    if (
+      queryLayer(e.point, WAYPOINT_LAYER_ID).length > 0 ||
+      queryLayer(e.point, VIA_LAYER_ID).length > 0
+    ) {
+      return;
+    }
+    const unitId = e.features?.[0]?.properties?.unitId as string | undefined;
+    const lngLat: [number, number] = [e.lngLat.lng, e.lngLat.lat];
+    const hit = findClosestLegSegment(legFeatures, lngLat, unitId);
+    if (!hit?.unitId || hit.stateIndex < 0) return;
+    const { unitId: hitUnitId, stateIndex, viaIndex } = hit;
+
+    unitActions.updateUnitStateVia(hitUnitId, "add", stateIndex, viaIndex, lngLat);
+    unitActions.updateUnitState(hitUnitId);
+    drawHistory();
+
+    startDrag(e, {
+      source: "via",
+      matches: (f) =>
+        f.properties?.unitId === hitUnitId &&
+        f.properties?.stateIndex === stateIndex &&
+        f.properties?.viaIndex === viaIndex,
+      commit: (position) => {
+        unitActions.updateUnitStateVia(
+          hitUnitId,
+          "modify",
+          stateIndex,
+          viaIndex,
+          position,
+        );
+        unitActions.updateUnitState(hitUnitId);
       },
     });
   }
@@ -446,6 +530,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
 
   mlMap.on("mousedown", WAYPOINT_LAYER_ID, onWaypointMouseDown);
   mlMap.on("mousedown", VIA_LAYER_ID, onViaMouseDown);
+  mlMap.on("mousedown", LEG_LAYER_ID, onLegMouseDown);
 
   activeScenario.store.onUndoRedo?.(({ meta }) => {
     if (meta?.value && selectedUnitIds.value.has(meta.value as string)) {
@@ -470,6 +555,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
   function dispose() {
     mlMap.off("mousedown", WAYPOINT_LAYER_ID, onWaypointMouseDown);
     mlMap.off("mousedown", VIA_LAYER_ID, onViaMouseDown);
+    mlMap.off("mousedown", LEG_LAYER_ID, onLegMouseDown);
     mlMap.off("mousemove", onDragMove);
     clearWaypointFeatureStates();
   }

--- a/src/geo/history.legGeometry.test.ts
+++ b/src/geo/history.legGeometry.test.ts
@@ -1,0 +1,34 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import type LineString from "ol/geom/LineString";
+import { createUnitPathFeatures, INITIAL_TIME, VIA_TIME } from "@/geo/history";
+
+function createUnit() {
+  return {
+    id: "unit-1",
+    name: "Unit 1",
+    location: [10, 60],
+    state: [
+      { id: "state-1", t: 1000, location: [11, 61], via: [[10.5, 60.5]] },
+      { id: "state-2", t: 2000, location: [12, 62] },
+    ],
+  } as any;
+}
+
+describe("createUnitPathFeatures leg geometry", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it("carries the waypoint time as the M ordinate", () => {
+    // Path editing reads the time back off the dragged vertex to find the state
+    // entry to update, so the M ordinate has to survive both the antimeridian
+    // unwind and the projection transform.
+    const { legFeatures } = createUnitPathFeatures(createUnit(), { isEditMode: true });
+
+    expect(legFeatures).toHaveLength(1);
+    const coordinates = (legFeatures[0].getGeometry() as LineString).getCoordinates();
+    expect(coordinates.map((c) => c[2])).toEqual([INITIAL_TIME, VIA_TIME, 1000, 2000]);
+  });
+});

--- a/src/geo/history.ts
+++ b/src/geo/history.ts
@@ -22,7 +22,7 @@ import VectorLayer from "ol/layer/Vector";
 import VectorSource from "ol/source/Vector";
 import LayerGroup from "ol/layer/Group";
 import { useTimeFormatStore } from "@/stores/timeFormatStore";
-import { unwindCoordinates } from "@/geo/longitude";
+import { unwindCoordinates, unwrapLongitude } from "@/geo/longitude";
 
 export const VIA_TIME = -1337;
 // Marks the synthetic waypoint for a unit's initial location (`unit.location`),
@@ -252,6 +252,16 @@ function createGreatCircleArcFeature(leg: Position[]) {
   return coords;
 }
 
+/**
+ * Describes where a new via point would go if it was inserted at a given
+ * position in a leg. `stateIndex` is an index into `unit.state`, `viaIndex` the
+ * insertion index within that state entry's `via` array.
+ */
+export interface LegSegmentMeta {
+  stateIndex: number;
+  viaIndex: number;
+}
+
 export interface UnitPathGeoJson {
   legs: GeoJsonFeature<GeoJsonLineString>[];
   arcs: GeoJsonFeature<GeoJsonLineString>[];
@@ -298,6 +308,10 @@ export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
   const legs: GeoJsonFeature<GeoJsonLineString>[] = [];
   const arcs: GeoJsonFeature<GeoJsonLineString>[] = [];
 
+  // The initial waypoint is the unit's own location and has no state entry.
+  const getStateIndex = (s: LocationState) =>
+    s.t === INITIAL_TIME ? -1 : (unit.state?.findIndex((entry) => entry.t === s.t) ?? -1);
+
   let waypointIndex = 0;
   parts.forEach((part) => {
     part.forEach((s) => {
@@ -306,9 +320,7 @@ export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
       const label = isInitial
         ? `#${waypointIndex}`
         : `#${waypointIndex} ${fmt.trackFormatter.format(s.t)}`;
-      const stateIndex = isInitial
-        ? -1
-        : (unit.state?.findIndex((entry) => entry.t === s.t) ?? -1);
+      const stateIndex = getStateIndex(s);
       const feature: GeoJsonFeature<GeoJsonPoint> = {
         type: "Feature",
         geometry: {
@@ -344,14 +356,30 @@ export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
 
     if (part.length < 2) return;
     const segment: Position[] = [];
+    // Where a via point inserted *at* the coordinate with the same index would
+    // go. Via points belong to the state entry at the end of the leg segment
+    // they precede, so a waypoint coordinate maps to an append at the end of
+    // its own via list.
+    const coordinateMeta: LegSegmentMeta[] = [];
     for (let i = 0; i < part.length - 1; i++) {
       const from = part[i];
       const to = part[i + 1];
-      if (i === 0) segment.push([from.location[0], from.location[1]]);
+      if (i === 0) {
+        segment.push([from.location[0], from.location[1]]);
+        coordinateMeta.push({ stateIndex: getStateIndex(from), viaIndex: 0 });
+      }
+      const toStateIndex = getStateIndex(to);
       if (to.via) {
-        to.via.forEach((v) => segment.push([v[0], v[1]]));
+        to.via.forEach((v, viaIndex) => {
+          segment.push([v[0], v[1]]);
+          coordinateMeta.push({ stateIndex: toStateIndex, viaIndex });
+        });
       }
       segment.push([to.location[0], to.location[1]]);
+      coordinateMeta.push({
+        stateIndex: toStateIndex,
+        viaIndex: to.via?.length ?? 0,
+      });
     }
     legs.push({
       type: "Feature",
@@ -359,7 +387,8 @@ export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
         type: "LineString",
         coordinates: unwindCoordinates(segment),
       },
-      properties: { unitId: unit.id },
+      // `segments[i]` describes the segment between coordinate i and i + 1.
+      properties: { unitId: unit.id, segments: coordinateMeta.slice(1) },
     });
     arcs.push({
       type: "Feature",
@@ -372,6 +401,60 @@ export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
   });
 
   return { legs, arcs, waypoints, viaPoints };
+}
+
+function squaredDistanceToSegment(p: Position, a: Position, b: Position): number {
+  const dx = b[0] - a[0];
+  const dy = b[1] - a[1];
+  const lengthSquared = dx * dx + dy * dy;
+  let t = 0;
+  if (lengthSquared > 0) {
+    t = ((p[0] - a[0]) * dx + (p[1] - a[1]) * dy) / lengthSquared;
+    t = Math.max(0, Math.min(1, t));
+  }
+  const ex = a[0] + t * dx - p[0];
+  const ey = a[1] + t * dy - p[1];
+  return ex * ex + ey * ey;
+}
+
+export interface LegSegmentHit extends LegSegmentMeta {
+  unitId?: string;
+}
+
+/**
+ * Finds the leg segment closest to `point`, so a grabbed leg can be resolved to
+ * the via point insertion position it represents.
+ */
+export function findClosestLegSegment(
+  legs: GeoJsonFeature<GeoJsonLineString>[],
+  point: Position,
+  unitId?: string,
+): LegSegmentHit | null {
+  let best: LegSegmentHit | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const leg of legs) {
+    const legUnitId = leg.properties?.unitId as string | undefined;
+    if (unitId !== undefined && legUnitId !== unitId) continue;
+    const segments = leg.properties?.segments as LegSegmentMeta[] | undefined;
+    if (!segments) continue;
+    const coordinates = leg.geometry?.coordinates ?? [];
+    for (let i = 0; i < coordinates.length - 1; i++) {
+      const meta = segments[i];
+      if (!meta) continue;
+      const a = coordinates[i];
+      const b = coordinates[i + 1];
+      // Leg coordinates are unwound, so bring the query point into the same
+      // longitude window before measuring.
+      const reference = (a[0] + b[0]) / 2;
+      const shifted: Position = [unwrapLongitude(reference, point[0]), point[1]];
+      const distance = squaredDistanceToSegment(shifted, a, b);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = { unitId: legUnitId, ...meta };
+      }
+    }
+  }
+  return best;
 }
 
 function splitLocationStateIntoParts(state: LocationState[]): LocationState[][] {

--- a/src/geo/history.ts
+++ b/src/geo/history.ts
@@ -262,6 +262,17 @@ export interface LegSegmentMeta {
   viaIndex: number;
 }
 
+/**
+ * Identifies the point a leg coordinate was drawn from, so a drag can rewrite
+ * that coordinate for a live preview of the line.
+ */
+export interface LegVertexMeta {
+  stateIndex: number;
+  /** Absent for a waypoint coordinate, set for a via coordinate. */
+  viaIndex?: number;
+  isInitial?: boolean;
+}
+
 export interface UnitPathGeoJson {
   legs: GeoJsonFeature<GeoJsonLineString>[];
   arcs: GeoJsonFeature<GeoJsonLineString>[];
@@ -269,7 +280,7 @@ export interface UnitPathGeoJson {
   viaPoints: GeoJsonFeature<GeoJsonPoint>[];
 }
 
-function createArcCoords(leg: Position[]): Position[] {
+export function createArcCoords(leg: Position[]): Position[] {
   const coords: Position[] = [];
   for (let i = 0; i < leg.length - 1; i++) {
     const from = leg[i];
@@ -361,18 +372,26 @@ export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
     // they precede, so a waypoint coordinate maps to an append at the end of
     // its own via list.
     const coordinateMeta: LegSegmentMeta[] = [];
+    // `vertexMeta[i]` identifies the point coordinate i was drawn from.
+    const vertexMeta: LegVertexMeta[] = [];
     for (let i = 0; i < part.length - 1; i++) {
       const from = part[i];
       const to = part[i + 1];
       if (i === 0) {
+        const fromStateIndex = getStateIndex(from);
         segment.push([from.location[0], from.location[1]]);
-        coordinateMeta.push({ stateIndex: getStateIndex(from), viaIndex: 0 });
+        coordinateMeta.push({ stateIndex: fromStateIndex, viaIndex: 0 });
+        vertexMeta.push({
+          stateIndex: fromStateIndex,
+          isInitial: from.t === INITIAL_TIME,
+        });
       }
       const toStateIndex = getStateIndex(to);
       if (to.via) {
         to.via.forEach((v, viaIndex) => {
           segment.push([v[0], v[1]]);
           coordinateMeta.push({ stateIndex: toStateIndex, viaIndex });
+          vertexMeta.push({ stateIndex: toStateIndex, viaIndex });
         });
       }
       segment.push([to.location[0], to.location[1]]);
@@ -380,6 +399,7 @@ export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
         stateIndex: toStateIndex,
         viaIndex: to.via?.length ?? 0,
       });
+      vertexMeta.push({ stateIndex: toStateIndex, isInitial: to.t === INITIAL_TIME });
     }
     legs.push({
       type: "Feature",
@@ -387,8 +407,13 @@ export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
         type: "LineString",
         coordinates: unwindCoordinates(segment),
       },
-      // `segments[i]` describes the segment between coordinate i and i + 1.
-      properties: { unitId: unit.id, segments: coordinateMeta.slice(1) },
+      // `segments[i]` describes the segment between coordinate i and i + 1,
+      // `vertices[i]` the point coordinate i came from.
+      properties: {
+        unitId: unit.id,
+        segments: coordinateMeta.slice(1),
+        vertices: vertexMeta,
+      },
     });
     arcs.push({
       type: "Feature",

--- a/src/geo/history.ts
+++ b/src/geo/history.ts
@@ -25,6 +25,9 @@ import { useTimeFormatStore } from "@/stores/timeFormatStore";
 import { unwindCoordinates } from "@/geo/longitude";
 
 export const VIA_TIME = -1337;
+// Marks the synthetic waypoint for a unit's initial location (`unit.location`),
+// which is not backed by a state entry.
+export const INITIAL_TIME = Number.MIN_SAFE_INTEGER;
 
 const viaStyle = new Style({
   image: new CircleStyle({
@@ -155,7 +158,7 @@ export function createUnitPathFeatures(
   // extract the location states from the unit, and add the initial location
   // we then remove any states that don't have a location
   const state = [
-    { location: unit.location, t: Number.MIN_SAFE_INTEGER },
+    { location: unit.location, t: INITIAL_TIME },
     ...(unit.state || []),
   ].filter((s) => s.location !== undefined) as LocationState[];
 
@@ -218,7 +221,7 @@ export function createUnitPathFeatures(
       id: state.id,
       unitId: unit.id,
       label:
-        state.t > Number.MIN_SAFE_INTEGER
+        state.t > INITIAL_TIME
           ? `#${index} ${fmt.trackFormatter.format(state.t)}`
           : `#${index}`,
     });
@@ -284,7 +287,7 @@ function createArcCoords(leg: Position[]): Position[] {
 export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
   const fmt = useTimeFormatStore();
   const state = [
-    { location: unit.location, t: Number.MIN_SAFE_INTEGER },
+    { location: unit.location, t: INITIAL_TIME },
     ...(unit.state || []),
   ].filter((s) => s.location !== undefined) as LocationState[];
 
@@ -299,7 +302,7 @@ export function createUnitPathGeoJson(unit: Unit | NUnit): UnitPathGeoJson {
   parts.forEach((part) => {
     part.forEach((s) => {
       waypointIndex += 1;
-      const isInitial = s.t === Number.MIN_SAFE_INTEGER;
+      const isInitial = s.t === INITIAL_TIME;
       const label = isInitial
         ? `#${waypointIndex}`
         : `#${waypointIndex} ${fmt.trackFormatter.format(s.t)}`;

--- a/src/geo/longitude.test.ts
+++ b/src/geo/longitude.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { unwindCoordinates, unwrapLongitude, wrapLongitude } from "@/geo/longitude";
+
+describe("wrapLongitude", () => {
+  it("wraps longitudes into [-180, 180]", () => {
+    expect(wrapLongitude(190)).toBe(-170);
+    expect(wrapLongitude(-190)).toBe(170);
+    expect(wrapLongitude(10)).toBe(10);
+  });
+});
+
+describe("unwrapLongitude", () => {
+  it("picks the representation closest to the reference", () => {
+    expect(unwrapLongitude(170, -170)).toBe(190);
+    expect(unwrapLongitude(-170, 170)).toBe(-190);
+  });
+});
+
+describe("unwindCoordinates", () => {
+  it("keeps a path continuous across the antimeridian", () => {
+    expect(
+      unwindCoordinates([
+        [170, 10],
+        [-170, 12],
+      ]),
+    ).toEqual([
+      [170, 10],
+      [190, 12],
+    ]);
+  });
+
+  it("preserves ordinates beyond longitude and latitude", () => {
+    // The unit path encodes the waypoint time as a third (M) ordinate; dropping
+    // it leaves the OpenLayers leg geometry without the times that path editing
+    // needs to find the state entry to update.
+    expect(
+      unwindCoordinates([
+        [170, 10, 1000],
+        [-170, 12, 2000],
+      ]),
+    ).toEqual([
+      [170, 10, 1000],
+      [190, 12, 2000],
+    ]);
+  });
+
+  it("preserves the extra ordinate of a single coordinate", () => {
+    expect(unwindCoordinates([[10, 60, 1000]])).toEqual([[10, 60, 1000]]);
+  });
+});

--- a/src/geo/longitude.ts
+++ b/src/geo/longitude.ts
@@ -20,16 +20,18 @@ export function unwrapPositionRelative(
   return [unwrapLongitude(reference[0], position[0]), position[1]];
 }
 
+// Only the longitude is rewritten; any further ordinates (the unit path carries
+// the waypoint time as M) are passed through untouched.
 export function unwindCoordinates(coordinates: Position[]): Position[] {
   if (coordinates.length <= 1) {
-    return coordinates.map(([longitude, latitude]) => [longitude, latitude]);
+    return coordinates.map((coordinate) => [...coordinate]);
   }
 
-  const result: Position[] = [[coordinates[0]![0], coordinates[0]![1]]];
+  const result: Position[] = [[...coordinates[0]!]];
 
   for (let index = 1; index < coordinates.length; index += 1) {
-    const [longitude, latitude] = coordinates[index]!;
-    result.push([unwrapLongitude(result[index - 1]![0], longitude), latitude]);
+    const [longitude, ...rest] = coordinates[index]!;
+    result.push([unwrapLongitude(result[index - 1]![0], longitude!), ...rest]);
   }
 
   return result;

--- a/src/geo/maplibreMidpoint.ts
+++ b/src/geo/maplibreMidpoint.ts
@@ -1,0 +1,98 @@
+import type { Map as MlMap } from "maplibre-gl";
+import type { Position } from "geojson";
+import { unwrapPositionRelative } from "@/geo/longitude";
+import {
+  isGlobeProjection,
+  latitudeToMercatorY,
+  mercatorYToLatitude,
+} from "@/geo/mercator";
+
+const SEGMENT_SAMPLES = 64;
+
+export function midpoint(a: Position, b: Position): Position {
+  return [(a[0] + b[0]) / 2, (a[1] + b[1]) / 2];
+}
+
+/**
+ * The midpoint of a segment as it is drawn on screen, so a handle placed there
+ * sits visually halfway along the line even when the projection curves it.
+ */
+export function getRenderedMidpoint(map: MlMap, a: Position, b: Position): Position {
+  if (isGlobeProjection(map)) {
+    return projectedMercatorSegmentMidpoint(map, a, b);
+  }
+  try {
+    const projectedA = map.project(a as [number, number]);
+    const projectedB = map.project(b as [number, number]);
+    const renderedMidpoint = map.unproject([
+      (projectedA.x + projectedB.x) / 2,
+      (projectedA.y + projectedB.y) / 2,
+    ]);
+    return [renderedMidpoint.lng, renderedMidpoint.lat];
+  } catch {
+    return midpoint(a, b);
+  }
+}
+
+function projectedMercatorSegmentMidpoint(
+  map: MlMap,
+  a: Position,
+  b: Position,
+): Position {
+  try {
+    const coordinates = sampleMercatorSegmentCoordinates(a, b);
+    const projected = coordinates.map((coordinate) => ({
+      coordinate,
+      point: map.project(coordinate as [number, number]),
+    }));
+    const lengths: number[] = [];
+    let totalLength = 0;
+
+    for (let index = 0; index < projected.length - 1; index++) {
+      const start = projected[index]!.point;
+      const end = projected[index + 1]!.point;
+      const length = Math.hypot(end.x - start.x, end.y - start.y);
+      lengths.push(length);
+      totalLength += length;
+    }
+
+    if (totalLength === 0) return midpoint(a, b);
+
+    let remaining = totalLength / 2;
+    for (let index = 0; index < lengths.length; index++) {
+      const length = lengths[index]!;
+      if (remaining > length) {
+        remaining -= length;
+        continue;
+      }
+      const start = projected[index]!.coordinate;
+      const end = projected[index + 1]!.coordinate;
+      const ratio = length === 0 ? 0 : remaining / length;
+      return unwrapPositionRelative(a, [
+        start[0] + (end[0] - start[0]) * ratio,
+        start[1] + (end[1] - start[1]) * ratio,
+      ]);
+    }
+
+    return coordinates[Math.floor(coordinates.length / 2)]!;
+  } catch {
+    return midpoint(a, b);
+  }
+}
+
+function sampleMercatorSegmentCoordinates(a: Position, b: Position): Position[] {
+  const end = unwrapPositionRelative(a, b);
+  const startY = latitudeToMercatorY(a[1]);
+  const endY = latitudeToMercatorY(end[1]);
+  const coordinates: Position[] = [];
+
+  for (let index = 0; index <= SEGMENT_SAMPLES; index++) {
+    const ratio = index / SEGMENT_SAMPLES;
+    coordinates.push([
+      a[0] + (end[0] - a[0]) * ratio,
+      mercatorYToLatitude(startY + (endY - startY) * ratio),
+    ]);
+  }
+
+  return coordinates;
+}


### PR DESCRIPTION
Unit path editing was broken in MapLibre mode and misbehaved in OpenLayers mode. Three related fixes plus a usability pass on adding via points.

**Waypoints were undraggable in MapLibre.** MapLibre coerces top-level GeoJSON feature ids with `parseInt`, so our nanoid waypoint ids arrived as `NaN` and nothing could be selected or dragged. The waypoint source now uses `promoteId: "waypointId"` and reads the id back from the property.

**The unit jumped to the edited point in OpenLayers.** `unwindCoordinates` destructured every coordinate down to `[longitude, latitude]`, silently dropping the M ordinate that carries each waypoint's time. Every leg vertex came back with `M === undefined`, so dragging a waypoint fell through to the current scenario time instead of the waypoint's own, and adding a via point never matched the vertex OpenLayers inserts — which is why nothing was committed. Longitude is now the only ordinate rewritten.

Dragging the first waypoint moves `unit.location` rather than inserting a state entry at `INITIAL_TIME`, which would otherwise pin every interpolation to the dragged point. Alt-clicking the origin waypoint no longer deletes the last waypoint via `splice(-1, 1)`.

**Via points in MapLibre.** They can now be dragged, added, and removed with alt-click. Adding one initially meant grabbing the 2px leg line, which needed pixel-perfect aim and gave no hint it was possible; each leg segment now draws a midpoint handle styled like the ones the feature draw editor uses for lines, resolved with the same 12px (26px touch) tolerance box.

Dragging any point rewrites the leg and arc lines as well as the point, so the path follows the cursor instead of snapping into place on release. Leg features carry a `vertices` meta array for that. The globe-aware midpoint helper moved out of `maplibreDrawInteraction.ts` into `@/geo/maplibreMidpoint` so both editors share it.