### PR TITLE
Fix mobile freehand drawing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed freehand line and polygon drawing on touch devices in MapLibre mode.
 - Fixed the ORBAT panel opening again when you select a unit on the map in desktop mode. A closed panel now stays closed. Search, the locate shortcut, and "Locate in ORBAT" still open the panel and show the unit in the tree.
 - Fixed right-clicking a unit track in MapLibre edit mode, which inserted a via point and started dragging it instead of opening the context menu.
 - Fixed symbol changes from unit events not showing in MapLibre mode, the ORBAT chart, unit search results, or the map context menus, which all drew the base unit symbol instead of the symbol at the current time.

--- a/src/composables/maplibreDrawInteraction.test.ts
+++ b/src/composables/maplibreDrawInteraction.test.ts
@@ -552,6 +552,29 @@ describe("useMapLibreDrawInteraction", () => {
     );
   });
 
+  it("creates a freehand line from touch drag samples", () => {
+    const harness = createHarness({ freehand: true });
+
+    harness.draw.startDrawing("LineString");
+    harness.trigger("touchstart", createEvent(1, 2));
+    harness.trigger("touchmove", createEvent(2, 3));
+    harness.trigger("touchmove", createEvent(3, 4));
+    harness.trigger("touchend", createEvent(3, 4));
+
+    expect(harness.addFeature).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        geometry: {
+          type: "LineString",
+          coordinates: [
+            [1, 2],
+            [2, 3],
+            [3, 4],
+          ],
+        },
+      }),
+    );
+  });
+
   it("finishes a line drawing with a mobile double tap", () => {
     const harness = createHarness();
 

--- a/src/composables/maplibreDrawInteraction.ts
+++ b/src/composables/maplibreDrawInteraction.ts
@@ -343,6 +343,15 @@ export function useMapLibreDrawInteraction(
   }
 
   function onTouchMove(e: MapTouchEvent) {
+    if (
+      isDrawing.value &&
+      unref(options.freehand) &&
+      (currentDrawType.value === "LineString" || currentDrawType.value === "Polygon")
+    ) {
+      suppressMapEvent(e);
+      appendFreehandVertex(getEventPosition(e));
+      return;
+    }
     // MapLibre does not synthesize "mousemove" from touch, so without this the
     // vertex/midpoint/translate drag has no live preview until the finger lifts.
     if (!dragState) return;


### PR DESCRIPTION
## Summary

- sample MapLibre touch-move events during freehand line and polygon drawing
- add regression coverage for a touch-drawn freehand line
- document the fix in the July 2026 changelog

## Verification

- `pnpm vitest run src/composables/maplibreDrawInteraction.test.ts`
- `pnpm type-check`
- `git diff --check`