### PR TITLE
Convert between waypoints and via points from the map context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,11 @@ All notable changes to this project will be documented in this file.
 
 - Added unit track editing to MapLibre mode: drag waypoints and via points to move them, drag a midpoint handle on a leg to insert a via point, and alt-click a point to delete it. The track redraws while dragging.
 - Added the unit track editing gestures to the keyboard shortcuts dialog.
+- Added map context menu options for converting a waypoint into a via point and a via point into a waypoint. The new waypoint is timed from the average speed of the leg it sits on.
 
 ### Fixed
 
+- Fixed right-clicking a unit track in MapLibre edit mode, which inserted a via point and started dragging it instead of opening the context menu.
 - Fixed unit track editing in MapLibre mode, where dragging a waypoint or via point never committed the new position.
 - Fixed the unit jumping to the edited waypoint in OpenLayers mode, and via points losing their leg times.
 

--- a/src/components/keyboardShortcuts.ts
+++ b/src/components/keyboardShortcuts.ts
@@ -51,6 +51,10 @@ export const mapEditModeShortcuts: KeyboardCategory[] = [
       { shortcut: [["alt", "click"]], description: "Delete a waypoint or via point" },
       { shortcut: [["drag"]], description: "Move a waypoint or via point" },
       { shortcut: [["drag"]], description: "Add a via point (drag a midpoint handle)" },
+      {
+        shortcut: [["right click"]],
+        description: "Convert between waypoint and via point",
+      },
     ],
   },
   {

--- a/src/composables/geoUnitHistory.ts
+++ b/src/composables/geoUnitHistory.ts
@@ -27,7 +27,7 @@ import { useSelectedWaypoints } from "@/stores/selectedWaypoints";
 import OLMap from "ol/Map";
 import { MapCtrlClick } from "@/geo/olInteractions";
 import { getDistance } from "ol/sphere";
-import { convertSpeedToMetric } from "@/utils/convert";
+import { getUnitSpeedMps } from "@/scenariostore/unitTrackConversions";
 import { useTimeFormatStore } from "@/stores/timeFormatStore";
 import { useRoutingStore } from "@/stores/routingStore";
 
@@ -103,11 +103,7 @@ export function useUnitHistory(
       if (lastLocationEntry) {
         const { location, t } = lastLocationEntry;
         const distance = getDistance(location!, clickPosition);
-        const speedValue = unit.properties?.averageSpeed || unit.properties?.maxSpeed;
-        const speed = speedValue
-          ? convertSpeedToMetric(speedValue.value, speedValue.uom)
-          : convertSpeedToMetric(30, "km/h");
-        const time = distance / speed;
+        const time = distance / getUnitSpeedMps(unit);
         newTime = Math.round(t + time * 1000);
       }
 

--- a/src/composables/maplibreUnitHistory.test.ts
+++ b/src/composables/maplibreUnitHistory.test.ts
@@ -433,6 +433,69 @@ describe("useMaplibreUnitHistory", () => {
     expect(harness.unitActions.updateUnitStateVia).not.toHaveBeenCalled();
   });
 
+  it("leaves a right click near a midpoint handle to the context menu", () => {
+    const harness = createHarness();
+    setupEditing(harness);
+    stubMidpointHits(harness);
+
+    harness.trigger(
+      "mousedown",
+      createEvent(11.5 + 6, 21.5 + 6, undefined, { button: 2 }),
+    );
+
+    expect(harness.unitActions.updateUnitStateVia).not.toHaveBeenCalled();
+  });
+
+  it("leaves a right click on a leg to the context menu", () => {
+    const harness = createHarness();
+    setupEditing(harness);
+
+    harness.trigger(
+      "mousedown:unitHistoryLegLayer",
+      createEvent(10.5, 20.5, LEG_FEATURE, { button: 2 }),
+    );
+
+    expect(harness.unitActions.updateUnitStateVia).not.toHaveBeenCalled();
+  });
+
+  it("does not drag a right clicked waypoint", () => {
+    const harness = createHarness();
+    setupEditing(harness);
+
+    const feature = {
+      id: NaN,
+      properties: { unitId: UNIT_ID, waypointId: WAYPOINT_ID, t: 2000, isInitial: false },
+    };
+    harness.trigger(
+      "mousedown:unitHistoryWaypointLayer",
+      createEvent(11, 21, [feature], { button: 2 }),
+    );
+    harness.trigger("mouseup", createEvent(30, 40));
+
+    expect(harness.addUnitPosition).not.toHaveBeenCalled();
+  });
+
+  it("does not drag a right clicked via point", () => {
+    const harness = createHarness();
+    harness.unit.state[0].via = [[11.5, 21.5]];
+    setupEditing(harness);
+
+    harness.trigger(
+      "mousedown:unitHistoryViaLayer",
+      createEvent(
+        11.5,
+        21.5,
+        [{ properties: { unitId: UNIT_ID, stateIndex: 0, viaIndex: 0 } }],
+        {
+          button: 2,
+        },
+      ),
+    );
+    harness.trigger("mouseup", createEvent(30, 40));
+
+    expect(harness.unitActions.updateUnitStateVia).not.toHaveBeenCalled();
+  });
+
   it("leaves a ctrl-click on a leg to the waypoint handler", () => {
     const harness = createHarness();
     setupEditing(harness);

--- a/src/composables/maplibreUnitHistory.ts
+++ b/src/composables/maplibreUnitHistory.ts
@@ -25,7 +25,7 @@ import { useSelectedItems } from "@/stores/selectedStore";
 import { useSelectedWaypoints } from "@/stores/selectedWaypoints";
 import { useUnitSettingsStore } from "@/stores/geoStore";
 import { useTimeFormatStore } from "@/stores/timeFormatStore";
-import { convertSpeedToMetric } from "@/utils/convert";
+import { getUnitSpeedMps } from "@/scenariostore/unitTrackConversions";
 
 const ARC_SOURCE_ID = "unitHistoryArcSource";
 const LEG_SOURCE_ID = "unitHistoryLegSource";
@@ -35,9 +35,9 @@ const MIDPOINT_SOURCE_ID = "unitHistoryLegMidpointSource";
 
 const ARC_LAYER_ID = "unitHistoryArcLayer";
 const LEG_LAYER_ID = "unitHistoryLegLayer";
-export const WAYPOINT_LAYER_ID = "unitHistoryWaypointLayer";
+const WAYPOINT_LAYER_ID = "unitHistoryWaypointLayer";
 const WAYPOINT_LABEL_LAYER_ID = "unitHistoryWaypointLabelLayer";
-export const VIA_LAYER_ID = "unitHistoryViaLayer";
+const VIA_LAYER_ID = "unitHistoryViaLayer";
 const MIDPOINT_LAYER_ID = "unitHistoryLegMidpointLayer";
 
 export const UNIT_HISTORY_LAYER_IDS = [
@@ -60,6 +60,85 @@ const coarsePointerQuery =
     : null;
 
 const EMPTY_FC: FeatureCollection = { type: "FeatureCollection", features: [] };
+
+/** A waypoint or via point of a drawn unit path, resolved from a map pixel. */
+export type TrackPointHit =
+  | { kind: "waypoint"; unitId: string; stateIndex: number }
+  | { kind: "via"; unitId: string; stateIndex: number; viaIndex: number };
+
+function getHandleHitTolerance(e?: MapMouseEvent): number {
+  const isTouch =
+    (e?.originalEvent?.type?.startsWith("touch") ?? false) ||
+    (coarsePointerQuery?.matches ?? false);
+  return isTouch ? TOUCH_HANDLE_HIT_TOLERANCE_PX : HANDLE_HIT_TOLERANCE_PX;
+}
+
+/** The rendered feature whose drawn position is nearest the given pixel. */
+function closestFeatureTo<T extends { geometry: unknown }>(
+  mlMap: MlMap,
+  features: T[],
+  x: number,
+  y: number,
+): T | undefined {
+  const distance = (f: T) => {
+    const coordinates = (f.geometry as { coordinates?: [number, number] }).coordinates;
+    if (!coordinates) return Number.POSITIVE_INFINITY;
+    const projected = mlMap.project(coordinates);
+    return Math.hypot(projected.x - x, projected.y - y);
+  };
+  let best: T | undefined;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const feature of features) {
+    const d = distance(feature);
+    if (d < bestDistance) {
+      best = feature;
+      bestDistance = d;
+    }
+  }
+  return best;
+}
+
+/** Queries a handle layer with the press buffered into a tolerance box. */
+function queryHandlesInBox(
+  mlMap: MlMap,
+  [x, y]: [number, number],
+  layerId: string,
+  tolerance: number,
+) {
+  if (!mlMap.getLayer(layerId)) return [];
+  return mlMap.queryRenderedFeatures(
+    [
+      [x - tolerance, y - tolerance],
+      [x + tolerance, y + tolerance],
+    ],
+    { layers: [layerId] },
+  );
+}
+
+/**
+ * Resolves a map pixel to the closest waypoint or via point of a drawn unit
+ * path. Shared by the edit handlers and the map context menu, so both agree on
+ * the hit tolerance and on waypoints winning a shared hit.
+ */
+export function queryTrackPointAt(
+  mlMap: MlMap,
+  point: [number, number],
+  tolerance = getHandleHitTolerance(),
+): TrackPointHit | null {
+  // Waypoints are drawn on top of via points, so they win a shared hit.
+  for (const layerId of [WAYPOINT_LAYER_ID, VIA_LAYER_ID]) {
+    const hits = queryHandlesInBox(mlMap, point, layerId, tolerance);
+    const closest = closestFeatureTo(mlMap, hits, point[0], point[1]);
+    const unitId = closest?.properties?.unitId as string | undefined;
+    const stateIndex = closest?.properties?.stateIndex as number | undefined;
+    if (!unitId || stateIndex === undefined) continue;
+    if (layerId === WAYPOINT_LAYER_ID) return { kind: "waypoint", unitId, stateIndex };
+    const viaIndex = closest?.properties?.viaIndex as number | undefined;
+    if (viaIndex === undefined) continue;
+    return { kind: "via", unitId, stateIndex, viaIndex };
+  }
+  return null;
+}
 
 export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) {
   const { geo, unitActions } = activeScenario;
@@ -404,11 +483,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
       if (lastLocationEntry) {
         const { location, t } = lastLocationEntry;
         const travelDistance = distanceMeters(location!, lngLat);
-        const speedValue = unit.properties?.averageSpeed || unit.properties?.maxSpeed;
-        const speed = speedValue
-          ? convertSpeedToMetric(speedValue.value, speedValue.uom)
-          : convertSpeedToMetric(30, "km/h");
-        const travel = travelDistance / speed;
+        const travel = travelDistance / getUnitSpeedMps(unit);
         newTime = Math.round(t + travel * 1000);
       }
       geo.addUnitPosition(unitId, lngLat, newTime);
@@ -598,13 +673,6 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     });
   }
 
-  function getHandleHitTolerance(e: MapMouseEvent): number {
-    const isTouch =
-      (e.originalEvent?.type?.startsWith("touch") ?? false) ||
-      (coarsePointerQuery?.matches ?? false);
-    return isTouch ? TOUCH_HANDLE_HIT_TOLERANCE_PX : HANDLE_HIT_TOLERANCE_PX;
-  }
-
   /**
    * Dragging a midpoint handle inserts a via point at that segment. Runs off a
    * map-level mousedown so the press can be buffered into a tolerance box
@@ -624,26 +692,15 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     ) {
       return;
     }
-    const tolerance = getHandleHitTolerance(e);
     const { x, y } = e.point;
-    const hits = mlMap.queryRenderedFeatures(
-      [
-        [x - tolerance, y - tolerance],
-        [x + tolerance, y + tolerance],
-      ],
-      { layers: [MIDPOINT_LAYER_ID] },
+    const hits = queryHandlesInBox(
+      mlMap,
+      [x, y],
+      MIDPOINT_LAYER_ID,
+      getHandleHitTolerance(e),
     );
-    if (hits.length === 0) return;
-    const closest = hits.reduce((best, feature) => {
-      const distance = (f: (typeof hits)[number]) => {
-        const coordinates = (f.geometry as { coordinates?: [number, number] })
-          .coordinates;
-        if (!coordinates) return Number.POSITIVE_INFINITY;
-        const projected = mlMap.project(coordinates);
-        return Math.hypot(projected.x - x, projected.y - y);
-      };
-      return distance(feature) < distance(best) ? feature : best;
-    }, hits[0]!);
+    const closest = closestFeatureTo(mlMap, hits, x, y);
+    if (!closest) return;
 
     const unitId = closest.properties?.unitId as string | undefined;
     const stateIndex = closest.properties?.stateIndex as number | undefined;

--- a/src/composables/maplibreUnitHistory.ts
+++ b/src/composables/maplibreUnitHistory.ts
@@ -35,9 +35,9 @@ const MIDPOINT_SOURCE_ID = "unitHistoryLegMidpointSource";
 
 const ARC_LAYER_ID = "unitHistoryArcLayer";
 const LEG_LAYER_ID = "unitHistoryLegLayer";
-const WAYPOINT_LAYER_ID = "unitHistoryWaypointLayer";
+export const WAYPOINT_LAYER_ID = "unitHistoryWaypointLayer";
 const WAYPOINT_LABEL_LAYER_ID = "unitHistoryWaypointLabelLayer";
-const VIA_LAYER_ID = "unitHistoryViaLayer";
+export const VIA_LAYER_ID = "unitHistoryViaLayer";
 const MIDPOINT_LAYER_ID = "unitHistoryLegMidpointLayer";
 
 export const UNIT_HISTORY_LAYER_IDS = [
@@ -385,6 +385,14 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
     return (e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey;
   }
 
+  /**
+   * MapLibre reports a press of any button as `mousedown`, so the edit handlers
+   * have to keep out of the way of the right click that opens the context menu.
+   */
+  function isPrimaryButton(e: MapMouseEvent): boolean {
+    return (e.originalEvent?.button ?? 0) === 0;
+  }
+
   function handleCtrlClick(e: MapMouseEvent): boolean {
     if (selectedUnitIds.value.size === 0) return false;
     const lngLat: [number, number] = [e.lngLat.lng, e.lngLat.lat];
@@ -482,7 +490,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
   }
 
   function onWaypointMouseDown(e: MapLayerMouseEvent) {
-    if (!editHistory.value) return;
+    if (!editHistory.value || !isPrimaryButton(e)) return;
     const feature = e.features?.[0];
     if (!feature) return;
     const unitId = feature.properties?.unitId as string | undefined;
@@ -515,7 +523,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
 
   function onViaMouseDown(e: MapLayerMouseEvent) {
     // A waypoint drawn on top of a via point wins; its handler runs first.
-    if (!editHistory.value || dragState) return;
+    if (!editHistory.value || dragState || !isPrimaryButton(e)) return;
     // Alt-click removes the via point, so it must not start a drag.
     if (e.originalEvent.altKey) return;
     // Ctrl-click appends a waypoint instead.
@@ -548,7 +556,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
    * starts dragging it, like the OpenLayers Modify interaction does.
    */
   function onLegMouseDown(e: MapLayerMouseEvent) {
-    if (!editHistory.value || dragState) return;
+    if (!editHistory.value || dragState || !isPrimaryButton(e)) return;
     // Alt-click is reserved for deleting points.
     if (e.originalEvent.altKey) return;
     // Ctrl-click appends a waypoint, so it must not also insert a via point.
@@ -604,6 +612,7 @@ export function useMaplibreUnitHistory(mlMap: MlMap, activeScenario: TScenario) 
    */
   function onMapMouseDown(e: MapMouseEvent) {
     if (!showHistory.value || !editHistory.value || dragState) return;
+    if (!isPrimaryButton(e)) return;
     if (e.originalEvent.altKey) return;
     // Ctrl-click appends a waypoint, so it must not also insert a via point.
     if (isAddWaypointModifier(e.originalEvent)) return;

--- a/src/modules/maplibreview/MaplibreContextMenu.test.ts
+++ b/src/modules/maplibreview/MaplibreContextMenu.test.ts
@@ -224,6 +224,8 @@ describe("MaplibreContextMenu", () => {
         getCombinedSymbolOptions: vi.fn(() => ({})),
         isUnitLocked: vi.fn(() => false),
         createSubordinateUnit: vi.fn(() => "unit-2"),
+        convertViaPointToWaypoint: vi.fn(),
+        convertWaypointToViaPoint: vi.fn(),
       },
       geo: {
         addUnitPosition: vi.fn(),
@@ -241,6 +243,8 @@ describe("MaplibreContextMenu", () => {
                 id: "unit-1",
                 sidc: "SFGPUCI----K",
                 name: "Unit 1",
+                location: [0, 0],
+                state: [{ id: "state-1", t: 1000, location: [2, 0], via: [[1, 0]] }],
               }
             : undefined,
         ),
@@ -442,6 +446,7 @@ describe("MaplibreContextMenu", () => {
       }),
       unproject: () => ({ lng: 10, lat: 20 }),
       getZoom: () => 7,
+      getLayer: () => undefined,
       queryRenderedFeatures: () => [
         {
           layer: { id: "unitLayer" },
@@ -466,6 +471,77 @@ describe("MaplibreContextMenu", () => {
     expect(wrapper.text()).toContain("Feature 1");
     expect(wrapper.text()).toContain("Open in");
     expect(wrapper.text()).toContain("Map as image");
+  });
+
+  function createTrackMapRef(hits: Record<string, any[]>) {
+    return {
+      getContainer: () => ({
+        getBoundingClientRect: () => ({ left: 0, top: 0 }),
+      }),
+      unproject: () => ({ lng: 10, lat: 20 }),
+      getZoom: () => 7,
+      project: () => ({ x: 10, y: 20 }),
+      getLayer: (id: string) => (hits[id] ? { id } : undefined),
+      queryRenderedFeatures: (_point: unknown, options?: { layers?: string[] }) =>
+        options?.layers?.flatMap((id) => hits[id] ?? []) ?? [],
+    };
+  }
+
+  it("converts a right clicked via point into a waypoint", async () => {
+    const mapRef = createTrackMapRef({
+      unitHistoryViaLayer: [
+        {
+          layer: { id: "unitHistoryViaLayer" },
+          geometry: { type: "Point", coordinates: [1, 0] },
+          properties: { unitId: "unit-1", stateIndex: 0, viaIndex: 0 },
+        },
+      ],
+    });
+
+    const { wrapper, scenario } = mountMenu({ mapRef });
+    await wrapper.get(".h-full.w-full").trigger("contextmenu", {
+      button: 2,
+      clientX: 10,
+      clientY: 20,
+    });
+
+    const item = wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Convert via point to waypoint");
+    expect(item).toBeDefined();
+    await item?.trigger("click");
+
+    expect(scenario.unitActions.convertViaPointToWaypoint).toHaveBeenCalledWith(
+      "unit-1",
+      0,
+      0,
+    );
+  });
+
+  it("disables the waypoint conversion when there is no leg to merge into", async () => {
+    const mapRef = createTrackMapRef({
+      unitHistoryWaypointLayer: [
+        {
+          layer: { id: "unitHistoryWaypointLayer" },
+          geometry: { type: "Point", coordinates: [2, 0] },
+          properties: { unitId: "unit-1", stateIndex: 0, waypointId: "state-1" },
+        },
+      ],
+    });
+
+    const { wrapper } = mountMenu({ mapRef });
+    await wrapper.get(".h-full.w-full").trigger("contextmenu", {
+      button: 2,
+      clientX: 10,
+      clientY: 20,
+    });
+
+    // unit-1's only waypoint ends the path, so it cannot become a via point.
+    const item = wrapper
+      .findAll("button")
+      .find((button) => button.text() === "Convert waypoint to via point");
+    expect(item?.attributes("disabled")).toBeDefined();
+    expect(wrapper.text()).not.toContain("Convert via point to waypoint");
   });
 
   it("triggers the shared export action from the maplibre context menu", async () => {

--- a/src/modules/maplibreview/MaplibreContextMenu.test.ts
+++ b/src/modules/maplibreview/MaplibreContextMenu.test.ts
@@ -15,6 +15,10 @@ import { useUiStore } from "@/stores/uiStore";
 import { useSelectedItems } from "@/stores/selectedStore";
 import { useRecordingStore } from "@/stores/recordingStore";
 import { useMapSettingsStore } from "@/stores/mapSettingsStore";
+import {
+  canConvertViaPointToWaypoint,
+  canConvertWaypointToViaPoint,
+} from "@/scenariostore/unitTrackConversions";
 
 vi.mock("@/composables/mainToolbarData", () => ({
   useActiveSidc: () => ({
@@ -213,6 +217,14 @@ describe("MaplibreContextMenu", () => {
       id: "feature-1",
       name: "Feature 1",
     };
+    const unit = {
+      id: "unit-1",
+      sidc: "SFGPUCI----K",
+      name: "Unit 1",
+      location: [0, 0],
+      state: [{ id: "state-1", t: 1000, location: [2, 0], via: [[1, 0]] }],
+    } as any;
+    const getUnit = (id: string) => (id === "unit-1" ? unit : undefined);
     const scenario = {
       store: {
         state: {
@@ -224,6 +236,18 @@ describe("MaplibreContextMenu", () => {
         getCombinedSymbolOptions: vi.fn(() => ({})),
         isUnitLocked: vi.fn(() => false),
         createSubordinateUnit: vi.fn(() => "unit-2"),
+        // Delegate to the real rules, so the menu's enablement stays in sync
+        // with what the store actions actually allow.
+        canConvertViaPointToWaypoint: vi.fn(
+          (id: string, stateIndex: number, viaIndex: number) => {
+            const u = getUnit(id);
+            return !!u && canConvertViaPointToWaypoint(u, stateIndex, viaIndex);
+          },
+        ),
+        canConvertWaypointToViaPoint: vi.fn((id: string, stateIndex: number) => {
+          const u = getUnit(id);
+          return !!u && canConvertWaypointToViaPoint(u, stateIndex);
+        }),
         convertViaPointToWaypoint: vi.fn(),
         convertWaypointToViaPoint: vi.fn(),
       },
@@ -237,17 +261,7 @@ describe("MaplibreContextMenu", () => {
         layerItemsLayers: ref([{ id: "layer-1", items: [] }]),
       },
       helpers: {
-        getUnitById: vi.fn((id: string) =>
-          id === "unit-1"
-            ? {
-                id: "unit-1",
-                sidc: "SFGPUCI----K",
-                name: "Unit 1",
-                location: [0, 0],
-                state: [{ id: "state-1", t: 1000, location: [2, 0], via: [[1, 0]] }],
-              }
-            : undefined,
-        ),
+        getUnitById: vi.fn(getUnit),
       },
     } as any;
     const searchHooks = {

--- a/src/modules/maplibreview/MaplibreContextMenu.vue
+++ b/src/modules/maplibreview/MaplibreContextMenu.vue
@@ -58,11 +58,7 @@ import { useActiveUnitStore } from "@/stores/dragStore";
 import { useMainToolbarStore } from "@/stores/mainToolbarStore.ts";
 import UnitSymbol from "@/components/UnitSymbol.vue";
 import { useRecordingStore } from "@/stores/recordingStore";
-import { VIA_LAYER_ID, WAYPOINT_LAYER_ID } from "@/composables/maplibreUnitHistory";
-import {
-  canConvertViaPointToWaypoint,
-  canConvertWaypointToViaPoint,
-} from "@/scenariostore/unitTrackConversions";
+import { queryTrackPointAt, type TrackPointHit } from "@/composables/maplibreUnitHistory";
 
 const maplibreLayersStore = useMaplibreLayersStore();
 const {
@@ -111,17 +107,9 @@ const clickedUnits = ref<NUnit[]>([]);
 const clickedFeatures = ref<NGeometryLayerItem[]>([]);
 const dropPosition = ref<Position>([0, 0]);
 const mapZoomLevel = ref(0);
-const clickedWaypoint = ref<{ unitId: string; stateIndex: number } | null>(null);
-const clickedViaPoint = ref<{
-  unitId: string;
-  stateIndex: number;
-  viaIndex: number;
-} | null>(null);
+const clickedTrackPoint = ref<TrackPointHit | null>(null);
 const LONG_PRESS_MS = 550;
 const MOVE_TOLERANCE_PX = 10;
-// The track handles are small circles, so buffer the click into a box the way
-// the press handlers do.
-const HANDLE_HIT_TOLERANCE_PX = 12;
 
 let longPressTimer: ReturnType<typeof setTimeout> | null = null;
 let activePointerId: number | null = null;
@@ -295,68 +283,31 @@ function onAddPoint() {
 }
 
 const canConvertWaypoint = computed(() => {
-  const hit = clickedWaypoint.value;
-  if (!hit) return false;
-  const unit = getUnitById(hit.unitId);
-  return !!unit && canConvertWaypointToViaPoint(unit, hit.stateIndex);
+  const hit = clickedTrackPoint.value;
+  if (hit?.kind !== "waypoint") return false;
+  return unitActions.canConvertWaypointToViaPoint(hit.unitId, hit.stateIndex);
 });
 
 const canConvertViaPoint = computed(() => {
-  const hit = clickedViaPoint.value;
-  if (!hit) return false;
-  const unit = getUnitById(hit.unitId);
-  return !!unit && canConvertViaPointToWaypoint(unit, hit.stateIndex, hit.viaIndex);
+  const hit = clickedTrackPoint.value;
+  if (hit?.kind !== "via") return false;
+  return unitActions.canConvertViaPointToWaypoint(
+    hit.unitId,
+    hit.stateIndex,
+    hit.viaIndex,
+  );
 });
 
 function onConvertWaypointToViaPoint() {
-  const hit = clickedWaypoint.value;
-  if (!hit) return;
+  const hit = clickedTrackPoint.value;
+  if (hit?.kind !== "waypoint") return;
   unitActions.convertWaypointToViaPoint(hit.unitId, hit.stateIndex);
 }
 
 function onConvertViaPointToWaypoint() {
-  const hit = clickedViaPoint.value;
-  if (!hit) return;
+  const hit = clickedTrackPoint.value;
+  if (hit?.kind !== "via") return;
   unitActions.convertViaPointToWaypoint(hit.unitId, hit.stateIndex, hit.viaIndex);
-}
-
-/**
- * Resolves a right click to the closest waypoint or via point of a drawn unit
- * path, so the menu can offer to convert between the two.
- */
-function findClickedTrackPoint(mapRef: MlMap, point: [number, number]) {
-  const [x, y] = point;
-  const box: [[number, number], [number, number]] = [
-    [x - HANDLE_HIT_TOLERANCE_PX, y - HANDLE_HIT_TOLERANCE_PX],
-    [x + HANDLE_HIT_TOLERANCE_PX, y + HANDLE_HIT_TOLERANCE_PX],
-  ];
-  // Waypoints are drawn on top of via points, so they win a shared hit.
-  for (const layerId of [WAYPOINT_LAYER_ID, VIA_LAYER_ID]) {
-    if (!mapRef.getLayer(layerId)) continue;
-    const hits = mapRef.queryRenderedFeatures(box, { layers: [layerId] });
-    if (hits.length === 0) continue;
-    const closest = hits.reduce((best, feature) => {
-      const distance = (f: (typeof hits)[number]) => {
-        const coordinates = (f.geometry as { coordinates?: [number, number] })
-          .coordinates;
-        if (!coordinates) return Number.POSITIVE_INFINITY;
-        const projected = mapRef.project(coordinates);
-        return Math.hypot(projected.x - x, projected.y - y);
-      };
-      return distance(feature) < distance(best) ? feature : best;
-    }, hits[0]);
-    const unitId = closest.properties?.unitId as string | undefined;
-    const stateIndex = closest.properties?.stateIndex as number | undefined;
-    if (!unitId || stateIndex === undefined) continue;
-    if (layerId === WAYPOINT_LAYER_ID) {
-      clickedWaypoint.value = { unitId, stateIndex };
-      return;
-    }
-    const viaIndex = closest.properties?.viaIndex as number | undefined;
-    if (viaIndex === undefined) continue;
-    clickedViaPoint.value = { unitId, stateIndex, viaIndex };
-    return;
-  }
 }
 
 function onContextMenu(event: MouseEvent) {
@@ -371,10 +322,7 @@ function onContextMenu(event: MouseEvent) {
   mapZoomLevel.value = mapRef.getZoom() ?? 0;
   clickedUnits.value = [];
   clickedFeatures.value = [];
-  clickedWaypoint.value = null;
-  clickedViaPoint.value = null;
-
-  findClickedTrackPoint(mapRef, point);
+  clickedTrackPoint.value = queryTrackPointAt(mapRef, point);
 
   const seenUnitIds = new Set<string>();
   const seenFeatureIds = new Set<string>();
@@ -423,9 +371,9 @@ function onContextMenu(event: MouseEvent) {
         <span>{{ formattedPosition }}</span>
       </ContextMenuItem>
       <ContextMenuSeparator />
-      <template v-if="clickedWaypoint || clickedViaPoint">
+      <template v-if="clickedTrackPoint">
         <ContextMenuItem
-          v-if="clickedWaypoint"
+          v-if="clickedTrackPoint.kind === 'waypoint'"
           :disabled="!canConvertWaypoint"
           @select.prevent="onConvertWaypointToViaPoint()"
         >

--- a/src/modules/maplibreview/MaplibreContextMenu.vue
+++ b/src/modules/maplibreview/MaplibreContextMenu.vue
@@ -22,6 +22,8 @@ import {
   IconPlay,
   IconSpeedometer,
   IconSpeedometerSlow,
+  IconVectorPoint,
+  IconVectorPointMinus,
 } from "@iconify-prerendered/vue-mdi";
 import type { Position } from "geojson";
 import type { Map as MlMap } from "maplibre-gl";
@@ -56,6 +58,11 @@ import { useActiveUnitStore } from "@/stores/dragStore";
 import { useMainToolbarStore } from "@/stores/mainToolbarStore.ts";
 import UnitSymbol from "@/components/UnitSymbol.vue";
 import { useRecordingStore } from "@/stores/recordingStore";
+import { VIA_LAYER_ID, WAYPOINT_LAYER_ID } from "@/composables/maplibreUnitHistory";
+import {
+  canConvertViaPointToWaypoint,
+  canConvertWaypointToViaPoint,
+} from "@/scenariostore/unitTrackConversions";
 
 const maplibreLayersStore = useMaplibreLayersStore();
 const {
@@ -104,8 +111,17 @@ const clickedUnits = ref<NUnit[]>([]);
 const clickedFeatures = ref<NGeometryLayerItem[]>([]);
 const dropPosition = ref<Position>([0, 0]);
 const mapZoomLevel = ref(0);
+const clickedWaypoint = ref<{ unitId: string; stateIndex: number } | null>(null);
+const clickedViaPoint = ref<{
+  unitId: string;
+  stateIndex: number;
+  viaIndex: number;
+} | null>(null);
 const LONG_PRESS_MS = 550;
 const MOVE_TOLERANCE_PX = 10;
+// The track handles are small circles, so buffer the click into a box the way
+// the press handlers do.
+const HANDLE_HIT_TOLERANCE_PX = 12;
 
 let longPressTimer: ReturnType<typeof setTimeout> | null = null;
 let activePointerId: number | null = null;
@@ -278,6 +294,71 @@ function onAddPoint() {
   geo.addFeature(newFeature, activeLayer.id);
 }
 
+const canConvertWaypoint = computed(() => {
+  const hit = clickedWaypoint.value;
+  if (!hit) return false;
+  const unit = getUnitById(hit.unitId);
+  return !!unit && canConvertWaypointToViaPoint(unit, hit.stateIndex);
+});
+
+const canConvertViaPoint = computed(() => {
+  const hit = clickedViaPoint.value;
+  if (!hit) return false;
+  const unit = getUnitById(hit.unitId);
+  return !!unit && canConvertViaPointToWaypoint(unit, hit.stateIndex, hit.viaIndex);
+});
+
+function onConvertWaypointToViaPoint() {
+  const hit = clickedWaypoint.value;
+  if (!hit) return;
+  unitActions.convertWaypointToViaPoint(hit.unitId, hit.stateIndex);
+}
+
+function onConvertViaPointToWaypoint() {
+  const hit = clickedViaPoint.value;
+  if (!hit) return;
+  unitActions.convertViaPointToWaypoint(hit.unitId, hit.stateIndex, hit.viaIndex);
+}
+
+/**
+ * Resolves a right click to the closest waypoint or via point of a drawn unit
+ * path, so the menu can offer to convert between the two.
+ */
+function findClickedTrackPoint(mapRef: MlMap, point: [number, number]) {
+  const [x, y] = point;
+  const box: [[number, number], [number, number]] = [
+    [x - HANDLE_HIT_TOLERANCE_PX, y - HANDLE_HIT_TOLERANCE_PX],
+    [x + HANDLE_HIT_TOLERANCE_PX, y + HANDLE_HIT_TOLERANCE_PX],
+  ];
+  // Waypoints are drawn on top of via points, so they win a shared hit.
+  for (const layerId of [WAYPOINT_LAYER_ID, VIA_LAYER_ID]) {
+    if (!mapRef.getLayer(layerId)) continue;
+    const hits = mapRef.queryRenderedFeatures(box, { layers: [layerId] });
+    if (hits.length === 0) continue;
+    const closest = hits.reduce((best, feature) => {
+      const distance = (f: (typeof hits)[number]) => {
+        const coordinates = (f.geometry as { coordinates?: [number, number] })
+          .coordinates;
+        if (!coordinates) return Number.POSITIVE_INFINITY;
+        const projected = mapRef.project(coordinates);
+        return Math.hypot(projected.x - x, projected.y - y);
+      };
+      return distance(feature) < distance(best) ? feature : best;
+    }, hits[0]);
+    const unitId = closest.properties?.unitId as string | undefined;
+    const stateIndex = closest.properties?.stateIndex as number | undefined;
+    if (!unitId || stateIndex === undefined) continue;
+    if (layerId === WAYPOINT_LAYER_ID) {
+      clickedWaypoint.value = { unitId, stateIndex };
+      return;
+    }
+    const viaIndex = closest.properties?.viaIndex as number | undefined;
+    if (viaIndex === undefined) continue;
+    clickedViaPoint.value = { unitId, stateIndex, viaIndex };
+    return;
+  }
+}
+
 function onContextMenu(event: MouseEvent) {
   const { mapRef } = props;
   if (!mapRef) return;
@@ -290,6 +371,10 @@ function onContextMenu(event: MouseEvent) {
   mapZoomLevel.value = mapRef.getZoom() ?? 0;
   clickedUnits.value = [];
   clickedFeatures.value = [];
+  clickedWaypoint.value = null;
+  clickedViaPoint.value = null;
+
+  findClickedTrackPoint(mapRef, point);
 
   const seenUnitIds = new Set<string>();
   const seenFeatureIds = new Set<string>();
@@ -338,6 +423,25 @@ function onContextMenu(event: MouseEvent) {
         <span>{{ formattedPosition }}</span>
       </ContextMenuItem>
       <ContextMenuSeparator />
+      <template v-if="clickedWaypoint || clickedViaPoint">
+        <ContextMenuItem
+          v-if="clickedWaypoint"
+          :disabled="!canConvertWaypoint"
+          @select.prevent="onConvertWaypointToViaPoint()"
+        >
+          <IconVectorPointMinus class="mr-2 h-4 w-4" />
+          <span>Convert waypoint to via point</span>
+        </ContextMenuItem>
+        <ContextMenuItem
+          v-else
+          :disabled="!canConvertViaPoint"
+          @select.prevent="onConvertViaPointToWaypoint()"
+        >
+          <IconVectorPoint class="mr-2 h-4 w-4" />
+          <span>Convert via point to waypoint</span>
+        </ContextMenuItem>
+        <ContextMenuSeparator />
+      </template>
       <ContextMenuSub v-if="clickedUnits.length > 0">
         <ContextMenuSubTrigger inset
           ><span>Units</span>&nbsp;

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
@@ -31,6 +31,7 @@ import EditMetaForm from "@/modules/scenarioeditor/EditMetaForm.vue";
 import EditMediaForm from "@/modules/scenarioeditor/EditMediaForm.vue";
 import type { GeometryLayerItemUpdate, MediaUpdate } from "@/types/internalModels";
 import type { UpdateOptions } from "@/scenariostore/geo";
+import { getUnitSpeedMps } from "@/scenariostore/unitTrackConversions";
 import { inputEventFilter } from "@/components/helpers";
 import ScenarioFeatureDropdownMenu from "@/modules/scenarioeditor/ScenarioFeatureDropdownMenu.vue";
 import type { ScenarioFeatureActions } from "@/types/constants";
@@ -53,7 +54,6 @@ import {
   isAssignableTrackFeature,
 } from "@/importexport/unitTrackAssignment";
 import type { Feature } from "geojson";
-import { convertSpeedToMetric } from "@/utils/convert";
 
 interface Props {
   selectedIds: SelectedScenarioFeatures;
@@ -76,8 +76,6 @@ const uiStore = useUiStore();
 const { featureDetailsTab: selectedTab } = storeToRefs(useTabStore());
 const toolbarStore = useMainToolbarStore();
 const { rootUnitIds } = useRootUnitIds();
-
-const DEFAULT_ASSIGN_SPEED_M_S = convertSpeedToMetric(30, "km/h");
 
 const feature = computed(() => {
   if (props.selectedIds.size === 1) {
@@ -320,10 +318,7 @@ function assignFeatureToUnit() {
   const unit = store.state.unitMap[assignmentUnitId.value];
   if (!unit) return;
 
-  const speedValue = unit.properties?.averageSpeed || unit.properties?.maxSpeed;
-  const averageSpeed = speedValue
-    ? convertSpeedToMetric(speedValue.value, speedValue.uom)
-    : DEFAULT_ASSIGN_SPEED_M_S;
+  const averageSpeed = getUnitSpeedMps(unit);
 
   const result = createUnitTrackStatesFromFeature(
     geoJsonFeature,

--- a/src/modules/scenarioeditor/useScenarioRouting.ts
+++ b/src/modules/scenarioeditor/useScenarioRouting.ts
@@ -30,7 +30,7 @@ import {
 import { reduceObstacleSafeWaypoints } from "@/geo/routing/waypointReduction";
 import { combineRouteWaypoints } from "@/geo/routing/routeWaypoints";
 import { useSelectedItems } from "@/stores/selectedStore";
-import { convertSpeedToMetric } from "@/utils/convert";
+import { getUnitSpeedMps } from "@/scenariostore/unitTrackConversions";
 import type { NUnit } from "@/types/internalModels";
 import type { FullScenarioLayerItemsLayer } from "@/types/scenarioLayerItems";
 
@@ -439,13 +439,7 @@ export function useScenarioRouting(
   }
 
   function getTravelEndTime(unit: NUnit, totalLengthMeters: number, startTime: number) {
-    const speedValue = unit.properties?.averageSpeed || unit.properties?.maxSpeed;
-    const speed = speedValue
-      ? convertSpeedToMetric(speedValue.value, speedValue.uom)
-      : convertSpeedToMetric(30, "km/h");
-
-    if (speed <= 0) return startTime;
-    return Math.round(startTime + (totalLengthMeters / speed) * 1000);
+    return Math.round(startTime + (totalLengthMeters / getUnitSpeedMps(unit)) * 1000);
   }
 
   function getFinalLegs(includeCurrentPreview: boolean) {

--- a/src/scenariostore/unitManipulations.ts
+++ b/src/scenariostore/unitManipulations.ts
@@ -146,6 +146,8 @@ export function useUnitManipulations(store: NewScenarioStore) {
     updateUnitStateEntry,
     setUnitState,
     updateUnitStateVia,
+    canConvertViaPointToWaypoint,
+    canConvertWaypointToViaPoint,
     convertViaPointToWaypoint,
     convertWaypointToViaPoint,
   } = useUnitStateManipulations(store);
@@ -1229,6 +1231,8 @@ export function useUnitManipulations(store: NewScenarioStore) {
 
     expandUnit,
     updateUnitStateVia,
+    canConvertViaPointToWaypoint,
+    canConvertWaypointToViaPoint,
     convertViaPointToWaypoint,
     convertWaypointToViaPoint,
     updateUnitStateEntry,

--- a/src/scenariostore/unitManipulations.ts
+++ b/src/scenariostore/unitManipulations.ts
@@ -146,6 +146,8 @@ export function useUnitManipulations(store: NewScenarioStore) {
     updateUnitStateEntry,
     setUnitState,
     updateUnitStateVia,
+    convertViaPointToWaypoint,
+    convertWaypointToViaPoint,
   } = useUnitStateManipulations(store);
 
   function refreshProjectedHierarchy(s = state) {
@@ -1227,6 +1229,8 @@ export function useUnitManipulations(store: NewScenarioStore) {
 
     expandUnit,
     updateUnitStateVia,
+    convertViaPointToWaypoint,
+    convertWaypointToViaPoint,
     updateUnitStateEntry,
     addUnitStateEntry,
     convertStateEntryToInitialLocation,

--- a/src/scenariostore/unitStateManipulations.ts
+++ b/src/scenariostore/unitStateManipulations.ts
@@ -11,8 +11,8 @@ import {
   syncTimedHierarchyProjection,
 } from "@/scenariostore/hierarchy";
 import {
-  canConvertViaPointToWaypoint,
-  canConvertWaypointToViaPoint,
+  canConvertViaPointToWaypoint as canConvertViaPoint,
+  canConvertWaypointToViaPoint as canConvertWaypoint,
   computeViaPointTime,
   findFollowingLocationState,
   findPrecedingTrackPoint,
@@ -236,6 +236,22 @@ export function useUnitStateManipulations(store: NewScenarioStore) {
     );
   }
 
+  /** True when the via point can be turned into a waypoint of its own. */
+  function canConvertViaPointToWaypoint(
+    unitId: EntityId,
+    stateIndex: number,
+    viaIndex: number,
+  ) {
+    const unit = state.unitMap[unitId];
+    return !!unit && canConvertViaPoint(unit, stateIndex, viaIndex);
+  }
+
+  /** True when the waypoint can be turned into a via point on the merged leg. */
+  function canConvertWaypointToViaPoint(unitId: EntityId, stateIndex: number) {
+    const unit = state.unitMap[unitId];
+    return !!unit && canConvertWaypoint(unit, stateIndex);
+  }
+
   /**
    * Turns a via point into a waypoint of its own. The new waypoint is timed
    * from the average speed of the leg it sits on, so the unit keeps following
@@ -247,17 +263,10 @@ export function useUnitStateManipulations(store: NewScenarioStore) {
     viaIndex: number,
   ) {
     const unit = state.unitMap[unitId];
-    if (!unit || !canConvertViaPointToWaypoint(unit, stateIndex, viaIndex)) return;
+    if (!unit || !canConvertViaPoint(unit, stateIndex, viaIndex)) return;
     const stateEntry = unit.state![stateIndex]!;
     const prev = findPrecedingTrackPoint(unit, stateIndex)!;
-    const t = computeViaPointTime({
-      prev,
-      via: stateEntry.via!,
-      viaIndex,
-      destination: { location: stateEntry.location!, t: stateEntry.t },
-      viaStartTime: stateEntry.viaStartTime,
-      fallbackSpeedMps: getUnitSpeedMps(unit),
-    });
+    const t = computeViaPointTime(prev, stateEntry, viaIndex, getUnitSpeedMps(unit));
 
     const newEntry: NState = {
       id: nanoid(),
@@ -303,7 +312,7 @@ export function useUnitStateManipulations(store: NewScenarioStore) {
    */
   function convertWaypointToViaPoint(unitId: EntityId, stateIndex: number) {
     const unit = state.unitMap[unitId];
-    if (!unit || !canConvertWaypointToViaPoint(unit, stateIndex)) return;
+    if (!unit || !canConvertWaypoint(unit, stateIndex)) return;
     const stateEntry = unit.state![stateIndex]!;
     const following = findFollowingLocationState(unit, stateIndex)!;
     const mergedVia = klona([
@@ -350,6 +359,8 @@ export function useUnitStateManipulations(store: NewScenarioStore) {
     updateUnitStateEntry,
     setUnitState,
     updateUnitStateVia,
+    canConvertViaPointToWaypoint,
+    canConvertWaypointToViaPoint,
     convertViaPointToWaypoint,
     convertWaypointToViaPoint,
   };

--- a/src/scenariostore/unitStateManipulations.ts
+++ b/src/scenariostore/unitStateManipulations.ts
@@ -10,6 +10,14 @@ import {
   refreshHierarchyTimelineMetadata,
   syncTimedHierarchyProjection,
 } from "@/scenariostore/hierarchy";
+import {
+  canConvertViaPointToWaypoint,
+  canConvertWaypointToViaPoint,
+  computeViaPointTime,
+  findFollowingLocationState,
+  findPrecedingTrackPoint,
+  getUnitSpeedMps,
+} from "@/scenariostore/unitTrackConversions";
 
 export function removeUnusedUnitStateEntries(unit: NUnit) {
   if (!unit || !unit.state) return;
@@ -228,6 +236,111 @@ export function useUnitStateManipulations(store: NewScenarioStore) {
     );
   }
 
+  /**
+   * Turns a via point into a waypoint of its own. The new waypoint is timed
+   * from the average speed of the leg it sits on, so the unit keeps following
+   * the same path at the same pace.
+   */
+  function convertViaPointToWaypoint(
+    unitId: EntityId,
+    stateIndex: number,
+    viaIndex: number,
+  ) {
+    const unit = state.unitMap[unitId];
+    if (!unit || !canConvertViaPointToWaypoint(unit, stateIndex, viaIndex)) return;
+    const stateEntry = unit.state![stateIndex]!;
+    const prev = findPrecedingTrackPoint(unit, stateIndex)!;
+    const t = computeViaPointTime({
+      prev,
+      via: stateEntry.via!,
+      viaIndex,
+      destination: { location: stateEntry.location!, t: stateEntry.t },
+      viaStartTime: stateEntry.viaStartTime,
+      fallbackSpeedMps: getUnitSpeedMps(unit),
+    });
+
+    const newEntry: NState = {
+      id: nanoid(),
+      t,
+      location: klona(stateEntry.via![viaIndex]!),
+    };
+    const leadingVia = klona(stateEntry.via!.slice(0, viaIndex));
+    if (leadingVia.length) newEntry.via = leadingVia;
+    // The first half of the split leg keeps the original start time.
+    if (stateEntry.viaStartTime !== undefined) {
+      newEntry.viaStartTime = stateEntry.viaStartTime;
+    }
+
+    update(
+      (s) => {
+        const u = s.unitMap[unitId];
+        const entry = u?.state?.[stateIndex];
+        if (!u?.state || !entry) return;
+        const trailingVia = entry.via?.slice(viaIndex + 1) ?? [];
+        if (trailingVia.length) {
+          entry.via = trailingVia;
+        } else {
+          delete entry.via;
+        }
+        // The second half now starts at the new waypoint.
+        delete entry.viaStartTime;
+        // Rounding can place the new time before entries without a location,
+        // so walk back to where it keeps the state list sorted.
+        let insertIndex = stateIndex;
+        while (insertIndex > 0 && u.state[insertIndex - 1]!.t > t) insertIndex--;
+        u.state.splice(insertIndex, 0, newEntry);
+        refreshHierarchyTimelineMetadata(s);
+      },
+      { label: "addUnitPosition", value: unitId },
+    );
+    updateUnitState(unitId);
+  }
+
+  /**
+   * Turns a waypoint into a via point by merging the legs on either side of it.
+   * The waypoint's own timestamp is dropped, so the unit passes the point
+   * wherever the merged leg's average speed puts it.
+   */
+  function convertWaypointToViaPoint(unitId: EntityId, stateIndex: number) {
+    const unit = state.unitMap[unitId];
+    if (!unit || !canConvertWaypointToViaPoint(unit, stateIndex)) return;
+    const stateEntry = unit.state![stateIndex]!;
+    const following = findFollowingLocationState(unit, stateIndex)!;
+    const mergedVia = klona([
+      ...(stateEntry.via ?? []),
+      stateEntry.location!,
+      ...(following.state.via ?? []),
+    ]);
+    const viaStartTime = stateEntry.viaStartTime;
+
+    update(
+      (s) => {
+        const u = s.unitMap[unitId];
+        const entry = u?.state?.[stateIndex];
+        const followingEntry = u?.state?.[following.index];
+        if (!u?.state || !entry || !followingEntry) return;
+        followingEntry.via = mergedVia;
+        // The merged leg starts where the removed waypoint's leg did.
+        if (viaStartTime !== undefined) {
+          followingEntry.viaStartTime = viaStartTime;
+        } else {
+          delete followingEntry.viaStartTime;
+        }
+        delete entry.location;
+        delete entry.via;
+        delete entry.viaStartTime;
+        // Keep the entry around if it still carries something other than the
+        // position it just gave up.
+        if (!isNotEmptyState(entry) && !entry.title && !entry.description) {
+          u.state.splice(stateIndex, 1);
+        }
+        refreshHierarchyTimelineMetadata(s);
+      },
+      { label: "addUnitPosition", value: unitId },
+    );
+    updateUnitState(unitId);
+  }
+
   return {
     clearUnitState,
     updateUnitState,
@@ -237,5 +350,7 @@ export function useUnitStateManipulations(store: NewScenarioStore) {
     updateUnitStateEntry,
     setUnitState,
     updateUnitStateVia,
+    convertViaPointToWaypoint,
+    convertWaypointToViaPoint,
   };
 }

--- a/src/scenariostore/unitTrackConversions.test.ts
+++ b/src/scenariostore/unitTrackConversions.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from "vitest";
+import { useNewScenarioStore } from "@/scenariostore/newScenarioStore";
+import { useUnitManipulations } from "@/scenariostore/unitManipulations";
+import { useScenarioTime } from "@/scenariostore/time";
+import { computeViaPointTime } from "@/scenariostore/unitTrackConversions";
+
+const T0 = Date.parse("2025-01-01T00:00:00Z");
+const T1 = Date.parse("2025-01-01T01:00:00Z");
+const T2 = Date.parse("2025-01-01T02:00:00Z");
+
+function createScenario(state: any[] = []) {
+  return {
+    id: "scenario-1",
+    type: "ORBAT-mapper",
+    version: "2.3.0",
+    name: "Scenario",
+    startTime: "2025-01-01T00:00:00Z",
+    sides: [
+      {
+        id: "side-1",
+        name: "Blue",
+        standardIdentity: "3",
+        symbolOptions: {},
+        subUnits: [],
+        groups: [
+          {
+            id: "group-1",
+            name: "Units",
+            symbolOptions: {},
+            subUnits: [
+              {
+                id: "unit-1",
+                name: "1st Unit",
+                sidc: "10031000000000000000",
+                location: [0, 0],
+                state,
+                subUnits: [],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+    events: [],
+    layers: [{ id: "layer-1", name: "Features", features: [] }],
+    mapLayers: [],
+    settings: {
+      rangeRingGroups: [],
+      statuses: [],
+      supplyClasses: [],
+      supplyUoMs: [],
+    },
+  } as any;
+}
+
+/** A unit at [0, 0] that travels east, with a via point halfway along. */
+function createTrackScenario() {
+  return createScenario([
+    { id: "state-1", t: "2025-01-01T00:00:00Z", location: [0, 0] },
+    {
+      id: "state-2",
+      t: "2025-01-01T02:00:00Z",
+      location: [2, 0],
+      via: [[1, 0]],
+    },
+  ]);
+}
+
+function setup(scenario: any) {
+  const store = useNewScenarioStore(scenario);
+  return { store, actions: useUnitManipulations(store), time: useScenarioTime(store) };
+}
+
+describe("computeViaPointTime", () => {
+  it("splits the leg's time span by the distance travelled", () => {
+    const t = computeViaPointTime({
+      prev: { location: [0, 0], t: T0 },
+      via: [[1, 0]],
+      viaIndex: 0,
+      destination: { location: [2, 0], t: T2 },
+      fallbackSpeedMps: 10,
+    });
+    expect(t).toBe(T1);
+  });
+
+  it("measures from viaStartTime when the leg has one", () => {
+    const t = computeViaPointTime({
+      prev: { location: [0, 0], t: T0 },
+      via: [[1, 0]],
+      viaIndex: 0,
+      destination: { location: [2, 0], t: T2 },
+      viaStartTime: T1,
+      fallbackSpeedMps: 10,
+    });
+    expect(t).toBe(T1 + (T2 - T1) / 2);
+  });
+
+  it("works backwards from the unit's speed when the leg starts untimed", () => {
+    // 1 degree of longitude at the equator is ~111.2 km, covered in ~11120 s
+    // at 10 m/s.
+    const t = computeViaPointTime({
+      prev: { location: [0, 0] },
+      via: [[1, 0]],
+      viaIndex: 0,
+      destination: { location: [2, 0], t: T2 },
+      fallbackSpeedMps: 10,
+    });
+    expect((T2 - t) / 1000).toBeCloseTo(11119.5, 0);
+  });
+
+  it("keeps the new time inside the leg", () => {
+    const t = computeViaPointTime({
+      prev: { location: [0, 0], t: T0 },
+      via: [[2, 0]],
+      viaIndex: 0,
+      destination: { location: [2, 0], t: T2 },
+      fallbackSpeedMps: 10,
+    });
+    expect(t).toBe(T2 - 1);
+  });
+});
+
+describe("convertViaPointToWaypoint", () => {
+  it("adds a waypoint timed from the leg's average speed", () => {
+    const { store, actions } = setup(createTrackScenario());
+
+    actions.convertViaPointToWaypoint("unit-1", 1, 0);
+
+    const state = store.state.unitMap["unit-1"].state!;
+    expect(state).toHaveLength(3);
+    expect(state[1].location).toEqual([1, 0]);
+    expect(state[1].t).toBe(T1);
+    expect(state[1].via).toBeUndefined();
+    expect(state[2].location).toEqual([2, 0]);
+    expect(state[2].via).toBeUndefined();
+  });
+
+  it("leaves the unit where it was at any given time", () => {
+    const { store, actions, time } = setup(createTrackScenario());
+    const at = Date.parse("2025-01-01T00:30:00Z");
+
+    time.setCurrentTime(at);
+    const before = store.state.unitMap["unit-1"]._state?.location;
+
+    actions.convertViaPointToWaypoint("unit-1", 1, 0);
+
+    const after = store.state.unitMap["unit-1"]._state?.location;
+    expect(after![0]).toBeCloseTo(before![0], 6);
+    expect(after![1]).toBeCloseTo(before![1], 6);
+  });
+
+  it("splits the surrounding via points between the two legs", () => {
+    const { store, actions } = setup(
+      createScenario([
+        { id: "state-1", t: "2025-01-01T00:00:00Z", location: [0, 0] },
+        {
+          id: "state-2",
+          t: "2025-01-01T02:00:00Z",
+          location: [4, 0],
+          via: [
+            [1, 0],
+            [2, 0],
+            [3, 0],
+          ],
+        },
+      ]),
+    );
+
+    actions.convertViaPointToWaypoint("unit-1", 1, 1);
+
+    const state = store.state.unitMap["unit-1"].state!;
+    expect(state[1].location).toEqual([2, 0]);
+    expect(state[1].via).toEqual([[1, 0]]);
+    expect(state[2].via).toEqual([[3, 0]]);
+  });
+
+  it("hands viaStartTime to the first half of the split leg", () => {
+    const { store, actions } = setup(
+      createScenario([
+        { id: "state-1", t: "2025-01-01T00:00:00Z", location: [0, 0] },
+        {
+          id: "state-2",
+          t: "2025-01-01T02:00:00Z",
+          location: [2, 0],
+          via: [[1, 0]],
+          viaStartTime: "2025-01-01T01:00:00Z",
+        },
+      ]),
+    );
+
+    actions.convertViaPointToWaypoint("unit-1", 1, 0);
+
+    const state = store.state.unitMap["unit-1"].state!;
+    expect(state[1].viaStartTime).toBe(T1);
+    expect(state[2].viaStartTime).toBeUndefined();
+  });
+});
+
+describe("convertWaypointToViaPoint", () => {
+  it("merges the legs on either side of the waypoint", () => {
+    const { store, actions } = setup(
+      createScenario([
+        { id: "state-1", t: "2025-01-01T00:00:00Z", location: [0, 0] },
+        { id: "state-2", t: "2025-01-01T01:00:00Z", location: [1, 0] },
+        { id: "state-3", t: "2025-01-01T02:00:00Z", location: [2, 0] },
+      ]),
+    );
+
+    actions.convertWaypointToViaPoint("unit-1", 1);
+
+    const state = store.state.unitMap["unit-1"].state!;
+    expect(state).toHaveLength(2);
+    expect(state[1].location).toEqual([2, 0]);
+    expect(state[1].via).toEqual([[1, 0]]);
+  });
+
+  it("keeps the via points of both legs in order", () => {
+    const { store, actions } = setup(
+      createScenario([
+        { id: "state-1", t: "2025-01-01T00:00:00Z", location: [0, 0] },
+        { id: "state-2", t: "2025-01-01T01:00:00Z", location: [2, 0], via: [[1, 0]] },
+        { id: "state-3", t: "2025-01-01T02:00:00Z", location: [4, 0], via: [[3, 0]] },
+      ]),
+    );
+
+    actions.convertWaypointToViaPoint("unit-1", 1);
+
+    const state = store.state.unitMap["unit-1"].state!;
+    expect(state[1].via).toEqual([
+      [1, 0],
+      [2, 0],
+      [3, 0],
+    ]);
+  });
+
+  it("keeps a state entry that carries more than a position", () => {
+    const { store, actions } = setup(
+      createScenario([
+        { id: "state-1", t: "2025-01-01T00:00:00Z", location: [0, 0] },
+        {
+          id: "state-2",
+          t: "2025-01-01T01:00:00Z",
+          location: [1, 0],
+          sidc: "10031000001100000000",
+        },
+        { id: "state-3", t: "2025-01-01T02:00:00Z", location: [2, 0] },
+      ]),
+    );
+
+    actions.convertWaypointToViaPoint("unit-1", 1);
+
+    const state = store.state.unitMap["unit-1"].state!;
+    expect(state).toHaveLength(3);
+    expect(state[1].location).toBeUndefined();
+    expect(state[1].sidc).toBe("10031000001100000000");
+    expect(state[2].via).toEqual([[1, 0]]);
+  });
+
+  it("does nothing for the last waypoint of a path", () => {
+    const { store, actions } = setup(
+      createScenario([
+        { id: "state-1", t: "2025-01-01T00:00:00Z", location: [0, 0] },
+        { id: "state-2", t: "2025-01-01T01:00:00Z", location: [1, 0] },
+      ]),
+    );
+
+    actions.convertWaypointToViaPoint("unit-1", 1);
+
+    expect(store.state.unitMap["unit-1"].state).toHaveLength(2);
+  });
+
+  it("round-trips back to the original waypoint time", () => {
+    const { store, actions } = setup(
+      createScenario([
+        { id: "state-1", t: "2025-01-01T00:00:00Z", location: [0, 0] },
+        { id: "state-2", t: "2025-01-01T01:00:00Z", location: [1, 0] },
+        { id: "state-3", t: "2025-01-01T02:00:00Z", location: [2, 0] },
+      ]),
+    );
+
+    actions.convertWaypointToViaPoint("unit-1", 1);
+    actions.convertViaPointToWaypoint("unit-1", 1, 0);
+
+    const state = store.state.unitMap["unit-1"].state!;
+    expect(state).toHaveLength(3);
+    expect(state[1].location).toEqual([1, 0]);
+    expect(state[1].t).toBe(T1);
+  });
+});

--- a/src/scenariostore/unitTrackConversions.test.ts
+++ b/src/scenariostore/unitTrackConversions.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "vitest";
+import type { Position } from "geojson";
+import type { NState } from "@/types/internalModels";
 import { useNewScenarioStore } from "@/scenariostore/newScenarioStore";
 import { useUnitManipulations } from "@/scenariostore/unitManipulations";
 import { useScenarioTime } from "@/scenariostore/time";
@@ -72,50 +74,44 @@ function setup(scenario: any) {
 }
 
 describe("computeViaPointTime", () => {
+  function destination(via: Position[], viaStartTime?: number): NState {
+    return { id: "state-1", t: T2, location: [2, 0], via, viaStartTime };
+  }
+
   it("splits the leg's time span by the distance travelled", () => {
-    const t = computeViaPointTime({
-      prev: { location: [0, 0], t: T0 },
-      via: [[1, 0]],
-      viaIndex: 0,
-      destination: { location: [2, 0], t: T2 },
-      fallbackSpeedMps: 10,
-    });
+    const t = computeViaPointTime(
+      { location: [0, 0], t: T0 },
+      destination([[1, 0]]),
+      0,
+      10,
+    );
     expect(t).toBe(T1);
   });
 
   it("measures from viaStartTime when the leg has one", () => {
-    const t = computeViaPointTime({
-      prev: { location: [0, 0], t: T0 },
-      via: [[1, 0]],
-      viaIndex: 0,
-      destination: { location: [2, 0], t: T2 },
-      viaStartTime: T1,
-      fallbackSpeedMps: 10,
-    });
+    const t = computeViaPointTime(
+      { location: [0, 0], t: T0 },
+      destination([[1, 0]], T1),
+      0,
+      10,
+    );
     expect(t).toBe(T1 + (T2 - T1) / 2);
   });
 
   it("works backwards from the unit's speed when the leg starts untimed", () => {
     // 1 degree of longitude at the equator is ~111.2 km, covered in ~11120 s
     // at 10 m/s.
-    const t = computeViaPointTime({
-      prev: { location: [0, 0] },
-      via: [[1, 0]],
-      viaIndex: 0,
-      destination: { location: [2, 0], t: T2 },
-      fallbackSpeedMps: 10,
-    });
+    const t = computeViaPointTime({ location: [0, 0] }, destination([[1, 0]]), 0, 10);
     expect((T2 - t) / 1000).toBeCloseTo(11119.5, 0);
   });
 
   it("keeps the new time inside the leg", () => {
-    const t = computeViaPointTime({
-      prev: { location: [0, 0], t: T0 },
-      via: [[2, 0]],
-      viaIndex: 0,
-      destination: { location: [2, 0], t: T2 },
-      fallbackSpeedMps: 10,
-    });
+    const t = computeViaPointTime(
+      { location: [0, 0], t: T0 },
+      destination([[2, 0]]),
+      0,
+      10,
+    );
     expect(t).toBe(T2 - 1);
   });
 });

--- a/src/scenariostore/unitTrackConversions.ts
+++ b/src/scenariostore/unitTrackConversions.ts
@@ -1,0 +1,148 @@
+import turfLength from "@turf/length";
+import { lineString } from "@turf/helpers";
+import type { Position } from "geojson";
+import type { NState, NUnit } from "@/types/internalModels";
+import { convertSpeedToMetric } from "@/utils/convert";
+
+const DEFAULT_SPEED_KMH = 30;
+
+/**
+ * A point on a unit's drawn path. The unit's initial location has no timestamp
+ * of its own, so `t` is left out for it.
+ */
+export interface TrackPoint {
+  location: Position;
+  t?: number;
+}
+
+export interface FollowingLocationState {
+  index: number;
+  state: NState;
+}
+
+/**
+ * The point a state entry is travelled to from: the closest preceding state
+ * entry with a location, or the unit's own location when there is none.
+ * Returns null when the path is broken before `stateIndex`, since there is no
+ * leg to convert points on in that case.
+ */
+export function findPrecedingTrackPoint(
+  unit: NUnit,
+  stateIndex: number,
+): TrackPoint | null {
+  for (let i = stateIndex - 1; i >= 0; i--) {
+    const s = unit.state?.[i];
+    if (!s || s.location === undefined) continue;
+    // A null location takes the unit off the map and a non-interpolated entry
+    // starts a new part, so neither leaves a leg behind it.
+    if (s.location === null || s.interpolate === false) return null;
+    return { location: s.location, t: s.t };
+  }
+  return unit.location ? { location: unit.location } : null;
+}
+
+/**
+ * The state entry the path continues to after `stateIndex`. Returns null when
+ * the path ends or is broken there.
+ */
+export function findFollowingLocationState(
+  unit: NUnit,
+  stateIndex: number,
+): FollowingLocationState | null {
+  const state = unit.state ?? [];
+  for (let i = stateIndex + 1; i < state.length; i++) {
+    const s = state[i];
+    if (!s || s.location === undefined) continue;
+    if (s.location === null || s.interpolate === false) return null;
+    return { index: i, state: s };
+  }
+  return null;
+}
+
+/** The unit's own speed in m/s, falling back to a default when it has none. */
+export function getUnitSpeedMps(unit: NUnit): number {
+  const speedValue = unit.properties?.averageSpeed || unit.properties?.maxSpeed;
+  const speed = speedValue
+    ? convertSpeedToMetric(speedValue.value, speedValue.uom)
+    : undefined;
+  return speed !== undefined && speed > 0
+    ? speed
+    : convertSpeedToMetric(DEFAULT_SPEED_KMH, "km/h");
+}
+
+/** Distance in kilometers from the first coordinate to each of the others. */
+function cumulativeLengths(coordinates: Position[]): number[] {
+  const lengths = [0];
+  for (let i = 1; i < coordinates.length; i++) {
+    lengths.push(
+      lengths[i - 1]! + turfLength(lineString([coordinates[i - 1]!, coordinates[i]!])),
+    );
+  }
+  return lengths;
+}
+
+export interface ViaPointTimeOptions {
+  prev: TrackPoint;
+  via: Position[];
+  viaIndex: number;
+  destination: { location: Position; t: number };
+  viaStartTime?: number;
+  fallbackSpeedMps: number;
+}
+
+/**
+ * The timestamp a unit passes a via point at. The unit covers the leg at a
+ * constant average speed, so the time is the leg's time span split by the
+ * distance travelled so far. When the leg has no usable start time — it begins
+ * at the unit's untimed initial location — the unit's own speed is used to work
+ * backwards from the arrival time instead.
+ */
+export function computeViaPointTime({
+  prev,
+  via,
+  viaIndex,
+  destination,
+  viaStartTime,
+  fallbackSpeedMps,
+}: ViaPointTimeOptions): number {
+  const lengths = cumulativeLengths([prev.location, ...via, destination.location]);
+  const total = lengths[lengths.length - 1]!;
+  const travelled = lengths[viaIndex + 1]!;
+  const startTime = viaStartTime ?? prev.t;
+
+  let t: number;
+  if (startTime === undefined || total <= 0 || destination.t <= startTime) {
+    const remainingMeters = (total - travelled) * 1000;
+    t = destination.t - (remainingMeters / fallbackSpeedMps) * 1000;
+  } else {
+    t = startTime + ((destination.t - startTime) * travelled) / total;
+  }
+
+  // Keep the new waypoint strictly inside the leg, so neither half of the split
+  // ends up with a zero-length time span.
+  const upper = destination.t - 1;
+  let clamped = Math.min(Math.round(t), upper);
+  if (startTime !== undefined)
+    clamped = Math.max(clamped, Math.min(startTime + 1, upper));
+  return clamped;
+}
+
+/** True when the via point can be turned into a waypoint of its own. */
+export function canConvertViaPointToWaypoint(
+  unit: NUnit,
+  stateIndex: number,
+  viaIndex: number,
+): boolean {
+  const s = unit.state?.[stateIndex];
+  if (!s?.location || s.interpolate === false) return false;
+  if (!s.via || viaIndex < 0 || viaIndex >= s.via.length) return false;
+  return findPrecedingTrackPoint(unit, stateIndex) !== null;
+}
+
+/** True when the waypoint can be turned into a via point on the merged leg. */
+export function canConvertWaypointToViaPoint(unit: NUnit, stateIndex: number): boolean {
+  const s = unit.state?.[stateIndex];
+  if (!s?.location || s.interpolate === false) return false;
+  if (!findPrecedingTrackPoint(unit, stateIndex)) return false;
+  return findFollowingLocationState(unit, stateIndex) !== null;
+}

--- a/src/scenariostore/unitTrackConversions.ts
+++ b/src/scenariostore/unitTrackConversions.ts
@@ -1,6 +1,5 @@
-import turfLength from "@turf/length";
-import { lineString } from "@turf/helpers";
 import type { Position } from "geojson";
+import { distanceMeters } from "@/geo/distance";
 import type { NState, NUnit } from "@/types/internalModels";
 import { convertSpeedToMetric } from "@/utils/convert";
 
@@ -70,57 +69,47 @@ export function getUnitSpeedMps(unit: NUnit): number {
     : convertSpeedToMetric(DEFAULT_SPEED_KMH, "km/h");
 }
 
-/** Distance in kilometers from the first coordinate to each of the others. */
+/** Distance in meters from the first coordinate to each of the others. */
 function cumulativeLengths(coordinates: Position[]): number[] {
   const lengths = [0];
   for (let i = 1; i < coordinates.length; i++) {
-    lengths.push(
-      lengths[i - 1]! + turfLength(lineString([coordinates[i - 1]!, coordinates[i]!])),
-    );
+    lengths.push(lengths[i - 1]! + distanceMeters(coordinates[i - 1]!, coordinates[i]!));
   }
   return lengths;
 }
 
-export interface ViaPointTimeOptions {
-  prev: TrackPoint;
-  via: Position[];
-  viaIndex: number;
-  destination: { location: Position; t: number };
-  viaStartTime?: number;
-  fallbackSpeedMps: number;
-}
-
 /**
- * The timestamp a unit passes a via point at. The unit covers the leg at a
- * constant average speed, so the time is the leg's time span split by the
- * distance travelled so far. When the leg has no usable start time — it begins
- * at the unit's untimed initial location — the unit's own speed is used to work
- * backwards from the arrival time instead.
+ * The timestamp a unit passes the via point at `viaIndex` of `entry` at. The
+ * unit covers the leg at a constant average speed, so the time is the leg's
+ * time span split by the distance travelled so far. When the leg has no usable
+ * start time — it begins at the unit's untimed initial location — the unit's
+ * own speed is used to work backwards from the arrival time instead.
  */
-export function computeViaPointTime({
-  prev,
-  via,
-  viaIndex,
-  destination,
-  viaStartTime,
-  fallbackSpeedMps,
-}: ViaPointTimeOptions): number {
-  const lengths = cumulativeLengths([prev.location, ...via, destination.location]);
+export function computeViaPointTime(
+  prev: TrackPoint,
+  entry: NState,
+  viaIndex: number,
+  fallbackSpeedMps: number,
+): number {
+  const lengths = cumulativeLengths([
+    prev.location,
+    ...(entry.via ?? []),
+    entry.location!,
+  ]);
   const total = lengths[lengths.length - 1]!;
   const travelled = lengths[viaIndex + 1]!;
-  const startTime = viaStartTime ?? prev.t;
+  const startTime = entry.viaStartTime ?? prev.t;
 
   let t: number;
-  if (startTime === undefined || total <= 0 || destination.t <= startTime) {
-    const remainingMeters = (total - travelled) * 1000;
-    t = destination.t - (remainingMeters / fallbackSpeedMps) * 1000;
+  if (startTime === undefined || total <= 0 || entry.t <= startTime) {
+    t = entry.t - ((total - travelled) / fallbackSpeedMps) * 1000;
   } else {
-    t = startTime + ((destination.t - startTime) * travelled) / total;
+    t = startTime + ((entry.t - startTime) * travelled) / total;
   }
 
   // Keep the new waypoint strictly inside the leg, so neither half of the split
   // ends up with a zero-length time span.
-  const upper = destination.t - 1;
+  const upper = entry.t - 1;
   let clamped = Math.min(Math.round(t), upper);
   if (startTime !== undefined)
     clamped = Math.max(clamped, Math.min(startTime + 1, upper));


### PR DESCRIPTION
Right-clicking a point on a unit path in MapLibre mode now offers to convert it to the other kind.

**Convert waypoint to via point** merges the legs on either side, folding the waypoint and its own via points into the next state entry's `via` list in order. The waypoint's timestamp is dropped. A state entry that carries more than a position (a symbol change, a resource update, a title) keeps its place in the timeline without its location; an entry that carried nothing else is removed. Disabled for the initial position and for a path's last waypoint, where there is no leg to merge into.

**Convert via point to waypoint** splits the leg at that point. The new waypoint's time comes from the leg's average speed — the leg's time span split by the distance travelled — so the unit is in the same place at every instant as it was before the conversion. Surrounding via points are divided between the two new legs and `viaStartTime` moves to the first half. When the leg starts at the unit's untimed initial location there is no span to divide, so it falls back to the unit's own `averageSpeed`/`maxSpeed` and works backwards from the arrival time, the same fallback ctrl-click already uses.

Right-clicking a track in edit mode was broken independently of this: MapLibre reports a press of any button as `mousedown`, so a right click near a leg or a midpoint handle inserted a via point and started dragging it before the menu could open. The track edit handlers now ignore anything but the primary button.

The follow-up commit pulls the handle hit test out of the menu and into `maplibreUnitHistory` so the edit handlers and the menu share one implementation — the menu's copy had already drifted, using a 12px box where every other touch gesture uses 26px — and points the five inlined copies of the 30 km/h speed fallback at a single helper.

The legacy OpenLayers map is untouched. Its via points are vertices of the leg LineString rather than features of their own, so there is nothing there to right-click.

