### PR TITLE
Show event symbol changes on the map, chart and search

### DIFF
--- a/src/components/MapContextMenu.vue
+++ b/src/components/MapContextMenu.vue
@@ -290,7 +290,7 @@ const baseMapId = computed({
             <div class="flex items-center">
               <span class="flex w-7 items-center">
                 <UnitSymbol
-                  :sidc="unit.sidc"
+                  :sidc="unit._state?.sidc ?? unit.sidc"
                   class="w-6"
                   :options="unitActions.getCombinedSymbolOptions(unit)"
               /></span>

--- a/src/composables/searching.test.ts
+++ b/src/composables/searching.test.ts
@@ -2,7 +2,7 @@ import { mount } from "@vue/test-utils";
 import { defineComponent, ref } from "vue";
 import { describe, expect, it } from "vitest";
 import { activeScenarioKey } from "@/components/injects";
-import { useActionSearch } from "./searching";
+import { useActionSearch, useScenarioSearch } from "./searching";
 
 const SearchHarness = defineComponent({
   setup() {
@@ -44,5 +44,54 @@ describe("useActionSearch", () => {
       .searchActions("revert")
       .map((item) => item.action);
     expect(actions).toEqual(["restoreOriginal", "revertToSaved"]);
+  });
+});
+
+describe("useScenarioSearch", () => {
+  it("returns the symbol projected for the current scenario time", () => {
+    const unitMap: Record<string, any> = {
+      "unit-1": {
+        id: "unit-1",
+        name: "General Belgrano",
+        sidc: "10031000000000000000",
+        _pid: "unit-parent",
+        _state: { sidc: "10031000001100000000" },
+      },
+      "unit-parent": {
+        id: "unit-parent",
+        name: "Task Group",
+        sidc: "10031000000000000000",
+        _state: { sidc: "10031000001200000000" },
+      },
+    };
+    const SearchUnitsHarness = defineComponent({
+      setup() {
+        return useScenarioSearch();
+      },
+      template: "<div />",
+    });
+    const wrapper = mount(SearchUnitsHarness, {
+      global: {
+        provide: {
+          [activeScenarioKey as symbol]: {
+            unitActions: {
+              units: ref(Object.values(unitMap)),
+              getCombinedSymbolOptions: () => ({}),
+            },
+            store: { state: { events: [], eventMap: {} } },
+            geo: { itemsInfo: ref([]), mapLayers: ref([]) },
+            helpers: { getUnitById: (id: string) => unitMap[id] },
+          },
+        },
+      },
+    });
+
+    const { groups } = (
+      wrapper.vm as unknown as { search: (q: string) => { groups: Map<string, any[]> } }
+    ).search("Belgrano");
+    const [hit] = groups.get("Units")!;
+
+    expect(hit.sidc).toBe("10031000001100000000");
+    expect(hit.parent.sidc).toBe("10031000001200000000");
   });
 });

--- a/src/composables/searching.ts
+++ b/src/composables/searching.ts
@@ -37,10 +37,12 @@ export function useScenarioSearch(
         const parent = u.obj._pid && ({ ...getUnitById(u.obj._pid) } as NUnit);
         if (parent) {
           parent.symbolOptions = unitActions.getCombinedSymbolOptions(parent);
+          // Show the symbol projected for the current scenario time.
+          parent.sidc = parent._state?.sidc ?? parent.sidc;
         }
         return {
           name: u.obj.name,
-          sidc: u.obj.sidc,
+          sidc: u.obj._state?.sidc ?? u.obj.sidc,
           id: u.obj.id,
           index: i,
           parent,

--- a/src/modules/charteditor/OrbatChartSettingsChart.vue
+++ b/src/modules/charteditor/OrbatChartSettingsChart.vue
@@ -41,7 +41,9 @@ const rootUnitStore = useRootUnitStore();
 const showSearch = ref(false);
 
 const onUnitSelect = (unitId: string) => {
-  const unit = expandUnitWithSymbolOptions(getUnitById(unitId));
+  const unit = expandUnitWithSymbolOptions(getUnitById(unitId), {
+    useCurrentState: true,
+  });
   if (unit) rootUnitStore.unit = unit;
 };
 </script>

--- a/src/modules/maplibreview/MaplibreContextMenu.vue
+++ b/src/modules/maplibreview/MaplibreContextMenu.vue
@@ -355,7 +355,7 @@ function onContextMenu(event: MouseEvent) {
             <div class="flex items-center">
               <span class="flex w-7 items-center">
                 <UnitSymbol
-                  :sidc="unit.sidc"
+                  :sidc="unit._state?.sidc ?? unit.sidc"
                   class="w-6"
                   :options="unitActions.getCombinedSymbolOptions(unit)"
                 />

--- a/src/modules/maplibreview/MlMapLogic.test.ts
+++ b/src/modules/maplibreview/MlMapLogic.test.ts
@@ -423,6 +423,53 @@ describe("MlMapLogic", () => {
     );
   });
 
+  it("renders the symbol projected for the current scenario time", () => {
+    const mockMap = createMockMap();
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const activeScenario = {
+      store: {
+        state: {
+          id: "scenario-maplibre-state-sidc",
+          currentTime: 0,
+          featureStateCounter: 0,
+        },
+      },
+      unitActions: {
+        getCombinedSymbolOptions: vi.fn(() => ({})),
+      },
+      geo: {
+        everyVisibleUnit: computed(() => [
+          {
+            id: "unit-sunk",
+            sidc: "10031000000000000000",
+            shortName: "A1",
+            name: "Alpha 1",
+            _state: {
+              location: [10, 20],
+              sidc: "10031000001100000000",
+            },
+          },
+        ]),
+      },
+      time: {
+        setCurrentTime: vi.fn(),
+      },
+    } as any;
+
+    mountMlMapLogic({ mockMap, activeScenario, pinia });
+
+    const setDataCalls = mockMap.getSource("unitSource")?.setData.mock.calls ?? [];
+    const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
+    expect(unitData.features[0].properties.sidc).toBe("10031000001100000000");
+    mockMap.emit("styleimagemissing", { id: unitData.features[0].properties.symbolKey });
+
+    expect(symbolGenerator).toHaveBeenCalledWith(
+      "10031000001100000000",
+      expect.anything(),
+    );
+  });
+
   it("registers a symbol image source that re-rasterizes icons at an export render scale", async () => {
     const mockMap = createMockMap();
     const pinia = createPinia();

--- a/src/modules/maplibreview/MlMapLogic.vue
+++ b/src/modules/maplibreview/MlMapLogic.vue
@@ -1071,7 +1071,10 @@ function addUnits(
           : resolvedUniqueDesignation;
       const { size: _symbolOptionSize, ...combinedSymbolOptions } =
         unitActions.getCombinedSymbolOptions(unit);
-      const customSymbolId = getCustomSymbolId(unit.sidc);
+      // Use the symbol projected for the current scenario time, so symbol changes
+      // in unit states/events are reflected on the map.
+      const sidc = unit._state?.sidc ?? unit.sidc;
+      const customSymbolId = getCustomSymbolId(sidc);
       const customSymbol = customSymbolId
         ? activeScenario.store.state.customSymbolMap[customSymbolId]
         : undefined;
@@ -1090,7 +1093,7 @@ function addUnits(
             }
           : {
               kind: "milsymbol",
-              sidc: unit.sidc,
+              sidc,
               symbolOptions: {
                 size: renderedSymbolSize,
                 ...combinedSymbolOptions,
@@ -1120,11 +1123,11 @@ function addUnits(
           id: unit.id,
           visibilityGroup: visibilityGroup.id,
           symbolKey: imageId,
-          sidc: unit.sidc,
+          sidc,
           label: mapSettings.mapUnitLabelBelow
             ? unit.shortName || unit.name || "Unnamed Unit"
             : "",
-          textOffset: [0, getUnitLabelOffsetY(renderedSymbolSize, unit.sidc)],
+          textOffset: [0, getUnitLabelOffsetY(renderedSymbolSize, sidc)],
           symbolRotation,
         },
       } as Feature;

--- a/src/modules/scenarioeditor/ChartEditView.vue
+++ b/src/modules/scenarioeditor/ChartEditView.vue
@@ -42,7 +42,9 @@ const {
 const activeUnit = computed(
   () =>
     (activeUnitId.value &&
-      unitActions.expandUnitWithSymbolOptions(getUnitById(activeUnitId.value))) ||
+      unitActions.expandUnitWithSymbolOptions(getUnitById(activeUnitId.value), {
+        useCurrentState: true,
+      })) ||
     null,
 );
 

--- a/src/scenariostore/unitManipulations.test.ts
+++ b/src/scenariostore/unitManipulations.test.ts
@@ -880,3 +880,33 @@ describe("fresh load preserves base resource onHand", () => {
     expect(unit.personnel?.[0]).toEqual(expect.objectContaining({ count: 2, onHand: 1 }));
   });
 });
+
+describe("expandUnitWithSymbolOptions", () => {
+  function createTimedScenario() {
+    const scenario = createScenario();
+    scenario.sides[0].groups[0].subUnits[0].state = [
+      { id: "state-1", t: "2025-01-01T01:00:00Z", sidc: "10031000001100000000" },
+    ];
+    return scenario;
+  }
+
+  it("keeps the base symbol by default", () => {
+    const store = useNewScenarioStore(createTimedScenario());
+    const actions = useUnitManipulations(store);
+    useScenarioTime(store).setCurrentTime(Date.parse("2025-01-01T02:00:00Z"));
+
+    const unit = actions.expandUnitWithSymbolOptions(store.state.unitMap["unit-1"]);
+    expect(unit.sidc).toBe("10031000000000000000");
+  });
+
+  it("uses the symbol projected for the current time when asked", () => {
+    const store = useNewScenarioStore(createTimedScenario());
+    const actions = useUnitManipulations(store);
+    useScenarioTime(store).setCurrentTime(Date.parse("2025-01-01T02:00:00Z"));
+
+    const unit = actions.expandUnitWithSymbolOptions(store.state.unitMap["unit-1"], {
+      useCurrentState: true,
+    });
+    expect(unit.sidc).toBe("10031000001100000000");
+  });
+});

--- a/src/scenariostore/unitManipulations.ts
+++ b/src/scenariostore/unitManipulations.ts
@@ -59,6 +59,11 @@ export type NWalkSideGroupCallback = (
   side?: NSide,
 ) => void | false | true;
 
+export interface ExpandUnitOptions {
+  /** Use the symbol projected for the current scenario time instead of the base sidc. */
+  useCurrentState?: boolean;
+}
+
 export interface WalkSubUnitsOptions {
   includeParent: boolean;
   state: ScenarioState;
@@ -1054,13 +1059,18 @@ export function useUnitManipulations(store: NewScenarioStore) {
     };
   }
 
-  function expandUnitWithSymbolOptions(unit: NUnit): Unit {
+  function expandUnitWithSymbolOptions(
+    unit: NUnit,
+    options: ExpandUnitOptions = {},
+  ): Unit {
+    const { useCurrentState = false } = options;
     return {
       ...unit,
       state: [],
+      sidc: useCurrentState ? (unit._state?.sidc ?? unit.sidc) : unit.sidc,
       symbolOptions: getCombinedSymbolOptions(unit),
       subUnits: unit.subUnits.map((subUnitId) =>
-        expandUnitWithSymbolOptions(state.unitMap[subUnitId]),
+        expandUnitWithSymbolOptions(state.unitMap[subUnitId], options),
       ),
       equipment: unit.equipment?.map(({ id, count }) => ({
         name: state.equipmentMap[id].name || "",


### PR DESCRIPTION
Unit states can change a unit's symbol at a given time. The projected symbol lands in `unit._state.sidc`, which the ORBAT panel and the OpenLayers map styles already use, but several other consumers read the base `unit.sidc`, so a symbol change in an event never showed up there.

- **MapLibre map** — `addUnits()` resolves the sidc from `_state` once and uses it for the symbol image, the custom symbol lookup, the `sidc` feature property and the label offset.
- **ORBAT chart** — `expandUnitWithSymbolOptions()` takes a new `useCurrentState` option, applied recursively to sub-units, which the two chart call sites pass. The Spatial Illusions export keeps the base symbol.
- **Search hits and map context menus** — `searchUnits` emits the projected symbol for both the hit and its parent (covering the search modal and the command palette), and both context menus render it.

Fixes #614