### PR TITLE
Support multiple control-measure layers

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -6,6 +6,30 @@ to this project and not obvious from the code.
 
 ## Language
 
+### Layers
+
+**Active layer**:
+The single overlay layer that receives newly authored items. Its specialization and
+the editor's current authoring rules determine which kinds of items can be added;
+activating a control-measure layer replaces the active feature layer, and vice versa.
+When the user switches authoring families, the editor restores the most recently used
+compatible layer, creating one only if none exists.
+
+**Feature layer**:
+An unspecialized overlay layer. The current editor authors geometry, annotations, and
+measurements into it; future mixed-item authoring can broaden that behavior without a
+stored-model migration.
+
+**Layer specialization**:
+An optional restriction expressing that an overlay layer is dedicated to one content
+family. Existing layers remain unspecialized; specialization is not a required
+category on every layer.
+
+**Locked layer**:
+A layer whose contents cannot be added, edited, duplicated, deleted, reordered, or
+moved. The layer itself can still be shown or hidden, renamed, time-bounded,
+reordered, unlocked, or deleted.
+
 ### Geometry
 
 **Geometry layer item**:
@@ -39,6 +63,16 @@ where the kind and its extra fields cannot yet be guaranteed to line up.
 
 ### Control measures
 
+**Control-measure layer**:
+An overlay layer specialized for control measures. Its identity persists even while
+empty; it is not inferred from the items it happens to contain. The current editor
+does not author mixed content.
+
+**Control-measure stack**:
+The ordered collection of control-measure layers. Layers can be reordered within this
+stack, but the whole stack renders above all feature layers; cross-family interleaving
+is not currently supported.
+
 **Control measure**:
 A doctrinal tactical graphic — boundary, axis of advance, phase line, fire
 support area, … — drawn and rendered by the `@orbat-mapper/control-measures`
@@ -63,7 +97,7 @@ Neither exists in the control-measures library — both are **host projections**
 resolved at the `toControlMeasure` seam and never written into storage. Identity
 colours come from milsymbol's saturated colour mode, the same source the unit
 symbols use, so a control measure matches a unit of the same identity.
-_Avoid_: storing a resolved colour. The stored `style.color` is an *authored*
+_Avoid_: storing a resolved colour. The stored `style.color` is an _authored_
 override; absent it, colour is derived per render.
 
 **Session** (draw session / edit session):
@@ -134,7 +168,7 @@ identity changes underneath you on every re-attach.
 Specifically the removed OpenLayers-based scenario editor view — a historical
 term kept so old commits and docs stay intelligible.
 _Avoid_: using "legacy" for other retired routes (`/maplibre`, `/globe` are old
-*URLs* that redirect, not the legacy view).
+_URLs_ that redirect, not the legacy view).
 
 ### Offline use
 
@@ -143,7 +177,7 @@ How much infrastructure a deployment still depends on, on two independent axes �
 where the **application** is delivered from, and where the **map data** comes
 from. Three named rungs: **Level 1 — Self-hosted** (own web server, own tile
 server), **Level 2 — Local map file** (served application, basemap read from the
-user's disk), **Level 3 — Standalone file** (application *and* basemap read from
+user's disk), **Level 3 — Standalone file** (application _and_ basemap read from
 the user's disk). The numbering is a ladder of removed infrastructure, not a
 ranking of "how offline" — a Level 2 deployment on a public host still needs the
 network to load the application.
@@ -156,12 +190,12 @@ _Avoid_: "offline basemap" (a self-hosted tile server is also offline), "embedde
 basemap" (nothing is embedded — the archive stays a file the user picks).
 
 **PMTiles archive**:
-A basemap archive holding *tiles only*. Raster archives are self-describing;
+A basemap archive holding _tiles only_. Raster archives are self-describing;
 vector archives carry no style, glyphs or sprites, so the application supplies
 those (see [[adr-0003]]).
 
 **Mapbundle**:
-A basemap archive (a ZIP) holding tiles *and* the styles, glyphs and sprites that
+A basemap archive (a ZIP) holding tiles _and_ the styles, glyphs and sprites that
 go with them, so it needs nothing from the application to render.
 
 **Flavour**:

--- a/docs/adr/0006-control-measures-on-tactical-draw.md
+++ b/docs/adr/0006-control-measures-on-tactical-draw.md
@@ -155,6 +155,33 @@ Control measures render through tactical-draw, stacked **above** the flat scenar
 feature source that `maplibreScenarioFeatures.ts` maintains. They are not merged into
 it.
 
+The editor may hold multiple explicitly specialized control-measure layers. They form
+their own ordered stack: their relative order is honoured by tactical-draw and they
+may be reordered against one another, but the UI does not allow them to be interleaved
+with feature or reference layers. An empty control-measure layer remains one; its
+optional `specialization: "controlMeasure"` is persisted rather than inferred from
+its contents. Existing overlay layers remain unspecialized, leaving a future mixed-item
+model open without migrating every layer.
+
+Control-measure layers have the same applicable interactions as feature layers:
+active-layer selection, rename/timing, visibility, content locking, zoom, deletion,
+item and layer reordering, moving items between compatible layers, duplication, and
+GeoJSON copy of the rendered projection. Content locking prevents authoring and item
+changes but not management of the layer itself. There is no layer-count cap.
+
+There is still one active overlay layer. Switching authoring families restores the
+most recently used compatible unlocked layer (the topmost compatible layer when the
+session has no history). If no control-measure layer exists, choosing a control-measure
+tool creates and activates `Control measures`; if layers exist but all are locked, the
+tool asks the user to unlock or add one rather than creating another silently. Explicit
+layer creation instead creates `New control-measure layer`, activates it, and opens its
+inline editor.
+
+The editor enforces homogeneous authoring in this stage, but loading stays tolerant:
+items that do not match a layer's specialization are preserved and warned about rather
+than rejected or rewritten. Specialization cannot be converted through the UI in this
+iteration.
+
 The accepted cost is stated plainly: **a control measure always draws above every
 plain shape, regardless of layer order in the layers panel.** A user can reorder
 layers and the control measure will not move below a polygon. This is a real

--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.ts
@@ -41,6 +41,7 @@ import {
   type NScenarioLayerItem,
 } from "@/types/scenarioLayerItems";
 import { controlMeasureExtentFeature } from "@/geo/controlMeasures";
+import { isSupportedTacticalGraphic } from "@/scenariostore/tacticalGraphics";
 import { fixExtent } from "@/utils/geoConvert";
 import { createMapLibreKmlLayerRenderer } from "@/geo/kml/maplibre";
 import { findFirstUnitLayerId } from "@/geo/engines/maplibre/unitLayer";
@@ -328,8 +329,17 @@ export function createMapLibreScenarioLayerController(
   function zoomToScenarioLayer(layerId: FeatureId) {
     const fullLayer = activeScenario?.geo.getFullLayerItemsLayer(layerId);
     if (!fullLayer) return;
-    const items = fullLayer.items.filter(isNGeometryLayerItem);
+    const items = fullLayer.items.filter(
+      (item) =>
+        isNGeometryLayerItem(item) ||
+        (isNTacticalGraphicLayerItem(item) && isSupportedTacticalGraphic(item)),
+    );
     const visible = items.filter((item) => !item._hidden);
+    if (fullLayer.specialization === "controlMeasure") {
+      if (fullLayer.isHidden || fullLayer._hidden || !visible.length) return;
+      zoomToFeatures(visible.map((item) => item.id));
+      return;
+    }
     const picked = (visible.length ? visible : items).map((item) => item.id);
     zoomToFeatures(picked);
   }
@@ -851,8 +861,7 @@ export function createMapLibreScenarioLayerController(
       undoable: !active,
     });
     const source = safeGetSource(getImageSourceId(transform.layerId)) as
-      | { updateImage?: (options: { coordinates?: number[][] }) => void }
-      | undefined;
+      { updateImage?: (options: { coordinates?: number[][] }) => void } | undefined;
     source?.updateImage?.({ coordinates: getTransformCoordinates(transform.state) });
     emitLayerEvent({
       type: "map-layer-transform",

--- a/src/importexport/export/controlMeasureGeoJson.ts
+++ b/src/importexport/export/controlMeasureGeoJson.ts
@@ -51,7 +51,7 @@ export function isControlMeasureLabelFeature(
  */
 export function controlMeasureToGeoJsonFeatures(
   item: TacticalGraphicLayerItem,
-  options: Partial<GeoJsonSettings> = {},
+  options: Partial<GeoJsonSettings> & { includeGeneratedLabels?: boolean } = {},
 ): Feature<Geometry, GeoJsonProperties>[] {
   if (!isSupportedTacticalGraphic(item)) return [];
   const render = renderControlMeasure(toControlMeasure(item), {
@@ -61,7 +61,10 @@ export function controlMeasureToGeoJsonFeatures(
   const includeIdInProperties = options.includeIdInProperties ?? false;
 
   return render.features
-    .filter((feature) => !isControlMeasureLabelFeature(feature))
+    .filter(
+      (feature) =>
+        options.includeGeneratedLabels || !isControlMeasureLabelFeature(feature),
+    )
     .map((feature) => ({
       type: "Feature" as const,
       // The renderer's stable id is `${cmId}:${part}:${index}`.

--- a/src/modules/maplibreview/tacticalGraphicRenderPlan.test.ts
+++ b/src/modules/maplibreview/tacticalGraphicRenderPlan.test.ts
@@ -101,6 +101,21 @@ describe("buildTacticalGraphicRenderPlan", () => {
     expect(plan.graphics.map((g) => g.id)).toEqual(["bottom-a", "top-a", "top-b"]);
   });
 
+  it("keeps specialized empty layers harmless while preserving stack order", () => {
+    const plan = buildTacticalGraphicRenderPlan(
+      [
+        layer("top", [graphic("top")], { specialization: "controlMeasure" }),
+        layer("prepared", [], { specialization: "controlMeasure" }),
+        layer("bottom", [graphic("bottom")], {
+          specialization: "controlMeasure",
+        }),
+      ],
+      visible,
+    );
+
+    expect(plan.graphics.map((graphic) => graphic.id)).toEqual(["bottom", "top"]);
+  });
+
   it("filters out an unsupported graphicKind and reports it", () => {
     const plan = buildTacticalGraphicRenderPlan(
       [

--- a/src/modules/scenarioeditor/ControlMeasureLayer.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureLayer.test.ts
@@ -7,6 +7,7 @@ import { activeScenarioKey } from "@/components/injects";
 import type { NTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
 import type { NScenarioOverlayLayer } from "@/types/scenarioStackLayers";
 import { identityColor } from "@/symbology/identityColors";
+import { ScenarioLayerActions } from "@/types/constants";
 
 vi.mock("@/stores/selectedStore", () => ({
   useSelectedItems: () => ({
@@ -47,7 +48,7 @@ function mountLayer(items: NTacticalGraphicLayerItem[]) {
     props: {
       layer,
       items,
-      layerMenuItems: [],
+      layerMenuItems: [{ label: "Zoom to", action: ScenarioLayerActions.Zoom }],
       itemMenuItems: [],
     },
     global: {
@@ -74,10 +75,18 @@ describe("ControlMeasureLayer", () => {
     expect(rows[0]!.text()).toContain("PL BLUE");
   });
 
+  it("places the drag handle to the left like an ordinary layer item", () => {
+    const { wrapper } = mountLayer([cm("cm1")]);
+    const row = wrapper.find("[data-feature-id]");
+
+    expect(row.element.firstElementChild?.tagName).toBe("SPAN");
+    expect(row.element.children[1]?.tagName).toBe("BUTTON");
+  });
+
   it("tints the icon with the resolved stroke colour", () => {
     // Read time only: the identity is projected, never stored as a colour.
     const { wrapper } = mountLayer([cm("cm1", { standardIdentity: "6" })]);
-    const icon = wrapper.find("[data-feature-id] svg");
+    const icon = wrapper.find("[data-feature-id] > button svg");
 
     // jsdom normalises whitespace inside the rgb() triple.
     expect(icon.attributes("style")?.replace(/\s/g, "")).toContain(
@@ -90,7 +99,7 @@ describe("ControlMeasureLayer", () => {
       cm("cm1", { standardIdentity: "6", style: { strokeColor: "rgb(1, 2, 3)" } }),
     ]);
 
-    expect(wrapper.find("[data-feature-id] svg").attributes("style")).toContain(
+    expect(wrapper.find("[data-feature-id] > button svg").attributes("style")).toContain(
       "rgb(1, 2, 3)",
     );
   });
@@ -123,5 +132,22 @@ describe("ControlMeasureLayer", () => {
 
     expect(geo.updateLayer).toHaveBeenCalledWith("cm-layer", { isHidden: true });
     expect(geo.updateLayer).toHaveBeenCalledWith("cm-layer", { locked: true });
+  });
+
+  it("disables layer zoom when there is no currently visible extent", () => {
+    const empty = mountLayer([]).wrapper;
+    const visible = mountLayer([cm("cm1")]).wrapper;
+    const unsupported = mountLayer([
+      cm("cm1", { graphicKind: "from-the-future" as never }),
+    ]).wrapper;
+    const zoomAction = (wrapper: typeof empty) =>
+      wrapper
+        .findAllComponents({ name: "DotsMenu" })
+        .flatMap((menu) => menu.props("items"))
+        .find((item: any) => item.action === ScenarioLayerActions.Zoom);
+
+    expect(zoomAction(empty).disabled).toBe(true);
+    expect(zoomAction(visible).disabled).toBeFalsy();
+    expect(zoomAction(unsupported).disabled).toBe(true);
   });
 });

--- a/src/modules/scenarioeditor/ControlMeasureLayer.vue
+++ b/src/modules/scenarioeditor/ControlMeasureLayer.vue
@@ -7,6 +7,8 @@ import {
   IconEyeOff,
   IconLockOpenVariantOutline,
   IconLockOutline,
+  IconStar,
+  IconStarOutline,
 } from "@iconify-prerendered/vue-mdi";
 import { Button } from "@/components/ui/button";
 import EditLayerInlineForm from "@/modules/scenarioeditor/EditLayerInlineForm.vue";
@@ -20,15 +22,37 @@ import type { FeatureId } from "@/types/scenarioGeoModels";
 import type { NScenarioLayer } from "@/types/internalModels";
 import type { NTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
 import type { NScenarioOverlayLayer } from "@/types/scenarioStackLayers";
+import { computed, onMounted, onUnmounted, ref } from "vue";
+import {
+  draggable,
+  dropTargetForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import {
+  getScenarioFeatureLayerDragItem,
+  idle,
+  isScenarioFeatureDragItem,
+  isScenarioFeatureLayerDragItem,
+  type ItemState,
+} from "@/types/draggables";
+import DropIndicator from "@/components/DropIndicator.vue";
+import { IconDrag } from "@iconify-prerendered/vue-mdi";
+import { isControlMeasureLayer } from "@/modules/scenarioeditor/controlMeasureLayers";
+import { resolveControlMeasureControlPoints } from "@/geo/controlMeasures";
+import { isSupportedTacticalGraphic } from "@/scenariostore/tacticalGraphics";
 
 /**
- * A control-measures section: one top-level layer, rendered outside the layer tree.
+ * One specialized control-measure layer, rendered in the separate control-measure stack.
  *
  * Outside the tree because control measures render on their own tactical-draw stack
  * above every plain shape regardless of layer order (ADR-0006), so offering the tree's
- * reorder affordances here would promise an ordering the map does not honour. It is
- * still a real layer, which is why the header carries visibility and lock exactly as a
- * tree layer's does.
+ * cross-family reorder affordances would promise unsupported interleaving. Within the
+ * control-measure stack it carries the same applicable management interactions as a
+ * feature layer.
  */
 const props = defineProps<{
   layer: NScenarioOverlayLayer;
@@ -58,6 +82,98 @@ const { geo } = injectStrict(activeScenarioKey);
 const { selectedFeatureIds, activeFeatureId } = useSelectedItems();
 
 const editedLayerId = defineModel<FeatureId | null>("editedLayerId");
+const activeLayerId = defineModel<FeatureId | null | undefined>("activeLayerId");
+const layerOpen = computed({
+  get: () => props.layer._isOpen,
+  set: (open: boolean) =>
+    geo.updateLayer(props.layer.id, { _isOpen: open }, { undoable: false, noEmit: true }),
+});
+const elRef = ref<HTMLElement | null>(null);
+const handleRef = ref<HTMLElement | null>(null);
+const itemState = ref<ItemState>(idle);
+
+function menuItemsFor(item: NTacticalGraphicLayerItem) {
+  if (!props.layer.locked && !item.locked) return props.itemMenuItems;
+  const mutationActions = new Set(["moveUp", "moveDown", "delete", "duplicate"]);
+  return props.itemMenuItems.map((menuItem) =>
+    mutationActions.has(menuItem.action) ? { ...menuItem, disabled: true } : menuItem,
+  );
+}
+
+const availableLayerMenuItems = computed(() => {
+  const hasVisibleExtent =
+    !props.layer.isHidden &&
+    !props.layer._hidden &&
+    props.items.some(
+      (item) =>
+        !item.isHidden &&
+        !item._hidden &&
+        isSupportedTacticalGraphic(item) &&
+        resolveControlMeasureControlPoints(item).length > 0,
+    );
+  return props.layerMenuItems.map((menuItem) =>
+    menuItem.action === "Zoom"
+      ? { ...menuItem, disabled: menuItem.disabled || !hasVisibleExtent }
+      : menuItem,
+  );
+});
+
+let dndCleanup = () => {};
+onMounted(() => {
+  if (!elRef.value) return;
+  dndCleanup = combine(
+    draggable({
+      element: elRef.value,
+      dragHandle: handleRef.value!,
+      getInitialData: () =>
+        getScenarioFeatureLayerDragItem({
+          layer: props.layer as unknown as NScenarioLayer,
+        }),
+      onDragStart: () => (itemState.value = { type: "dragging" }),
+      onDrop: () => (itemState.value = idle),
+    }),
+    dropTargetForElements({
+      element: elRef.value,
+      canDrop: ({ source }) => {
+        if (isScenarioFeatureDragItem(source.data)) {
+          const sourceOwner = geo.getLayerById(source.data.feature._pid);
+          return (
+            source.data.feature.kind === "tacticalGraphic" &&
+            !source.data.feature.locked &&
+            !sourceOwner?.locked &&
+            !props.layer.locked &&
+            source.data.feature._pid !== props.layer.id
+          );
+        }
+        return (
+          isScenarioFeatureLayerDragItem(source.data) &&
+          source.data.layer.id !== props.layer.id &&
+          isControlMeasureLayer(source.data.layer as unknown as NScenarioOverlayLayer)
+        );
+      },
+      getData: ({ input, element, source }) => {
+        const data = getScenarioFeatureLayerDragItem({
+          layer: props.layer as unknown as NScenarioLayer,
+        });
+        return isScenarioFeatureLayerDragItem(source.data)
+          ? attachClosestEdge(data, {
+              input,
+              element,
+              allowedEdges: ["top", "bottom"],
+            })
+          : data;
+      },
+      onDrag: ({ self }) =>
+        (itemState.value = {
+          type: "drag-over",
+          closestEdge: extractClosestEdge(self.data),
+        }),
+      onDragLeave: () => (itemState.value = idle),
+      onDrop: () => (itemState.value = idle),
+    }),
+  );
+});
+onUnmounted(() => dndCleanup());
 
 function toggleLayerVisibility() {
   geo.updateLayer(props.layer.id, { isHidden: !props.layer.isHidden });
@@ -76,16 +192,48 @@ function toggleItemVisibility(item: NTacticalGraphicLayerItem) {
 <template>
   <ChevronPanel
     :label="layer.name"
-    v-model:open="layer._isOpen"
+    v-model:open="layerOpen"
     header-class="-ml-2"
     :data-control-measure-layer-id="layer.id"
+    v-model:header-ref="elRef"
   >
-    <template #left><span class="h-6 w-6" /></template>
+    <template #left>
+      <span ref="handleRef">
+        <IconDrag
+          class="text-muted-foreground h-6 w-6 cursor-move group-focus-within:opacity-100 group-hover:opacity-100 sm:opacity-0"
+        />
+      </span>
+    </template>
     <template #label>
-      <div :class="layer.isHidden ? 'opacity-50' : ''">{{ layer.name }}</div>
+      <div
+        @dblclick="activeLayerId = layer.id"
+        :class="[
+          layer.isHidden ? 'opacity-50' : '',
+          activeLayerId === layer.id ? 'dark:text-army2 text-red-800' : '',
+        ]"
+      >
+        {{ layer.name }}
+      </div>
+      <DropIndicator
+        v-if="itemState.type === 'drag-over' && itemState.closestEdge"
+        :edge="itemState.closestEdge"
+        gap="0px"
+      />
     </template>
     <template #right>
       <div class="-mr-2 flex items-center">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          @click="activeLayerId = layer.id"
+          @keydown.stop
+          class="opacity-0 group-focus-within:opacity-100 group-hover:opacity-100"
+          title="Set as active layer"
+        >
+          <IconStar v-if="activeLayerId === layer.id" class="size-5" />
+          <IconStarOutline v-else class="size-5" />
+        </Button>
         <Button
           type="button"
           variant="ghost"
@@ -117,7 +265,7 @@ function toggleItemVisibility(item: NTacticalGraphicLayerItem) {
         />
         <DotsMenu
           class="opacity-0 group-focus-within:opacity-100 group-hover:opacity-100"
-          :items="layerMenuItems"
+          :items="availableLayerMenuItems"
           @action="emit('layer-action', layer, $event)"
         />
       </div>
@@ -137,7 +285,7 @@ function toggleItemVisibility(item: NTacticalGraphicLayerItem) {
         :layer="layer"
         :selected="selectedFeatureIds.has(item.id)"
         :active="activeFeatureId === item.id"
-        :menu-items="itemMenuItems"
+        :menu-items="menuItemsFor(item)"
         @item-click="emit('item-click', item, layer, $event)"
         @item-double-click="emit('item-double-click', item, layer, $event)"
         @item-action="emit('item-action', item.id, $event)"

--- a/src/modules/scenarioeditor/ControlMeasureListItem.vue
+++ b/src/modules/scenarioeditor/ControlMeasureListItem.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
-import { computed } from "vue";
+import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import {
   IconAlertOutline,
   IconClockOutline,
   IconEye,
   IconEyeOff,
+  IconDrag,
 } from "@iconify-prerendered/vue-mdi";
 import DotsMenu from "@/components/DotsMenu.vue";
 import { getGeometryIcon } from "@/modules/scenarioeditor/featureLayerUtils";
@@ -15,6 +16,24 @@ import type { ScenarioFeatureActions } from "@/types/constants";
 import type { NTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
 import type { NScenarioOverlayLayer } from "@/types/scenarioStackLayers";
 import type { MenuItemData } from "@/components/types";
+import {
+  draggable,
+  dropTargetForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import DropIndicator from "@/components/DropIndicator.vue";
+import {
+  getScenarioFeatureDragItem,
+  idle,
+  isScenarioFeatureDragItem,
+  type ItemState,
+} from "@/types/draggables";
+import { injectStrict } from "@/utils";
+import { activeScenarioKey } from "@/components/injects";
 
 interface Props {
   item: NTacticalGraphicLayerItem;
@@ -35,6 +54,65 @@ const emit = defineEmits<{
 const hidden = computed(() => props.layer.isHidden || props.item._hidden);
 const supported = computed(() => isSupportedGraphicKind(props.item.graphicKind));
 const label = computed(() => getControlMeasureLabel(props.item));
+const elRef = ref<HTMLElement | null>(null);
+const handleRef = ref<HTMLElement | null>(null);
+const itemState = ref<ItemState>(idle);
+const { geo } = injectStrict(activeScenarioKey);
+
+let dndCleanup = () => {};
+let mounted = false;
+function installDragAndDrop() {
+  dndCleanup();
+  dndCleanup = () => {};
+  if (!mounted || !elRef.value || props.layer.locked || props.item.locked) return;
+  dndCleanup = combine(
+    draggable({
+      element: elRef.value,
+      dragHandle: handleRef.value!,
+      getInitialData: () => getScenarioFeatureDragItem({ feature: props.item }),
+      onDragStart: () => (itemState.value = { type: "dragging" }),
+      onDrop: () => (itemState.value = idle),
+    }),
+    dropTargetForElements({
+      element: elRef.value,
+      canDrop: ({ source }) => {
+        if (!isScenarioFeatureDragItem(source.data)) return false;
+        const sourceOwner = geo.getLayerById(source.data.feature._pid);
+        return (
+          source.data.feature.kind === "tacticalGraphic" &&
+          source.data.feature.id !== props.item.id &&
+          !source.data.feature.locked &&
+          !sourceOwner?.locked
+        );
+      },
+      getData: ({ input, element }) =>
+        attachClosestEdge(getScenarioFeatureDragItem({ feature: props.item }), {
+          input,
+          element,
+          allowedEdges: ["top", "bottom"],
+        }),
+      onDrag: ({ self }) =>
+        (itemState.value = {
+          type: "drag-over",
+          closestEdge: extractClosestEdge(self.data),
+        }),
+      onDragLeave: () => (itemState.value = idle),
+      onDrop: () => (itemState.value = idle),
+    }),
+  );
+}
+onMounted(() => {
+  mounted = true;
+  installDragAndDrop();
+});
+watch(
+  () => [props.layer.locked, props.item.locked],
+  () => installDragAndDrop(),
+);
+onUnmounted(() => {
+  mounted = false;
+  dndCleanup();
+});
 
 /**
  * Read-time only. The tint is the same projection the map renders with — an authored
@@ -49,18 +127,26 @@ const strokeColor = computed(() => {
 
 <template>
   <li
+    ref="elRef"
     class="group hover:bg-accent relative flex items-center justify-between border-l select-none"
     :data-feature-id="item.id"
     :class="
-      selected
-        ? 'border-yellow-500 bg-yellow-100 dark:bg-yellow-900'
-        : 'border-transparent'
+      itemState.type === 'dragging'
+        ? 'opacity-20'
+        : selected
+          ? 'border-yellow-500 bg-yellow-100 dark:bg-yellow-900'
+          : 'border-transparent'
     "
   >
+    <span ref="handleRef">
+      <IconDrag
+        class="text-muted-foreground h-6 w-6 cursor-move group-focus-within:opacity-100 group-hover:opacity-100 sm:opacity-0"
+      />
+    </span>
     <button
       @click="emit('item-click', $event)"
       @dblclick="emit('item-double-click', $event)"
-      class="flex flex-auto items-center py-2.5 pl-6 sm:py-2"
+      class="flex flex-auto items-center py-2.5 sm:py-2"
     >
       <component
         :is="getGeometryIcon(item)"
@@ -88,6 +174,7 @@ const strokeColor = computed(() => {
       <button
         type="button"
         @click.stop="emit('toggle-visibility')"
+        :disabled="layer.locked || item.locked"
         class="text-muted-foreground hover:text-foreground mr-1 opacity-0 group-focus-within:opacity-100 group-hover:opacity-100"
         title="Toggle visibility"
       >
@@ -105,5 +192,10 @@ const strokeColor = computed(() => {
         class="opacity-0 group-focus-within:opacity-100 group-hover:opacity-100"
       />
     </div>
+    <DropIndicator
+      v-if="itemState.type === 'drag-over' && itemState.closestEdge"
+      :edge="itemState.closestEdge"
+      gap="0px"
+    />
   </li>
 </template>

--- a/src/modules/scenarioeditor/ScenarioLayersTabPanel.test.ts
+++ b/src/modules/scenarioeditor/ScenarioLayersTabPanel.test.ts
@@ -1,11 +1,17 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from "vitest";
 import { mount } from "@vue/test-utils";
-import { ref, shallowRef } from "vue";
+import { nextTick, ref, shallowRef } from "vue";
 import ScenarioLayersTabPanel from "@/modules/scenarioeditor/ScenarioLayersTabPanel.vue";
 import type { NScenarioLayerItem } from "@/types/scenarioLayerItems";
 import type { NScenarioOverlayLayer } from "@/types/scenarioStackLayers";
 import { ScenarioLayerActions } from "@/types/constants";
+import { useNewScenarioStore } from "@/scenariostore/newScenarioStore";
+import { useGeo } from "@/scenariostore/geo";
+import {
+  getScenarioFeatureDragItem,
+  getScenarioFeatureLayerDragItem,
+} from "@/types/draggables";
 import {
   activeLayerKey,
   activeScenarioKey,
@@ -30,8 +36,13 @@ vi.mock("@/stores/selectedStore", () => ({
   }),
 }));
 
+const dragMonitor = vi.hoisted(() => ({ options: null as any }));
+
 vi.mock("@atlaskit/pragmatic-drag-and-drop/element/adapter", () => ({
-  monitorForElements: () => () => {},
+  monitorForElements: (options: any) => {
+    dragMonitor.options = options;
+    return () => {};
+  },
   draggable: () => () => {},
   dropTargetForElements: () => () => {},
 }));
@@ -75,10 +86,12 @@ describe("ScenarioLayersTabPanel", () => {
       template: "<div class='dots-menu-stub' />",
     };
 
+    const addLayer = vi.fn((layer) => ({ ...layer }));
+    const activeLayerId = ref<string | null>(null);
     const wrapper = mount(ScenarioLayersTabPanel, {
       global: {
         provide: {
-          [activeLayerKey as symbol]: ref(null),
+          [activeLayerKey as symbol]: activeLayerId,
           [activeScenarioMapEngineKey as symbol]: shallowRef({
             map: {} as any,
             layers: layerController,
@@ -96,7 +109,7 @@ describe("ScenarioLayersTabPanel", () => {
               layerItemsLayers: ref([]),
               deleteMapLayer: vi.fn(),
               moveMapLayer: vi.fn(),
-              addLayer: vi.fn(),
+              addLayer,
               updateMapLayer: vi.fn(),
               deleteLayer: vi.fn(),
               moveLayer: vi.fn(),
@@ -124,7 +137,7 @@ describe("ScenarioLayersTabPanel", () => {
       },
     });
 
-    return { wrapper, zoomToMapLayer };
+    return { wrapper, zoomToMapLayer, addLayer, activeLayerId };
   }
 
   it("routes map-layer double click through the layer controller", async () => {
@@ -145,6 +158,25 @@ describe("ScenarioLayersTabPanel", () => {
       disabled: true,
     });
   });
+
+  it("explicitly creates and edits an active control-measure layer", () => {
+    const { wrapper, addLayer, activeLayerId } = mountComponent(true);
+    const splitButton = wrapper.findComponent({ name: "SplitButton" });
+    const addControlMeasureLayer = splitButton
+      .props("items")
+      .find((item: { label: string }) => item.label === "Add control-measure layer");
+
+    addControlMeasureLayer.onClick();
+
+    expect(addLayer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "New control-measure layer",
+        specialization: "controlMeasure",
+        items: [],
+      }),
+    );
+    expect(activeLayerId.value).toBe(addLayer.mock.calls[0]![0].id);
+  });
 });
 
 describe("ScenarioLayersTabPanel control-measures section", () => {
@@ -155,6 +187,9 @@ describe("ScenarioLayersTabPanel control-measures section", () => {
       name: id,
       items: itemIds,
       _isOpen: true,
+      ...(itemIds.length > 0 && itemIds.every((itemId) => itemId.startsWith("cm"))
+        ? { specialization: "controlMeasure" as const }
+        : {}),
     } as NScenarioOverlayLayer;
   }
 
@@ -187,9 +222,11 @@ describe("ScenarioLayersTabPanel control-measures section", () => {
     {
       renderFeed,
       editedControlMeasureId,
+      drawingDestinationLayerId,
     }: {
       renderFeed?: { settle: ReturnType<typeof vi.fn> };
       editedControlMeasureId?: string;
+      drawingDestinationLayerId?: string;
     } = {},
   ) {
     const stackLayers = layersItems.map(({ layer }) => layer);
@@ -220,13 +257,20 @@ describe("ScenarioLayersTabPanel control-measures section", () => {
             store: { groupUpdate: vi.fn((fn: () => void) => fn()) },
           },
           ...(renderFeed ? { [tacticalGraphicRenderFeedKey as symbol]: renderFeed } : {}),
-          ...(editedControlMeasureId
+          ...(editedControlMeasureId || drawingDestinationLayerId
             ? {
                 [scenarioDrawKey as symbol]: {
-                  armed: shallowRef({
-                    kind: "cmEdit",
-                    featureId: editedControlMeasureId,
-                  }),
+                  armed: shallowRef(
+                    editedControlMeasureId
+                      ? {
+                          kind: "cmEdit",
+                          featureId: editedControlMeasureId,
+                        }
+                      : { kind: "cmDraw", graphicKind: "phase-line" },
+                  ),
+                  controlMeasureDrawDestinationLayerId: shallowRef(
+                    drawingDestinationLayerId ?? null,
+                  ),
                 },
               }
             : {}),
@@ -265,7 +309,36 @@ describe("ScenarioLayersTabPanel control-measures section", () => {
     expect(wrapper.find('[data-feature-id="cm1"]').exists()).toBe(true);
   });
 
-  it("keeps a mixed layer in the tree so its geometry items stay listed", () => {
+  it("shows empty specialized layers with the standard layer and item actions", () => {
+    const prepared = {
+      ...overlayLayer("prepared", []),
+      specialization: "controlMeasure" as const,
+    };
+    const wrapper = mountWithLayers([{ layer: prepared, items: [] }]);
+    const section = wrapper.findComponent({ name: "ControlMeasureLayer" });
+
+    expect(section.exists()).toBe(true);
+    expect(section.props("layerMenuItems").map((item: any) => item.action)).toEqual([
+      ScenarioLayerActions.Zoom,
+      ScenarioLayerActions.SetActive,
+      ScenarioLayerActions.Edit,
+      ScenarioLayerActions.MoveUp,
+      ScenarioLayerActions.MoveDown,
+      ScenarioLayerActions.CopyAsGeoJson,
+      ScenarioLayerActions.Delete,
+    ]);
+    expect(section.props("itemMenuItems").map((item: any) => item.action)).toEqual([
+      "zoom",
+      "pan",
+      "moveUp",
+      "moveDown",
+      "delete",
+      "duplicate",
+      "copyAsGeoJson",
+    ]);
+  });
+
+  it("keeps an unspecialized mixed layer in the feature tree", () => {
     const wrapper = mountWithLayers([
       {
         layer: overlayLayer("mixed-layer", ["g1", "cm1"]),
@@ -274,7 +347,7 @@ describe("ScenarioLayersTabPanel control-measures section", () => {
     ]);
 
     expect(wrapper.find('[data-tree-layer-id="mixed-layer"]').exists()).toBe(true);
-    expect(wrapper.findAllComponents({ name: "ControlMeasureLayer" })).toHaveLength(1);
+    expect(wrapper.findAllComponents({ name: "ControlMeasureLayer" })).toHaveLength(0);
   });
 
   it("settles only when the layer panel deletes the control measure being edited", () => {
@@ -316,5 +389,187 @@ describe("ScenarioLayersTabPanel control-measures section", () => {
 
     layers[0]!.vm.$emit("layer-action", cm1Layer, ScenarioLayerActions.Delete);
     expect(renderFeed.settle).toHaveBeenCalledWith("delete");
+  });
+
+  it("settles when deleting a draw's captured destination after active layer changes", () => {
+    const renderFeed = { settle: vi.fn() };
+    const destination = overlayLayer("cm1-layer", ["cm1"]);
+    const nowActive = overlayLayer("cm2-layer", ["cm2"]);
+    const wrapper = mountWithLayers(
+      [
+        { layer: destination, items: [cm("cm1")] },
+        { layer: nowActive, items: [cm("cm2")] },
+      ],
+      { renderFeed, drawingDestinationLayerId: destination.id },
+    );
+    const layers = wrapper.findAllComponents({ name: "ControlMeasureLayer" });
+
+    layers[0]!.vm.$emit("layer-action", destination, ScenarioLayerActions.Delete);
+
+    expect(renderFeed.settle).toHaveBeenCalledWith("delete");
+  });
+
+  it("duplicates, reorders, and moves control measures through the real store", async () => {
+    const store = useNewScenarioStore({
+      id: "scenario-1",
+      type: "ORBAT-mapper",
+      version: "3.4.0",
+      name: "Scenario",
+      startTime: "2025-01-01T00:00:00Z",
+      sides: [],
+      events: [],
+      layerStack: [
+        {
+          id: "feature-layer",
+          kind: "overlay",
+          name: "Features",
+          items: [],
+        },
+        {
+          id: "cm-a",
+          kind: "overlay",
+          name: "A",
+          specialization: "controlMeasure",
+          items: [
+            {
+              id: "cm-1",
+              kind: "tacticalGraphic",
+              graphicKind: "phase-line",
+              controlPoints: [
+                [10, 60],
+                [11, 61],
+              ],
+              options: { smooth: true },
+            },
+            {
+              id: "cm-2",
+              kind: "tacticalGraphic",
+              graphicKind: "phase-line",
+              controlPoints: [
+                [12, 62],
+                [13, 63],
+              ],
+            },
+          ],
+        },
+        {
+          id: "cm-b",
+          kind: "overlay",
+          name: "B",
+          specialization: "controlMeasure",
+          items: [],
+        },
+      ],
+    } as any);
+    const geo = useGeo(store);
+    const activeLayerId = ref("cm-a");
+    const wrapper = mount(ScenarioLayersTabPanel, {
+      global: {
+        provide: {
+          [activeLayerKey as symbol]: activeLayerId,
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            map: {} as never,
+            layers: { capabilities: {} },
+          }),
+          [activeScenarioKey as symbol]: {
+            store,
+            geo,
+          },
+        },
+        stubs: {
+          ChevronPanel: { template: "<div><slot name='label' /><slot /></div>" },
+          DotsMenu: true,
+          SplitButton: true,
+          EditLayerInlineForm: true,
+          ScenarioFeatureLayer: true,
+        },
+      },
+    });
+    const section = wrapper.findAllComponents({ name: "ControlMeasureLayer" })[0]!;
+
+    section.vm.$emit("item-action", "cm-1", "duplicate");
+    const duplicate = geo.layersItems.value
+      .find(({ layer }) => layer.id === "cm-a")!
+      .items.find((item) => item.id !== "cm-1" && item.id !== "cm-2")!;
+    expect(duplicate).toMatchObject({
+      kind: "tacticalGraphic",
+      graphicKind: "phase-line",
+      options: { smooth: true },
+      _pid: "cm-a",
+    });
+    store.undo();
+    expect(store.state.layerItemMap[duplicate.id]).toBeUndefined();
+
+    section.vm.$emit("item-action", "cm-1", "moveDown");
+    expect(geo.getLayerById("cm-a")!.items).toEqual(["cm-2", "cm-1"]);
+
+    dragMonitor.options.onDrop({
+      source: {
+        data: getScenarioFeatureDragItem({
+          feature: store.state.layerItemMap["cm-1"]!,
+        }),
+      },
+      location: {
+        current: {
+          dropTargets: [
+            {
+              data: getScenarioFeatureLayerDragItem({
+                layer: geo.getLayerById("cm-b")!,
+              }),
+            },
+          ],
+        },
+      },
+    });
+    expect(store.state.layerItemMap["cm-1"]!._pid).toBe("cm-b");
+    expect(geo.getLayerById("cm-b")!.items).toEqual(["cm-1"]);
+    expect(geo.getLayerById("feature-layer")!.items).toEqual([]);
+
+    store.undo();
+    expect(store.state.layerItemMap["cm-1"]!._pid).toBe("cm-a");
+    store.redo();
+    expect(store.state.layerItemMap["cm-1"]!._pid).toBe("cm-b");
+
+    dragMonitor.options.onDrop({
+      source: {
+        data: getScenarioFeatureDragItem({
+          feature: store.state.layerItemMap["cm-1"]!,
+        }),
+      },
+      location: {
+        current: {
+          dropTargets: [
+            {
+              data: getScenarioFeatureLayerDragItem({
+                layer: geo.getLayerById("feature-layer")!,
+              }),
+            },
+          ],
+        },
+      },
+    });
+    expect(store.state.layerItemMap["cm-1"]!._pid).toBe("cm-b");
+
+    geo.updateLayer("cm-b", { locked: true });
+    const lockedSection = wrapper.findAllComponents({ name: "ControlMeasureLayer" })[1]!;
+    lockedSection.vm.$emit("item-action", "cm-1", "duplicate");
+    lockedSection.vm.$emit("item-action", "cm-1", "moveUp");
+    lockedSection.vm.$emit("item-action", "cm-1", "delete");
+    expect(geo.getLayerById("cm-b")!.items).toEqual(["cm-1"]);
+
+    activeLayerId.value = "cm-b";
+    lockedSection.vm.$emit(
+      "layer-action",
+      geo.getLayerById("cm-b")!,
+      ScenarioLayerActions.Delete,
+    );
+    expect(activeLayerId.value).toBe("cm-a");
+    expect(geo.getLayerById("cm-b")).toBeUndefined();
+
+    await nextTick();
+    wrapper
+      .findComponent({ name: "ControlMeasureLayer" })
+      .vm.$emit("layer-action", geo.getLayerById("cm-a")!, ScenarioLayerActions.Delete);
+    expect(activeLayerId.value).toBe("feature-layer");
   });
 });

--- a/src/modules/scenarioeditor/ScenarioLayersTabPanel.vue
+++ b/src/modules/scenarioeditor/ScenarioLayersTabPanel.vue
@@ -29,15 +29,19 @@ import type {
 } from "@/types/constants";
 import { ScenarioLayerActions } from "@/types/constants";
 import { useSelectedItems } from "@/stores/selectedStore";
-import {
-  addMapLayer,
-  getMapLayerIcon,
-} from "@/modules/scenarioeditor/scenarioMapLayerUtils";
+import { addMapLayer } from "@/modules/scenarioeditor/scenarioMapLayerUtils";
 import SplitButton from "@/components/SplitButton.vue";
 import ScenarioFeatureLayer from "@/modules/scenarioeditor/ScenarioFeatureLayer.vue";
 import ControlMeasureLayer from "@/modules/scenarioeditor/ControlMeasureLayer.vue";
 import { getControlMeasureLayerGroups } from "@/modules/scenarioeditor/controlMeasureLayers";
-import type { NTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
+import {
+  isControlMeasureLayer,
+  NEW_CONTROL_MEASURE_LAYER_NAME,
+} from "@/modules/scenarioeditor/controlMeasureLayers";
+import type {
+  NScenarioLayerItem,
+  NTacticalGraphicLayerItem,
+} from "@/types/scenarioLayerItems";
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import {
   isScenarioFeatureDragItem,
@@ -49,12 +53,14 @@ import {
   type Edge,
   extractClosestEdge,
 } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
-import { isNGeometryLayerItem } from "@/types/scenarioLayerItems";
+import { isNTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
+import { isSupportedTacticalGraphic } from "@/scenariostore/tacticalGraphics";
 import {
   isScenarioOverlayLayer,
   isScenarioReferenceLayer,
   type NScenarioOverlayLayer,
   type NScenarioReferenceLayer,
+  type NScenarioStackLayer,
 } from "@/types/scenarioStackLayers";
 
 const emit = defineEmits(["feature-click"]);
@@ -97,9 +103,11 @@ const mapLayerMenuItems = computed<MenuItemData<ScenarioMapLayerAction>[]>(() =>
 const mapLayerButtonItems: ButtonGroupItem[] = [
   {
     label: "Add feature layer",
-    onClick: () => {
-      const newLayer = addNewLayer();
-    },
+    onClick: () => addNewLayer(),
+  },
+  {
+    label: "Add control-measure layer",
+    onClick: () => addNewControlMeasureLayer(),
   },
   {
     label: "Add image layer",
@@ -135,11 +143,11 @@ const stackLayers = computed(() => {
 });
 
 function isOverlayStackEntry(layer: unknown): layer is NScenarioOverlayLayer {
-  return isScenarioOverlayLayer(layer as any);
+  return isScenarioOverlayLayer(layer as NScenarioStackLayer);
 }
 
 function isReferenceStackEntry(layer: unknown): layer is NScenarioReferenceLayer {
-  return isScenarioReferenceLayer(layer as any);
+  return isScenarioReferenceLayer(layer as NScenarioStackLayer);
 }
 
 function getReferenceLayerSource(layer: NScenarioReferenceLayer) {
@@ -161,8 +169,8 @@ const layerMenuItems = computed<MenuItemData<ScenarioLayerAction>[]>(() => [
 ]);
 
 /**
- * The control-measures section(s), outside the layer tree and created lazily: nothing
- * appears until a scenario actually holds a `tacticalGraphic` item.
+ * The specialized control-measure stack, outside the mixed overlay/reference tree.
+ * Empty specialized layers deliberately remain present.
  *
  * `layersItems` is optional-chained because older injected `geo` mocks in tests only
  * expose `layerItemsLayers`.
@@ -172,42 +180,19 @@ const controlMeasureGroups = computed(() =>
 );
 
 /**
- * Layers the tree must not also render, or a dedicated control-measures layer would
- * get two headers and two visibility toggles.
- *
- * Only layers whose items are *all* control measures drop out. A layer that mixes
- * kinds keeps its tree row for the geometry it holds and additionally appears as a
- * section for its control measures — a duplicate header in that pathological case,
- * which is still better than leaving items unlisted in either place.
+ * Specialized layers the feature/reference tree must not also render.
  */
 const controlMeasureOnlyLayerIds = computed(
-  () =>
-    new Set(
-      controlMeasureGroups.value
-        .filter(({ layer, items }) => layer.items.length === items.length)
-        .map(({ layer }) => layer.id),
-    ),
+  () => new Set(controlMeasureGroups.value.map(({ layer }) => layer.id)),
 );
 
 /**
- * Deliberately shorter than the tree's layer menu. The control-measures layer is not
- * part of the stack ordering the map honours, so Move up/down and Zoom to would
- * promise behaviour that does not exist; Copy as GeoJSON is geometry-only.
+ * Control-measure layers expose the same applicable management actions as feature
+ * layers. Their move actions are constrained to their own family below.
  */
-const controlMeasureLayerMenuItems: MenuItemData<ScenarioLayerAction>[] = [
-  { label: "Edit", action: ScenarioLayerActions.Edit },
-  { label: "Delete", action: ScenarioLayerActions.Delete },
-];
+const controlMeasureLayerMenuItems = layerMenuItems;
 
-const controlMeasureItemMenuItems = computed<MenuItemData<ScenarioFeatureActions>[]>(
-  () => [
-    { label: "Zoom to", action: "zoom", disabled: !canZoomFeatures.value },
-    { label: "Pan to", action: "pan", disabled: !canPanFeatures.value },
-    { label: "Delete", action: "delete" },
-  ],
-);
-
-const availableFeatureMenuItems = computed<MenuItemData<ScenarioFeatureActions>[]>(() =>
+const availableItemMenuItems = computed<MenuItemData<ScenarioFeatureActions>[]>(() =>
   featureMenuItems.map((item) => ({
     ...item,
     disabled:
@@ -215,6 +200,9 @@ const availableFeatureMenuItems = computed<MenuItemData<ScenarioFeatureActions>[
       (item.action === "pan" && !canPanFeatures.value),
   })),
 );
+
+const controlMeasureItemMenuItems = availableItemMenuItems;
+const availableFeatureMenuItems = availableItemMenuItems;
 
 const { selectedFeatureIds, selectedMapLayerIds, activeMapLayerId, activeFeatureId } =
   useSelectedItems();
@@ -267,11 +255,7 @@ function onFeatureClick(
   emit("feature-click", feature, layer, event);
 }
 
-function onFeatureDoubleClick(
-  feature: NGeometryLayerItem,
-  layer: NScenarioLayer,
-  event?: MouseEvent,
-) {
+function onFeatureDoubleClick(feature: NGeometryLayerItem) {
   engineRef.value?.layers.zoomToFeature(feature.id);
 }
 
@@ -282,10 +266,8 @@ function settleEditedControlMeasureBeforeDelete(itemIds: readonly FeatureId[]) {
 }
 
 /**
- * Control measures are not geometry, so they cannot go through `onFeatureAction`:
- * every branch there resolves the item with `getGeometryLayerItemById`, which returns
- * nothing for a `tacticalGraphic`. Reorder and duplicate are absent for the same
- * reason — `moveFeature`/`duplicateFeature` are still geometry-only.
+ * Control-measure actions share the kind-aware store operations while retaining their
+ * rendered GeoJSON copy path and settle-first deletion.
  */
 function onControlMeasureAction(itemId: FeatureId, action: ScenarioFeatureActions) {
   if (action === "zoom") engineRef.value?.layers.zoomToFeature(itemId);
@@ -295,20 +277,36 @@ function onControlMeasureAction(itemId: FeatureId, action: ScenarioFeatureAction
     geo.deleteFeature(itemId);
     selectedFeatureIds.value.delete(itemId);
   }
+  if (action === "moveUp" || action === "moveDown") {
+    const item = geo.getLayerItemById(itemId).layerItem;
+    if (!item) return;
+    const owner = geo.getLayerById(item._pid);
+    if (!owner || owner.locked || item.locked) return;
+    const index = owner.items.indexOf(itemId);
+    geo.moveFeature(itemId, action === "moveUp" ? index - 1 : index + 1);
+  }
+  if (action === "duplicate") {
+    const newId = geo.duplicateFeature(itemId);
+    if (newId) activeFeatureId.value = newId;
+  }
+  if (action === "copyAsGeoJson") {
+    const item = geo.getLayerItemById(itemId).layerItem;
+    if (!item) return;
+    navigator.clipboard.writeText(layerItemsToGeoJsonString([item]));
+    notify({
+      message: isSupportedTacticalGraphic(item)
+        ? "Copied GeoJSON to clipboard"
+        : "The unsupported control measure was omitted from GeoJSON copy.",
+      type: isSupportedTacticalGraphic(item) ? undefined : "warning",
+    });
+  }
 }
 
 function onControlMeasureLayerAction(
   layer: { id: FeatureId; items?: FeatureId[]; _isOpen?: boolean },
   action: ScenarioLayerAction,
 ) {
-  if (action === ScenarioLayerActions.Edit) {
-    editedLayerId.value = layer.id;
-    layer._isOpen = true;
-  }
-  if (action === ScenarioLayerActions.Delete) {
-    settleEditedControlMeasureBeforeDelete(layer.items ?? []);
-    geo.deleteLayer(layer.id);
-  }
+  onLayerAction(layer as NScenarioLayer, action);
 }
 
 function onControlMeasureDoubleClick(item: NTacticalGraphicLayerItem) {
@@ -367,23 +365,72 @@ function onLayerAction(layer: NScenarioLayer, action: ScenarioLayerAction) {
       olCurrentLayer.value = null;
     }*/
     settleEditedControlMeasureBeforeDelete(layer.items);
+    if (
+      scenarioDraw?.armed.value.kind === "cmDraw" &&
+      scenarioDraw.controlMeasureDrawDestinationLayerId?.value === layer.id
+    ) {
+      tacticalGraphicRenderFeed?.settle("delete");
+    }
+    const overlays = geo.overlayLayers?.value ?? [];
+    const sameFamily = overlays.filter(
+      (candidate) =>
+        candidate.id !== layer.id &&
+        isControlMeasureLayer(candidate) ===
+          isControlMeasureLayer(layer as unknown as NScenarioOverlayLayer),
+    );
+    const layerIndex = overlays.findIndex((candidate) => candidate.id === layer.id);
+    const nearest = (candidates: NScenarioOverlayLayer[]) =>
+      candidates.find(
+        (candidate) =>
+          overlays.findIndex((overlay) => overlay.id === candidate.id) > layerIndex,
+      ) ??
+      [...candidates]
+        .reverse()
+        .find(
+          (candidate) =>
+            overlays.findIndex((overlay) => overlay.id === candidate.id) < layerIndex,
+        );
+    const otherFamily = overlays.filter(
+      (candidate) =>
+        candidate.id !== layer.id &&
+        isControlMeasureLayer(candidate) !==
+          isControlMeasureLayer(layer as unknown as NScenarioOverlayLayer),
+    );
+    const fallback = nearest(sameFamily) ?? nearest(otherFamily);
     geo.deleteLayer(layer.id);
+    if (activeLayerId.value === layer.id) activeLayerId.value = fallback?.id ?? null;
   }
   if (
     action === ScenarioLayerActions.MoveUp ||
     action === ScenarioLayerActions.MoveDown
   ) {
     const direction = action === ScenarioLayerActions.MoveUp ? "up" : "down";
-    let toIndex = geo.getLayerIndex(layer.id);
-    if (direction === "up") toIndex--;
-    if (direction === "down") toIndex++;
-    geo.moveLayer(layer.id, toIndex);
+    const current = geo.getLayerById(layer.id) as NScenarioOverlayLayer | undefined;
+    if (current && isControlMeasureLayer(current)) {
+      const family = (geo.overlayLayers?.value ?? []).filter(isControlMeasureLayer);
+      const familyIndex = family.findIndex((candidate) => candidate.id === layer.id);
+      const neighbor = family[direction === "up" ? familyIndex - 1 : familyIndex + 1];
+      if (neighbor) geo.moveLayer(layer.id, geo.getLayerIndex(neighbor.id));
+    } else {
+      let toIndex = geo.getLayerIndex(layer.id);
+      if (direction === "up") toIndex--;
+      if (direction === "down") toIndex++;
+      geo.moveLayer(layer.id, toIndex);
+    }
   }
   if (action === ScenarioLayerActions.CopyAsGeoJson) {
     const fullLayer = geo.getFullLayerItemsLayer(layer.id);
     if (fullLayer) {
       navigator.clipboard.writeText(layerItemsToGeoJsonString(fullLayer.items));
-      notify({ message: "Copied GeoJSON to clipboard" });
+      const unsupportedCount = fullLayer.items.filter(
+        (item) => isNTacticalGraphicLayerItem(item) && !isSupportedTacticalGraphic(item),
+      ).length;
+      notify({
+        message: unsupportedCount
+          ? `Copied GeoJSON; omitted ${unsupportedCount} unsupported control measure${unsupportedCount === 1 ? "" : "s"}.`
+          : "Copied GeoJSON to clipboard",
+        type: unsupportedCount ? "warning" : undefined,
+      });
     }
   }
 }
@@ -454,8 +501,8 @@ function onFeatureAction(
 }
 
 function onFeatureDrop(data: {
-  feature: NGeometryLayerItem;
-  destinationFeature: NGeometryLayerItem | NScenarioLayer;
+  feature: NScenarioLayerItem;
+  destinationFeature: NScenarioLayerItem | NScenarioLayer;
   target: DropTarget;
 }) {
   const { feature, destinationFeature, target } = data;
@@ -466,6 +513,20 @@ function addNewLayer() {
   const addedLayer = geo.addLayer({
     id: nanoid(),
     name: `New layer`,
+    items: [],
+    _isNew: false,
+  });
+  if (!addedLayer) return;
+  activeLayerId.value = addedLayer.id;
+  editedLayerId.value = addedLayer.id;
+  return addedLayer;
+}
+
+function addNewControlMeasureLayer() {
+  const addedLayer = geo.addLayer({
+    id: nanoid(),
+    name: NEW_CONTROL_MEASURE_LAYER_NAME,
+    specialization: "controlMeasure",
     items: [],
     _isNew: false,
   });
@@ -494,7 +555,7 @@ function getOverlayFeatures(layer: NScenarioOverlayLayer): NGeometryLayerItem[] 
     .filter((item): item is NGeometryLayerItem => !!item);
 }
 
-function onLayerDrop(layer: NScenarioLayer, feature: NGeometryLayerItem) {
+function onLayerDrop(layer: NScenarioLayer, feature: NScenarioLayerItem) {
   onFeatureDrop({
     feature,
     destinationFeature: layer,
@@ -559,6 +620,20 @@ onMounted(() => {
         const destinationId = isScenarioFeatureLayerDragItem(destination.data)
           ? destination.data.layer.id
           : destination.data.mapLayer.id;
+        if (isScenarioFeatureLayerDragItem(source.data)) {
+          const sourceIsControlMeasure = isControlMeasureLayer(
+            source.data.layer as unknown as NScenarioOverlayLayer,
+          );
+          if (
+            !isScenarioFeatureLayerDragItem(destination.data) ||
+            sourceIsControlMeasure !==
+              isControlMeasureLayer(
+                destination.data.layer as unknown as NScenarioOverlayLayer,
+              )
+          ) {
+            return;
+          }
+        }
         if (sourceId !== destinationId) {
           const fromIndex = geo.getLayerIndex(sourceId);
           let toIndex = geo.getLayerIndex(destinationId);
@@ -624,10 +699,8 @@ onUnmounted(() => {
     </div>
 
     <!--
-      One top-level control-measures section, outside the layer tree. It renders only
-      once a control measure exists, and it is a real layer, so its header owns
-      visibility and lock. It sits below the tree because the tactical-draw stack draws
-      above every plain shape regardless of layer order (ADR-0006).
+      The control-measure stack sits below the feature/reference tree in the panel,
+      reflecting that tactical-draw renders the whole stack above plain geometry.
     -->
     <div v-if="controlMeasureGroups.length">
       <ControlMeasureLayer
@@ -637,6 +710,7 @@ onUnmounted(() => {
         :items="group.items"
         :layer-menu-items="controlMeasureLayerMenuItems"
         :item-menu-items="controlMeasureItemMenuItems"
+        v-model:activeLayerId="activeLayerId"
         v-model:editedLayerId="editedLayerId"
         @item-click="onFeatureClick"
         @item-double-click="onControlMeasureDoubleClick"

--- a/src/modules/scenarioeditor/controlMeasureAuthoring.test.ts
+++ b/src/modules/scenarioeditor/controlMeasureAuthoring.test.ts
@@ -61,7 +61,7 @@ const EDITED_POINTS = [
   [21, 71],
 ];
 
-function createScenario(): TScenario {
+function createScenario(layerStack?: any[]): TScenario {
   const store = useNewScenarioStore({
     id: "scenario-1",
     type: "ORBAT-mapper",
@@ -70,11 +70,12 @@ function createScenario(): TScenario {
     startTime: "2025-01-01T00:00:00Z",
     sides: [],
     events: [],
-    layerStack: [
+    layerStack: layerStack ?? [
       {
         id: "layer-1",
         kind: "overlay",
         name: "Control measures",
+        specialization: "controlMeasure",
         items: [
           {
             id: "cm-1",
@@ -102,10 +103,12 @@ function storedItem(scenario: TScenario, id = "cm-1"): any {
   return scenario.store.state.layerItemMap[id];
 }
 
-function setup(setupOptions: { realFeed?: boolean } = {}) {
+function setup(
+  setupOptions: { realFeed?: boolean; scenario?: TScenario; activeLayerId?: string } = {},
+) {
   const pinia = createPinia();
   setActivePinia(pinia);
-  const scenario = createScenario();
+  const scenario = setupOptions.scenario ?? createScenario();
   const fake = createTacticalDrawSurfaceFake({
     generateId: () => "cm-new",
     editControlPoints: EDITED_POINTS,
@@ -117,6 +120,7 @@ function setup(setupOptions: { realFeed?: boolean } = {}) {
     draw: fake.surface,
   });
   const exposed = {} as ReturnType<typeof useScenarioDraw>;
+  const activeLayerId = ref(setupOptions.activeLayerId ?? "layer-1");
   const wrapper = mount(
     defineComponent({
       setup() {
@@ -137,7 +141,7 @@ function setup(setupOptions: { realFeed?: boolean } = {}) {
         provide: {
           [activeScenarioKey as symbol]: scenario,
           [activeScenarioMapEngineKey as symbol]: engineRef,
-          [activeLayerKey as symbol]: ref("layer-1"),
+          [activeLayerKey as symbol]: activeLayerId,
           [activeNativeMapKey as symbol]: shallowRef(null),
           [activeFeatureSelectInteractionKey as symbol]: shallowRef(null),
         },
@@ -152,12 +156,147 @@ function setup(setupOptions: { realFeed?: boolean } = {}) {
     fake,
     feed: feedFake,
     draw: exposed,
+    activeLayerId,
     mutations: () => mutations,
   };
 }
 
 describe("drawing a control measure", () => {
   beforeEach(() => vi.clearAllMocks());
+
+  it("commits to the active unlocked control-measure layer", async () => {
+    const scenario = createScenario([
+      {
+        id: "feature-layer",
+        kind: "overlay",
+        name: "Features",
+        items: [],
+      },
+      {
+        id: "cm-top",
+        kind: "overlay",
+        name: "Top control measures",
+        specialization: "controlMeasure",
+        items: [],
+      },
+      {
+        id: "cm-active",
+        kind: "overlay",
+        name: "Active control measures",
+        specialization: "controlMeasure",
+        items: [],
+      },
+    ]);
+    const { draw, fake } = setup({ scenario, activeLayerId: "cm-active" });
+
+    draw.arm({ kind: "cmDraw", graphicKind: "phase-line" });
+    fake.drawSession!.commit();
+    await nextTick();
+    await nextTick();
+
+    expect(storedItem(scenario, "cm-new")._pid).toBe("cm-active");
+  });
+
+  it("creates and activates a specialized destination before the first draw", () => {
+    const scenario = createScenario([
+      { id: "feature-layer", kind: "overlay", name: "Features", items: [] },
+    ]);
+    const { draw, fake, activeLayerId } = setup({
+      scenario,
+      activeLayerId: "feature-layer",
+    });
+
+    draw.arm({ kind: "cmDraw", graphicKind: "phase-line" });
+
+    const created = scenario.geo.overlayLayers.value.find(
+      (layer) => layer.specialization === "controlMeasure",
+    );
+    expect(created).toMatchObject({ name: "Control measures", items: [] });
+    expect(activeLayerId.value).toBe(created?.id);
+    expect(fake.drawSession).not.toBeNull();
+  });
+
+  it("does not create another layer when every control-measure layer is locked", () => {
+    const scenario = createScenario([
+      {
+        id: "cm-locked",
+        kind: "overlay",
+        name: "Locked",
+        specialization: "controlMeasure",
+        locked: true,
+        items: [],
+      },
+    ]);
+    const { draw, fake } = setup({ scenario, activeLayerId: "cm-locked" });
+
+    draw.arm({ kind: "cmDraw", graphicKind: "phase-line" });
+
+    expect(scenario.geo.overlayLayers.value).toHaveLength(1);
+    expect(fake.drawSession).toBeNull();
+    expect(draw.armed.value).toEqual({ kind: "none" });
+  });
+
+  it("uses the topmost compatible layer, then restores last-used destinations by family", async () => {
+    const scenario = createScenario([
+      { id: "feature-a", kind: "overlay", name: "Feature A", items: [] },
+      { id: "feature-b", kind: "overlay", name: "Feature B", items: [] },
+      {
+        id: "cm-top",
+        kind: "overlay",
+        name: "CM top",
+        specialization: "controlMeasure",
+        items: [],
+      },
+      {
+        id: "cm-last",
+        kind: "overlay",
+        name: "CM last",
+        specialization: "controlMeasure",
+        items: [],
+      },
+    ]);
+    const { draw, activeLayerId } = setup({ scenario, activeLayerId: "feature-b" });
+
+    draw.arm({ kind: "cmDraw", graphicKind: "phase-line" });
+    expect(activeLayerId.value).toBe("cm-top");
+
+    activeLayerId.value = "cm-last";
+    await nextTick();
+    draw.startDrawing("Point");
+    expect(activeLayerId.value).toBe("feature-b");
+
+    draw.arm({ kind: "cmDraw", graphicKind: "phase-line" });
+    expect(activeLayerId.value).toBe("cm-last");
+  });
+
+  it("refuses to edit a control measure in a locked layer", () => {
+    const scenario = createScenario([
+      {
+        id: "cm-locked",
+        kind: "overlay",
+        name: "Locked",
+        specialization: "controlMeasure",
+        locked: true,
+        items: [
+          {
+            id: "cm-1",
+            kind: "tacticalGraphic",
+            graphicKind: "phase-line",
+            controlPoints: [
+              [10, 60],
+              [11, 61],
+            ],
+          },
+        ],
+      },
+    ]);
+    const { draw, fake } = setup({ scenario, activeLayerId: "cm-locked" });
+
+    draw.startControlMeasureEdit("cm-1");
+
+    expect(draw.armed.value).toEqual({ kind: "none" });
+    expect(fake.editSession).toBeNull();
+  });
 
   it("writes exactly once, on settle, and undoes as one step", async () => {
     const { draw, scenario, fake, mutations } = setup();

--- a/src/modules/scenarioeditor/controlMeasureDrawHelpers.test.ts
+++ b/src/modules/scenarioeditor/controlMeasureDrawHelpers.test.ts
@@ -130,6 +130,7 @@ describe("addScenarioControlMeasure", () => {
     const layers = scenario.geo.layersItems.value;
     expect(layers).toHaveLength(1);
     expect(layers[0].layer.name).toBe(CONTROL_MEASURE_LAYER_NAME);
+    expect(layers[0].layer.specialization).toBe("controlMeasure");
     expect(controlMeasureItems(scenario)).toHaveLength(1);
   });
 
@@ -151,6 +152,16 @@ describe("addScenarioControlMeasure", () => {
 
     scenario.store.undo();
 
+    expect(controlMeasureItems(scenario)).toHaveLength(0);
+    expect(scenario.geo.layersItems.value).toHaveLength(0);
+  });
+
+  it("does not silently redirect when an explicit destination no longer exists", () => {
+    const scenario = createScenario();
+
+    const added = addScenarioControlMeasure(scenario, measure(), {}, "deleted-layer");
+
+    expect(added).toBeUndefined();
     expect(controlMeasureItems(scenario)).toHaveLength(0);
     expect(scenario.geo.layersItems.value).toHaveLength(0);
   });

--- a/src/modules/scenarioeditor/controlMeasureDrawHelpers.ts
+++ b/src/modules/scenarioeditor/controlMeasureDrawHelpers.ts
@@ -144,12 +144,9 @@ export function toTacticalGraphicLayerItem(
 }
 
 /**
- * The layer a new control measure goes into: the first one that already holds control
- * measures, otherwise a freshly created "Control measures" layer.
- *
- * Created lazily rather than up front so a scenario that never gets one keeps the
- * stored model M1 landed untouched, and so the section only appears in the layers panel
- * once there is something in it. Returns `undefined` only when the write itself failed.
+ * Fallback for callers that do not pass the destination selected by the armed-tool
+ * owner: use the topmost specialized layer, otherwise create one explicitly specialized
+ * as a control-measure layer.
  */
 function getOrCreateControlMeasureLayerId(scenario: TScenario): FeatureId | undefined {
   const existing = getControlMeasureLayerGroups(scenario.geo.layersItems.value)[0];
@@ -157,6 +154,7 @@ function getOrCreateControlMeasureLayerId(scenario: TScenario): FeatureId | unde
   return scenario.geo.addLayer({
     id: nanoid(),
     name: CONTROL_MEASURE_LAYER_NAME,
+    specialization: "controlMeasure",
     items: [],
     _isNew: false,
   })?.id;
@@ -174,15 +172,15 @@ export function addScenarioControlMeasure(
   scenario: TScenario,
   measure: ControlMeasure,
   defaults: NewControlMeasureDefaults = {},
+  destinationLayerId?: FeatureId,
 ): TacticalGraphicLayerItem | undefined {
   const item = toTacticalGraphicLayerItem(measure, defaults);
   let added = false;
   scenario.store.groupUpdate(
     () => {
-      const layerId = getOrCreateControlMeasureLayerId(scenario);
+      const layerId = destinationLayerId ?? getOrCreateControlMeasureLayerId(scenario);
       if (!layerId) return;
-      scenario.geo.addFeature(item, layerId);
-      added = true;
+      added = Boolean(scenario.geo.addFeature(item, layerId));
     },
     { label: "addFeature", value: item.id },
   );

--- a/src/modules/scenarioeditor/controlMeasureLayers.test.ts
+++ b/src/modules/scenarioeditor/controlMeasureLayers.test.ts
@@ -13,6 +13,10 @@ function layer(id: string, itemIds: string[]): NScenarioOverlayLayer {
   return { id, kind: "overlay", name: id, items: itemIds } as NScenarioOverlayLayer;
 }
 
+function controlMeasureLayer(id: string, itemIds: string[]): NScenarioOverlayLayer {
+  return { ...layer(id, itemIds), specialization: "controlMeasure" };
+}
+
 function cm(
   id: string,
   graphicKind = "boundary",
@@ -43,6 +47,17 @@ function geometry(id: string): NScenarioLayerItem {
 }
 
 describe("getControlMeasureLayerGroups", () => {
+  it("includes an empty specialized control-measure layer", () => {
+    const preparedLayer = {
+      ...layer("prepared", []),
+      specialization: "controlMeasure" as const,
+    };
+
+    expect(getControlMeasureLayerGroups([{ layer: preparedLayer, items: [] }])).toEqual([
+      { layer: preparedLayer, items: [] },
+    ]);
+  });
+
   it("returns nothing when the scenario holds no control measures", () => {
     // Lazy by construction: no section, so the stored model stays untouched.
     expect(
@@ -54,7 +69,7 @@ describe("getControlMeasureLayerGroups", () => {
   });
 
   it("groups control measures under the layer that owns them, in store order", () => {
-    const l = layer("layer-1", ["g1", "cm1", "cm2"]);
+    const l = controlMeasureLayer("layer-1", ["g1", "cm1", "cm2"]);
     const groups = getControlMeasureLayerGroups([
       { layer: l, items: [geometry("g1"), cm("cm1"), cm("cm2")] },
     ]);
@@ -66,9 +81,9 @@ describe("getControlMeasureLayerGroups", () => {
 
   it("keeps one group per layer rather than hiding scattered control measures", () => {
     const groups = getControlMeasureLayerGroups([
-      { layer: layer("layer-1", ["cm1"]), items: [cm("cm1")] },
+      { layer: controlMeasureLayer("layer-1", ["cm1"]), items: [cm("cm1")] },
       { layer: layer("layer-2", ["g1"]), items: [geometry("g1")] },
-      { layer: layer("layer-3", ["cm2"]), items: [cm("cm2")] },
+      { layer: controlMeasureLayer("layer-3", ["cm2"]), items: [cm("cm2")] },
     ]);
 
     expect(groups.map((g) => g.layer.id)).toEqual(["layer-1", "layer-3"]);
@@ -77,12 +92,20 @@ describe("getControlMeasureLayerGroups", () => {
   it("lists an unsupported graphicKind alongside the supported ones", () => {
     const groups = getControlMeasureLayerGroups([
       {
-        layer: layer("layer-1", ["cm1", "cm2"]),
+        layer: controlMeasureLayer("layer-1", ["cm1", "cm2"]),
         items: [cm("cm1"), cm("cm2", "from-the-future")],
       },
     ]);
 
     expect(groups[0]!.items.map((i) => i.id)).toEqual(["cm1", "cm2"]);
+  });
+
+  it("does not infer specialization from tactical-graphic contents", () => {
+    expect(
+      getControlMeasureLayerGroups([
+        { layer: layer("unspecialized", ["cm1"]), items: [cm("cm1")] },
+      ]),
+    ).toEqual([]);
   });
 });
 

--- a/src/modules/scenarioeditor/controlMeasureLayers.ts
+++ b/src/modules/scenarioeditor/controlMeasureLayers.ts
@@ -11,10 +11,17 @@ import { isSupportedGraphicKind } from "@/scenariostore/tacticalGraphics";
 /**
  * The name a lazily created control-measures layer is given.
  *
- * Only M2's authoring path creates one; M1 renders whatever a loaded scenario
- * already carries.
+ * Used by implicit authoring creation; explicit panel creation uses the distinct
+ * "New control-measure layer" label.
  */
 export const CONTROL_MEASURE_LAYER_NAME = "Control measures";
+export const NEW_CONTROL_MEASURE_LAYER_NAME = "New control-measure layer";
+
+export function isControlMeasureLayer(
+  layer: Pick<NScenarioOverlayLayer, "specialization">,
+): boolean {
+  return layer.specialization === "controlMeasure";
+}
 
 /**
  * One control-measures section, backed by a real overlay layer.
@@ -29,17 +36,10 @@ export interface ControlMeasureLayerGroup {
 }
 
 /**
- * Resolve the control-measures section(s) from the store's layer/items pairs.
- *
- * Lazy by construction: a layer only appears here once it actually holds a
- * `tacticalGraphic` item, so a scenario without control measures renders no section
- * at all and the stored model from steps 1–2 stays untouched.
- *
- * Normally this returns exactly one group — control measures live in one host-created
- * layer. It returns several rather than one when a hand-authored or imported scenario
- * scattered them across layers: listing only the first would silently hide the rest,
- * and each group's header then owns the visibility and lock of the layer that actually
- * contains its items.
+ * Resolve every explicitly specialized control-measure layer from the store's
+ * layer/items pairs. Contents never determine identity, so empty layers remain visible
+ * and unspecialized layers stay feature layers even when malformed data contains a
+ * tactical graphic.
  *
  * The `layer` handed back is the store's own reactive object, not a copy, so the
  * section's open/closed state (`_isOpen`) survives the same way the layer tree's does.
@@ -49,11 +49,11 @@ export function getControlMeasureLayerGroups(
 ): ControlMeasureLayerGroup[] {
   const groups: ControlMeasureLayerGroup[] = [];
   for (const { layer, items } of layersItems) {
+    if (!isControlMeasureLayer(layer)) continue;
     const controlMeasures = items.filter(
       (item): item is NTacticalGraphicLayerItem =>
         !!item && isNTacticalGraphicLayerItem(item),
     );
-    if (!controlMeasures.length) continue;
     groups.push({ layer, items: controlMeasures });
   }
   return groups;

--- a/src/modules/scenarioeditor/featureLayerUtils.items.test.ts
+++ b/src/modules/scenarioeditor/featureLayerUtils.items.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { layerItemsToGeoJsonString } from "@/modules/scenarioeditor/featureLayerUtils";
 import { createScenarioLayerItemFeatures } from "@/modules/scenarioeditor/featureLayerUtilsOl";
-import type { AnnotationLayerItem, GeometryLayerItem } from "@/types/scenarioLayerItems";
+import type {
+  AnnotationLayerItem,
+  GeometryLayerItem,
+  TacticalGraphicLayerItem,
+} from "@/types/scenarioLayerItems";
 
 const geometryItem: GeometryLayerItem = {
   kind: "geometry",
@@ -48,5 +52,46 @@ describe("feature layer item adapters", () => {
     expect(parsed.features[0].id).toBe("feature-1");
     expect(parsed.features[0].geometry.type).toBe("Point");
     expect(parsed.features[0].properties.name).toBe("HQ");
+  });
+
+  it("exports every rendered part of a control measure", () => {
+    const controlMeasure: TacticalGraphicLayerItem = {
+      id: "cm-1",
+      kind: "tacticalGraphic",
+      graphicKind: "boundary",
+      controlPoints: [
+        [10, 60],
+        [11, 61],
+      ],
+      textAmplifiers: { T: "BLUE" },
+    };
+
+    const parsed = JSON.parse(layerItemsToGeoJsonString([controlMeasure])) as {
+      features: Array<{ properties: Record<string, unknown> }>;
+    };
+
+    expect(parsed.features.length).toBeGreaterThan(1);
+    expect(parsed.features.every((feature) => feature.properties.cmId === "cm-1")).toBe(
+      true,
+    );
+    expect(parsed.features[0]!.properties.graphicKind).toBe("boundary");
+  });
+
+  it("omits unsupported control measures and reports them", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const unsupported = {
+      id: "future-cm",
+      kind: "tacticalGraphic",
+      graphicKind: "future-kind",
+      controlPoints: [[10, 60]],
+    } as unknown as TacticalGraphicLayerItem;
+
+    const parsed = JSON.parse(layerItemsToGeoJsonString([unsupported])) as {
+      features: unknown[];
+    };
+
+    expect(parsed.features).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("future-kind"));
+    warn.mockRestore();
   });
 });

--- a/src/modules/scenarioeditor/featureLayerUtils.ts
+++ b/src/modules/scenarioeditor/featureLayerUtils.ts
@@ -1,6 +1,7 @@
 import { featureCollection } from "@turf/helpers";
 import turfCircle from "@turf/circle";
 import type { ScenarioFeature } from "@/types/scenarioGeoModels";
+import type { Feature, GeoJsonProperties, Geometry } from "geojson";
 import {
   IconLayersOutline,
   IconMapMarker,
@@ -16,8 +17,11 @@ import type { MenuItemData } from "@/components/types";
 import type { GeometryLayerItem, ScenarioLayerItem } from "@/types/scenarioLayerItems";
 import {
   isGeometryLayerItemLike,
+  isTacticalGraphicLayerItem,
   toGeometryLayerItemGeoJsonProperties,
 } from "@/types/scenarioLayerItems";
+import { isSupportedTacticalGraphic } from "@/scenariostore/tacticalGraphics";
+import { controlMeasureToGeoJsonFeatures } from "@/importexport/export/controlMeasureGeoJson";
 
 export const LayerTypes = {
   scenarioFeature: "SCENARIO_FEATURE",
@@ -51,9 +55,7 @@ const geometryIconMap: any = {
 };
 
 export type GeometryFeatureLike =
-  | GeometryLayerItem
-  | NGeometryLayerItem
-  | ScenarioFeature;
+  GeometryLayerItem | NGeometryLayerItem | ScenarioFeature;
 
 export function getGeometryKind(item: GeometryFeatureLike): string {
   return "geometryMeta" in item ? item.geometryMeta.geometryKind : item.meta.type;
@@ -112,34 +114,53 @@ export const featureMenuItems: MenuItemData<ScenarioFeatureActions>[] = [
 export function layerItemsToGeoJsonString(
   items: (ScenarioLayerItem | NGeometryLayerItem | ScenarioFeature)[],
 ) {
-  const fc = featureCollection(
-    items.filter(isGeometryFeatureLike).map((f) => {
-      const properties =
-        "geometryMeta" in f
-          ? toGeometryLayerItemGeoJsonProperties(f)
-          : {
-              name: f.meta.name,
-              description: f.meta.description,
-              ...f.properties,
-            };
-      const radius = getGeometryRadius(f);
-      if (
-        getGeometryKind(f) === "Circle" &&
-        radius !== undefined &&
-        f.geometry.type === "Point"
-      ) {
-        const poly = turfCircle(f.geometry.coordinates, radius, {
-          units: "meters",
-        });
-        return { ...poly, id: f.id, properties };
+  const features: Feature<Geometry, GeoJsonProperties>[] = [];
+  for (const item of items) {
+    if (isTacticalGraphicLayerItem(item)) {
+      const graphicKind = String(item.graphicKind);
+      if (!isSupportedTacticalGraphic(item)) {
+        console.warn(
+          `Unsupported control measure kind '${graphicKind}' omitted from GeoJSON export.`,
+        );
+        continue;
       }
-      return {
-        type: "Feature" as const,
-        id: f.id,
-        properties,
-        geometry: f.geometry,
-      };
-    }),
-  );
+      features.push(
+        ...controlMeasureToGeoJsonFeatures(item, {
+          includeId: true,
+          includeGeneratedLabels: true,
+        }),
+      );
+      continue;
+    }
+    if (!isGeometryFeatureLike(item)) continue;
+    const f = item;
+    const properties =
+      "geometryMeta" in f
+        ? toGeometryLayerItemGeoJsonProperties(f)
+        : {
+            name: f.meta.name,
+            description: f.meta.description,
+            ...f.properties,
+          };
+    const radius = getGeometryRadius(f);
+    if (
+      getGeometryKind(f) === "Circle" &&
+      radius !== undefined &&
+      f.geometry.type === "Point"
+    ) {
+      const poly = turfCircle(f.geometry.coordinates, radius, {
+        units: "meters",
+      });
+      features.push({ ...poly, id: f.id, properties });
+      continue;
+    }
+    features.push({
+      type: "Feature" as const,
+      id: f.id,
+      properties,
+      geometry: f.geometry,
+    });
+  }
+  const fc = featureCollection(features);
   return JSON.stringify(fc, null, 2);
 }

--- a/src/modules/scenarioeditor/useControlMeasureDrawSession.ts
+++ b/src/modules/scenarioeditor/useControlMeasureDrawSession.ts
@@ -55,6 +55,8 @@ export interface UseControlMeasureDrawSessionOptions {
    * `newControlMeasureDefaults`.
    */
   defaults?: (graphicKind: ControlMeasureKind) => NewControlMeasureDefaults;
+  /** The compatible layer selected when the session opens. */
+  destinationLayerId?: () => string | number | null | undefined;
   /**
    * A session ended on its own. The armed-tool owner decides what happens next —
    * re-arm on commit when `addMultiple`, disarm otherwise.
@@ -65,6 +67,8 @@ export interface UseControlMeasureDrawSessionOptions {
 export interface ControlMeasureDrawSession {
   /** Non-null exactly while a draw session is open. */
   readonly progress: Ref<ControlMeasureDrawProgress | null>;
+  /** Session-sticky destination, non-null exactly while a draw is open. */
+  readonly destinationLayerId: Ref<string | null>;
   /** Open a draw session for `graphicKind`. Supersedes whatever this owner had open. */
   start(graphicKind: ControlMeasureKind): void;
   /** Give up ownership of any open session without committing. */
@@ -77,6 +81,7 @@ export function useControlMeasureDrawSession(
   options: UseControlMeasureDrawSessionOptions,
 ): ControlMeasureDrawSession {
   const progress = shallowRef<ControlMeasureDrawProgress | null>(null);
+  const openDestinationLayerId = shallowRef<string | null>(null);
 
   // Bumped by every `start`/`stop`, and captured by each session's callbacks. A
   // `draw()` promise settles a microtask after the abort that caused it, so without
@@ -103,27 +108,35 @@ export function useControlMeasureDrawSession(
     generation += 1;
     session = null;
     progress.value = null;
+    openDestinationLayerId.value = null;
   }
 
   async function finish(
     token: number,
     graphicKind: ControlMeasureKind,
     measure: Parameters<typeof addScenarioControlMeasure>[1] | null,
+    destinationLayerId?: string | number | null,
   ) {
     if (token !== generation) return;
     // Cleared before the write, so the settle this write's re-render triggers does not
     // try to cancel a session that has already settled.
     session = null;
     progress.value = null;
+    openDestinationLayerId.value = null;
     if (!measure) {
       options.onSettled({ committed: false, graphicKind });
       return;
     }
-    addScenarioControlMeasure(
+    const added = addScenarioControlMeasure(
       options.scenario,
       measure,
       options.defaults?.(graphicKind) ?? {},
+      destinationLayerId == null ? undefined : String(destinationLayerId),
     );
+    if (!added) {
+      options.onSettled({ committed: false, graphicKind });
+      return;
+    }
     // Required by the library's contract, not an optimisation: it hands the override
     // back and expects the host's next render to be authoritative.
     options.renderFeed?.render("commit");
@@ -138,8 +151,11 @@ export function useControlMeasureDrawSession(
   function start(graphicKind: ControlMeasureKind) {
     stop();
     const token = generation;
+    const destinationLayerId = options.destinationLayerId?.();
     const surface = options.surface();
     if (!surface) return;
+    openDestinationLayerId.value =
+      destinationLayerId == null ? null : String(destinationLayerId);
     const draft = {
       kind: graphicKind,
       options: draftOptionsForNewControlMeasure(graphicKind),
@@ -165,14 +181,16 @@ export function useControlMeasureDrawSession(
           });
         },
       })
-      .then((snapshot) => finish(token, graphicKind, snapshot.graphic))
+      .then((snapshot) =>
+        finish(token, graphicKind, snapshot.graphic, destinationLayerId),
+      )
       .catch((error) => {
         // Abort is the normal way a draw ends — Escape, another tool armed, a basemap
         // swap mid-gesture. Nothing is written and nothing is reported.
         if (!isTacticalDrawAbortError(error)) {
           console.error("[controlMeasureDraw] draw session failed", error);
         }
-        return finish(token, graphicKind, null);
+        return finish(token, graphicKind, null, destinationLayerId);
       });
   }
 
@@ -191,6 +209,7 @@ export function useControlMeasureDrawSession(
 
   return {
     progress,
+    destinationLayerId: openDestinationLayerId,
     start,
     stop,
     commit: () => session?.commit() ?? false,

--- a/src/modules/scenarioeditor/useScenarioClipboardImport.ts
+++ b/src/modules/scenarioeditor/useScenarioClipboardImport.ts
@@ -37,16 +37,19 @@ export function useScenarioClipboardImport(options: ScenarioClipboardImportOptio
   } = options;
 
   function getTargetLayerId() {
-    if (
-      activeLayerId.value &&
-      state.layerStackMap[activeLayerId.value]?.kind === "overlay"
-    ) {
+    const isWritableFeatureLayer = (layerId: FeatureId) => {
+      const layer = state.layerStackMap[layerId];
+      return (
+        layer?.kind === "overlay" &&
+        layer.specialization !== "controlMeasure" &&
+        !layer.locked
+      );
+    };
+    if (activeLayerId.value && isWritableFeatureLayer(activeLayerId.value)) {
       return activeLayerId.value;
     }
 
-    return state.layerStack.find(
-      (layerId) => state.layerStackMap[layerId]?.kind === "overlay",
-    );
+    return state.layerStack.find(isWritableFeatureLayer);
   }
 
   function pasteGeoJSON(data: unknown) {
@@ -85,9 +88,18 @@ export function useScenarioClipboardImport(options: ScenarioClipboardImportOptio
     const addedFeatureIds: string[] = [];
     groupUpdate(() => {
       importedFeatures.forEach((feature) => {
-        addedFeatureIds.push(geo.addFeature(feature, targetLayerId));
+        const addedFeatureId = geo.addFeature(feature, targetLayerId);
+        if (addedFeatureId) addedFeatureIds.push(addedFeatureId);
       });
     });
+
+    if (!addedFeatureIds.length) {
+      send({
+        message: "No writable feature layer available for pasted GeoJSON",
+        type: "error",
+      });
+      return false;
+    }
 
     clearSelection();
     activeFeatureId.value = addedFeatureIds[0];

--- a/src/modules/scenarioeditor/useScenarioDraw.ts
+++ b/src/modules/scenarioeditor/useScenarioDraw.ts
@@ -27,7 +27,7 @@ import {
   activeFeatureSelectInteractionKey,
   activeNativeMapKey,
 } from "@/modules/scenarioeditor/olInjects";
-import { injectStrict } from "@/utils";
+import { injectStrict, nanoid } from "@/utils";
 import { useEditingInteraction, type DrawType } from "@/composables/geoEditing";
 import { useMapLibreDrawInteraction } from "@/composables/maplibreDrawInteraction";
 import { useMainToolbarStore } from "@/stores/mainToolbarStore";
@@ -58,6 +58,11 @@ import {
   type TacticalGraphicLayerItemUpdate,
 } from "@/types/scenarioLayerItems";
 import type { FeatureId } from "@/types/scenarioGeoModels";
+import { useNotifications } from "@/composables/notifications";
+import {
+  CONTROL_MEASURE_LAYER_NAME,
+  isControlMeasureLayer,
+} from "@/modules/scenarioeditor/controlMeasureLayers";
 
 /**
  * What the map is currently armed with — one union, one writer.
@@ -182,6 +187,7 @@ export function useScenarioDraw(options: UseScenarioDrawOptions = {}) {
   const controlMeasureToolStore = useControlMeasureToolStore();
   const { isRecordingGeometry } = storeToRefs(recordingStore);
   const mapSelectStore = useMapSelectStore();
+  const { send: notify } = useNotifications();
 
   const snap = ref(true);
   const translate = ref(false);
@@ -200,6 +206,87 @@ export function useScenarioDraw(options: UseScenarioDrawOptions = {}) {
   );
 
   const armed = shallowRef<ArmedTool>({ kind: "none" });
+  const lastUsedFeatureLayerId = ref<FeatureId | null>(null);
+  const lastUsedControlMeasureLayerId = ref<FeatureId | null>(null);
+
+  function overlayLayers() {
+    return (
+      activeScenario.geo.overlayLayers?.value ??
+      activeScenario.geo.layerItemsLayers?.value ??
+      []
+    );
+  }
+
+  function getOverlayLayer(layerId: FeatureId | null | undefined) {
+    if (layerId == null) return undefined;
+    return overlayLayers().find((layer) => layer.id === layerId);
+  }
+
+  function isCompatibleUnlockedLayer(
+    layerId: FeatureId | null | undefined,
+    family: "feature" | "controlMeasure",
+  ) {
+    const candidate = getOverlayLayer(layerId);
+    if (!candidate || candidate.locked) return false;
+    return family === "controlMeasure"
+      ? isControlMeasureLayer(candidate)
+      : !isControlMeasureLayer(candidate);
+  }
+
+  watch(
+    activeLayerIdRef,
+    (layerId) => {
+      const activeLayer = getOverlayLayer(layerId);
+      if (!activeLayer) return;
+      if (isControlMeasureLayer(activeLayer)) {
+        lastUsedControlMeasureLayerId.value = activeLayer.id;
+      } else {
+        lastUsedFeatureLayerId.value = activeLayer.id;
+      }
+    },
+    { immediate: true },
+  );
+
+  function selectAuthoringLayer(family: "feature" | "controlMeasure"): boolean {
+    // Compatibility for lightweight injected test/host doubles that predate the
+    // canonical overlay collection. The production store always exposes both.
+    if (!activeScenario.geo.overlayLayers && !activeScenario.geo.addLayer) return true;
+    if (isCompatibleUnlockedLayer(activeLayerIdRef.value, family)) return true;
+    const remembered =
+      family === "controlMeasure"
+        ? lastUsedControlMeasureLayerId.value
+        : lastUsedFeatureLayerId.value;
+    if (isCompatibleUnlockedLayer(remembered, family)) {
+      activeLayerIdRef.value = remembered;
+      return true;
+    }
+    const compatibleLayers = overlayLayers().filter((layer) =>
+      family === "controlMeasure"
+        ? isControlMeasureLayer(layer)
+        : !isControlMeasureLayer(layer),
+    );
+    const topmostUnlocked = compatibleLayers.find((layer) => !layer.locked);
+    if (topmostUnlocked) {
+      activeLayerIdRef.value = topmostUnlocked.id;
+      return true;
+    }
+    if (family === "feature") return false;
+    if (compatibleLayers.length > 0) {
+      notify({ message: "Unlock or add a control-measure layer to draw." });
+      return false;
+    }
+    const created = activeScenario.geo.addLayer({
+      id: nanoid(),
+      name: CONTROL_MEASURE_LAYER_NAME,
+      specialization: "controlMeasure",
+      items: [],
+      _isNew: false,
+    });
+    if (!created) return false;
+    activeLayerIdRef.value = created.id;
+    lastUsedControlMeasureLayerId.value = created.id;
+    return true;
+  }
 
   // Selection suppression snapshots rather than force-enables. This composable used to
   // die with the draw toolbar, so writing `true` on disarm was harmless; hoisted, it
@@ -430,6 +517,7 @@ export function useScenarioDraw(options: UseScenarioDrawOptions = {}) {
     // creation and its façade on every basemap swap.
     surface: () => engineRef.value?.draw,
     renderFeed,
+    destinationLayerId: () => activeLayerIdRef.value,
     // Session-sticky UI state, read per session rather than captured: a default changed
     // between two draws applies to the second one. Narrowed per kind, because authored
     // colour is offered for the Generic Graphics kinds only.
@@ -530,6 +618,19 @@ export function useScenarioDraw(options: UseScenarioDrawOptions = {}) {
    * there is exactly one settle mechanism.
    */
   function arm(tool: ArmedTool) {
+    if (tool.kind === "cmEdit") {
+      const item = activeScenario.geo.getLayerItemById(tool.featureId).layerItem;
+      const owner = item ? getOverlayLayer(item._pid) : undefined;
+      if (!item || item.locked || owner?.locked) tool = { kind: "none" };
+    }
+    if (tool.kind === "cmDraw" && !selectAuthoringLayer("controlMeasure")) {
+      tool = { kind: "none" };
+    } else if (
+      (tool.kind === "plainDraw" || tool.kind === "plainModify") &&
+      !selectAuthoringLayer("feature")
+    ) {
+      tool = { kind: "none" };
+    }
     // An open **edit** settles by folding its work into the store, and that write does
     // not always reach the feed synchronously: with geometry recording on the fold goes
     // through `addTacticalGraphicStateControlPoints`, which signals only via
@@ -843,6 +944,7 @@ export function useScenarioDraw(options: UseScenarioDrawOptions = {}) {
     isDrawing,
     /** Non-null exactly while a control-measure draw session is open. */
     controlMeasureDrawProgress: controlMeasureDraw.progress,
+    controlMeasureDrawDestinationLayerId: controlMeasureDraw.destinationLayerId,
     commitControlMeasureDraw: () => controlMeasureDraw.commit(),
     /** Non-null exactly while a control-measure edit session is open. */
     controlMeasureEditFeatureId: controlMeasureEdit.featureId,

--- a/src/modules/scenarioeditor/useScenarioRouting.ts
+++ b/src/modules/scenarioeditor/useScenarioRouting.ts
@@ -517,8 +517,19 @@ export function useScenarioRouting(
       routingStore.setError("Finish at least one routed leg before saving a route.");
       return false;
     }
-    const targetLayerId =
-      activeLayerId.value ?? activeScenario.geo.layerItemsLayers.value[0]?.id;
+    const writableFeatureLayers = activeScenario.geo.layerItemsLayers.value.filter(
+      (layer) => layer.specialization !== "controlMeasure" && !layer.locked,
+    );
+    const currentLayer = activeLayerId.value
+      ? activeScenario.geo.getLayerById(activeLayerId.value)
+      : undefined;
+    const activeLayer =
+      currentLayer &&
+      currentLayer.specialization !== "controlMeasure" &&
+      !currentLayer.locked
+        ? currentLayer
+        : undefined;
+    const targetLayerId = activeLayer?.id ?? writableFeatureLayers[0]?.id;
     const targetLayer = targetLayerId
       ? activeScenario.geo.getLayerById(targetLayerId)
       : null;

--- a/src/scenariostore/geo.ts
+++ b/src/scenariostore/geo.ts
@@ -390,8 +390,10 @@ export function useGeo(store: NewScenarioStore) {
   }
 
   function moveFeature(featureId: FeatureId, toIndex: number) {
-    const feature = getGeometryLayerItemFromMap(state.layerItemMap, featureId);
+    const feature = state.layerItemMap[featureId];
     if (!feature) return;
+    const owner = getOverlayLayerFromMap(state.layerStackMap, feature._pid);
+    if (!owner || owner.locked || feature.locked) return;
 
     update(
       (s) => {
@@ -400,9 +402,8 @@ export function useGeo(store: NewScenarioStore) {
         const fromIndex = layer.items.indexOf(String(featureId));
         moveItemMutable(layer.items, fromIndex, toIndex);
         layer.items.forEach((fid, i) => {
-          const feature = getGeometryLayerItemFromMap(s.layerItemMap, fid);
-          if (!feature) return;
-          if (feature._zIndex !== i) feature._zIndex = i;
+          const item = s.layerItemMap[fid];
+          if (item?.kind === "geometry" && item._zIndex !== i) item._zIndex = i;
         });
       },
       { label: "moveFeature", value: featureId },
@@ -415,11 +416,8 @@ export function useGeo(store: NewScenarioStore) {
     destinationFeatureOrLayerId: FeatureId,
     target: DropTarget,
   ) {
-    const feature = getGeometryLayerItemFromMap(state.layerItemMap, featureId);
-    const destinationFeature = getGeometryLayerItemFromMap(
-      state.layerItemMap,
-      destinationFeatureOrLayerId,
-    );
+    const feature = state.layerItemMap[featureId];
+    const destinationFeature = state.layerItemMap[destinationFeatureOrLayerId];
     const destinationLayerId = destinationFeature?._pid ?? destinationFeatureOrLayerId;
     if (!feature) return;
     const layer = getOverlayLayerFromMap(state.layerStackMap, feature._pid);
@@ -428,6 +426,11 @@ export function useGeo(store: NewScenarioStore) {
       destinationLayerId,
     );
     if (!layer || !destinationLayer) return;
+    if (layer.locked || destinationLayer.locked || feature.locked) return;
+    const itemNeedsControlMeasureLayer = feature.kind === "tacticalGraphic";
+    const destinationIsControlMeasureLayer =
+      destinationLayer.specialization === "controlMeasure";
+    if (itemNeedsControlMeasureLayer !== destinationIsControlMeasureLayer) return;
 
     const toIndex = destinationLayer.items.indexOf(String(destinationFeatureOrLayerId));
     if (layer.id === destinationLayer.id) {
@@ -454,9 +457,7 @@ export function useGeo(store: NewScenarioStore) {
           } else {
             toLayer.items.push(String(featureId));
           }
-          if (f.kind === "geometry") {
-            (f as NGeometryLayerItem)._pid = toLayer.id;
-          }
+          f._pid = toLayer.id;
         },
         { label: "moveFeature", value: featureId },
       );
@@ -612,6 +613,15 @@ export function useGeo(store: NewScenarioStore) {
     if (!newFeature.id) newFeature.id = nanoid();
     if (!newFeature.kind) (newFeature as NGeometryLayerItem).kind = "geometry";
     newFeature._pid = layerId;
+    const destination = getOverlayLayerFromMap(state.layerStackMap, layerId);
+    if (!destination || destination.locked) return;
+    const requiresControlMeasureLayer = newFeature.kind === "tacticalGraphic";
+    if (
+      requiresControlMeasureLayer !==
+      (destination.specialization === "controlMeasure")
+    ) {
+      return;
+    }
     update(
       (s) => {
         const layer = getOverlayLayerFromMap(s.layerStackMap, layerId);
@@ -638,6 +648,8 @@ export function useGeo(store: NewScenarioStore) {
     const noEmit = options.noEmit ?? false;
     const feature = state.layerItemMap[featureId];
     if (!feature) return;
+    const owner = getOverlayLayerFromMap(state.layerStackMap, feature._pid);
+    if (owner?.locked || feature.locked) return;
     update(
       (s) => {
         const layer = getOverlayLayerFromMap(s.layerStackMap, feature._pid);
@@ -652,11 +664,13 @@ export function useGeo(store: NewScenarioStore) {
   }
 
   function duplicateFeature(featureId: FeatureId) {
-    const feature = getGeometryLayerItemFromMap(state.layerItemMap, featureId);
+    const feature = state.layerItemMap[featureId];
     if (!feature) return;
-    const shallowCopy = { ...feature };
-    shallowCopy.id = nanoid();
-    return addFeature(shallowCopy, feature._pid);
+    const owner = getOverlayLayerFromMap(state.layerStackMap, feature._pid);
+    if (!owner || owner.locked || feature.locked) return;
+    const copy = klona(feature);
+    copy.id = nanoid();
+    return addFeature(copy, feature._pid);
   }
 
   function updateFeature(
@@ -667,6 +681,11 @@ export function useGeo(store: NewScenarioStore) {
     const undoable = options.undoable ?? true;
     const noEmit = options.noEmit ?? false;
     const isGeometry = data.geometry !== undefined;
+    const currentFeature = getGeometryLayerItemFromMap(state.layerItemMap, featureId);
+    const currentOwner = currentFeature
+      ? getOverlayLayerFromMap(state.layerStackMap, currentFeature._pid)
+      : undefined;
+    if (!currentFeature || currentFeature.locked || currentOwner?.locked) return;
     if (undoable) {
       update(
         (s) => {
@@ -770,6 +789,8 @@ export function useGeo(store: NewScenarioStore) {
     // for the whole draft.
     const apply = (item: NScenarioLayerItem | undefined, currentTime: number) => {
       if (!item) return;
+      const owner = getOverlayLayerFromMap(state.layerStackMap, item._pid);
+      if (owner?.locked || item.locked) return;
       Object.entries(data).forEach(([key, value]) => {
         if (value === undefined) return;
         (item as unknown as Record<string, unknown>)[key] = value;
@@ -817,6 +838,8 @@ export function useGeo(store: NewScenarioStore) {
     // for the whole draft.
     const apply = (item: NScenarioLayerItem | undefined) => {
       if (!item || !isNTacticalGraphicLayerItem(item)) return;
+      const owner = getOverlayLayerFromMap(state.layerStackMap, item._pid);
+      if (owner?.locked || item.locked) return;
       TACTICAL_GRAPHIC_UPDATE_FIELDS.forEach((field) => {
         const value = data[field];
         if (value === undefined) return;
@@ -856,6 +879,8 @@ export function useGeo(store: NewScenarioStore) {
       (s) => {
         const item = s.layerItemMap[itemId];
         if (!item || !isNTacticalGraphicLayerItem(item)) return;
+        const owner = getOverlayLayerFromMap(s.layerStackMap, item._pid);
+        if (owner?.locked || item.locked) return;
         const t = atTime ?? s.currentTime;
         const nextState = [...(item.state ?? [])];
         for (let i = 0, len = nextState.length; i < len; i++) {

--- a/src/scenariostore/layerItemRoundTrip.test.ts
+++ b/src/scenariostore/layerItemRoundTrip.test.ts
@@ -61,6 +61,48 @@ function storeItem(store: ReturnType<typeof loadStore>, id: string) {
 }
 
 describe("layer item round trip", () => {
+  it("preserves an empty control-measure layer specialization", () => {
+    const scenario = loadControlMeasureScenarioFixture();
+    scenario.layerStack.push({
+      id: "empty-cm-layer",
+      kind: "overlay",
+      name: "Prepared control measures",
+      specialization: "controlMeasure",
+      items: [],
+    });
+
+    const serialized = serialize(loadStore(scenario));
+    const layer = serialized.layerStack.find(
+      (candidate) => candidate.id === "empty-cm-layer",
+    );
+
+    expect(layer).toMatchObject({
+      kind: "overlay",
+      specialization: "controlMeasure",
+      items: [],
+    });
+  });
+
+  it("preserves mismatched content and warns without rewriting it", () => {
+    const scenario = loadControlMeasureScenarioFixture();
+    const overlay = scenario.layerStack.find(
+      (layer) =>
+        layer.kind === "overlay" && layer.items.some((item) => item.kind === "geometry"),
+    )!;
+    if (overlay.kind !== "overlay") throw new Error("Expected overlay fixture");
+    overlay.specialization = "controlMeasure";
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const serialized = serialize(loadStore(scenario));
+    const loadedOverlay = serialized.layerStack.find((layer) => layer.id === overlay.id)!;
+    if (loadedOverlay.kind !== "overlay") throw new Error("Expected overlay round trip");
+
+    expect(loadedOverlay.items.some((item) => item.kind === "geometry")).toBe(true);
+    expect(loadedOverlay.specialization).toBe("controlMeasure");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("mismatched items"));
+    warn.mockRestore();
+  });
+
   it("keeps every item of every kind, in order, across a save and load", () => {
     const first = loadStore(loadControlMeasureScenarioFixture());
     const serialized = serialize(first);

--- a/src/scenariostore/upgrade.test.ts
+++ b/src/scenariostore/upgrade.test.ts
@@ -129,7 +129,7 @@ describe("upgradeScenarioIfNecessary", () => {
     expect(getOverlayLayers(upgraded)[0]).not.toHaveProperty("features");
   });
 
-  it("keeps annotation, tacticalGraphic and measurement items without warning", () => {
+  it("keeps mixed items and warns about tactical graphics in an unspecialized layer", () => {
     const feature = createFeature();
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const scenario = createScenario({
@@ -186,7 +186,8 @@ describe("upgradeScenarioIfNecessary", () => {
       "tacticalGraphic-1",
       "measurement-1",
     ]);
-    expect(warnSpy).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toContain("mismatched items");
   });
 
   it("warns once for the whole scenario about unsupported graphicKinds", () => {
@@ -231,9 +232,12 @@ describe("upgradeScenarioIfNecessary", () => {
     // Stored verbatim, never dropped and never replaced by a placeholder.
     expect(getOverlayLayers(upgraded)[0].items).toHaveLength(2);
     expect(getOverlayLayers(upgraded)[1].items).toHaveLength(1);
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toContain("from-the-future=2");
-    expect(warnSpy.mock.calls[0][0]).toContain("also-unknown=1");
+    const unsupportedWarning = warnSpy.mock.calls.find(([message]) =>
+      String(message).includes("Unsupported control measure kinds"),
+    );
+    expect(unsupportedWarning).toBeDefined();
+    expect(unsupportedWarning![0]).toContain("from-the-future=2");
+    expect(unsupportedWarning![0]).toContain("also-unknown=1");
   });
 
   it("still drops items whose kind is entirely unknown", () => {

--- a/src/scenariostore/upgrade.ts
+++ b/src/scenariostore/upgrade.ts
@@ -297,6 +297,20 @@ function canonicalizeOverlayLayer(
     );
   }
 
+  const isControlMeasureLayer =
+    (rest as { specialization?: string }).specialization === "controlMeasure";
+  const mismatchedItemCount = canonicalItems.filter((item) =>
+    isControlMeasureLayer
+      ? item.kind !== "tacticalGraphic"
+      : item.kind === "tacticalGraphic",
+  ).length;
+  if (mismatchedItemCount > 0) {
+    console.warn(
+      `Layer "${layer.name}" (${layer.id}) contains ${mismatchedItemCount} mismatched items for its specialization. ` +
+        `They were preserved but the editor will not author more mixed content.`,
+    );
+  }
+
   return { ...rest, id: String(rest.id), kind: "overlay", items: canonicalItems };
 }
 

--- a/src/testdata/controlMeasureScenario.test.ts
+++ b/src/testdata/controlMeasureScenario.test.ts
@@ -64,9 +64,13 @@ describe("control measure fixture — load", () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     loadFixture();
 
-    // Aggregated: one message per load, not one per item and not one per layer.
-    expect(warn).toHaveBeenCalledTimes(1);
-    expect(warn.mock.calls[0]![0]).toContain("phase-line-from-the-future=1");
+    // Unsupported kinds remain aggregated into one message even when specialization
+    // mismatch warnings are also emitted for affected legacy layers.
+    const unsupportedWarnings = warn.mock.calls.filter(([message]) =>
+      String(message).includes("Unsupported control measure kinds"),
+    );
+    expect(unsupportedWarnings).toHaveLength(1);
+    expect(unsupportedWarnings[0]![0]).toContain("phase-line-from-the-future=1");
     warn.mockRestore();
   });
 

--- a/src/types/draggables.ts
+++ b/src/types/draggables.ts
@@ -1,10 +1,5 @@
-import type {
-  NGeometryLayerItem,
-  NScenarioLayer,
-  NSide,
-  NSideGroup,
-  NUnit,
-} from "@/types/internalModels";
+import type { NScenarioLayer, NSide, NSideGroup, NUnit } from "@/types/internalModels";
+import type { NScenarioLayerItem } from "@/types/scenarioLayerItems";
 import type { ScenarioMapLayer } from "@/types/scenarioGeoModels";
 import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
 
@@ -26,7 +21,7 @@ export type UnitDragItemSource = "orbatTree" | "breadcrumbs" | "detailsPanel";
 
 export type ScenarioFeatureDragItem = {
   [privateKey]: boolean;
-  feature: NGeometryLayerItem;
+  feature: NScenarioLayerItem;
 };
 
 export type ScenarioFeatureLayerDragItem = {

--- a/src/types/scenarioLayerItems.ts
+++ b/src/types/scenarioLayerItems.ts
@@ -494,7 +494,11 @@ export type ScenarioLayerItemState =
   | TacticalGraphicLayerItemState
   | MeasurementLayerItemState;
 
+export type ScenarioLayerSpecialization = "controlMeasure";
+
 export interface ScenarioLayerItemsLayer extends Omit<ScenarioLayer, "features"> {
+  /** Optional authoring restriction. Omitted layers retain existing feature behavior. */
+  specialization?: ScenarioLayerSpecialization;
   items: ScenarioLayerItem[];
 }
 


### PR DESCRIPTION
## Summary

- persist optional control-measure layer specialization and support multiple dedicated layers
- route authoring to compatible unlocked layers while preserving unspecialized layers for future mixed content
- add standard layer/item interactions, locking, ordering, deletion fallback, and rendered GeoJSON export
- align control-measure item drag handles with ordinary layer items

## Verification

- `pnpm type-check`
- `pnpm exec vitest run --reporter=dot` — 1,523 passed, 5 skipped

Closes #651