### PR TITLE
Disarm unavailable control-measure draws

### DIFF
--- a/src/modules/scenarioeditor/useControlMeasureDrawSession.ts
+++ b/src/modules/scenarioeditor/useControlMeasureDrawSession.ts
@@ -69,8 +69,8 @@ export interface ControlMeasureDrawSession {
   readonly progress: Ref<ControlMeasureDrawProgress | null>;
   /** Session-sticky destination, non-null exactly while a draw is open. */
   readonly destinationLayerId: Ref<string | null>;
-  /** Open a draw session for `graphicKind`. Supersedes whatever this owner had open. */
-  start(graphicKind: ControlMeasureKind): void;
+  /** Open a draw session for `graphicKind`. `false` when no surface is available. */
+  start(graphicKind: ControlMeasureKind): boolean;
   /** Give up ownership of any open session without committing. */
   stop(): void;
   /** Finish the open session if it has enough points. `false` when it does not. */
@@ -153,7 +153,7 @@ export function useControlMeasureDrawSession(
     const token = generation;
     const destinationLayerId = options.destinationLayerId?.();
     const surface = options.surface();
-    if (!surface) return;
+    if (!surface) return false;
     openDestinationLayerId.value =
       destinationLayerId == null ? null : String(destinationLayerId);
     const draft = {
@@ -192,6 +192,7 @@ export function useControlMeasureDrawSession(
         }
         return finish(token, graphicKind, null, destinationLayerId);
       });
+    return true;
   }
 
   // The settle-first guard's draw disposition: a `DrawSession` has no way to keep

--- a/src/modules/scenarioeditor/useScenarioDraw.test.ts
+++ b/src/modules/scenarioeditor/useScenarioDraw.test.ts
@@ -424,6 +424,23 @@ describe("useScenarioDraw", () => {
     expect(mapSelectStore.selectionSuppressed).toBe(false);
   });
 
+  it("disarms when the tactical-draw surface disappears before a deferred draw starts", async () => {
+    const { draw, engineRef } = mountHarness();
+    engineRef.value = createEngine();
+    await nextTick();
+    const mapSelectStore = useMapSelectStore();
+
+    draw.arm({ kind: "cmEdit", featureId: "cm-1" });
+    draw.arm({ kind: "cmDraw", graphicKind: "phase-line" });
+    engineRef.value = undefined;
+    await nextTick();
+    await nextTick();
+
+    expect(draw.controlMeasureDrawProgress.value).toBeNull();
+    expect(draw.armed.value).toEqual({ kind: "none" });
+    expect(mapSelectStore.selectionSuppressed).toBe(false);
+  });
+
   it("settles the render feed when a tool is armed", async () => {
     const renderFeed = createRenderFeed();
     const { draw, engineRef } = mountHarness({ renderFeed });

--- a/src/modules/scenarioeditor/useScenarioDraw.ts
+++ b/src/modules/scenarioeditor/useScenarioDraw.ts
@@ -582,7 +582,9 @@ export function useScenarioDraw(options: UseScenarioDrawOptions = {}) {
       // whatever it armed has already opened its own session.
       if (armed.value !== tool) return;
       if (tool.kind === "cmDraw") {
-        controlMeasureDraw.start(tool.graphicKind);
+        // The surface can disappear while an edit's replacement is deferred. Do not
+        // leave a draw tool armed at no session with map selection suppressed.
+        if (!controlMeasureDraw.start(tool.graphicKind)) armed.value = { kind: "none" };
       } else if (tool.kind === "cmEdit") {
         // Nothing editable behind that id — deleted, or an unsupported kind the library
         // cannot put handles on. Fall straight back to disarmed rather than leaving the


### PR DESCRIPTION
## Summary

- make control-measure draw startup report when no tactical-draw surface is available
- disarm a deferred draw that cannot open a session, restoring map selection
- add regression coverage for surface loss between arming and session startup

Addresses finding 1 in #655.

## Verification

- `pnpm type-check`
- `pnpm vitest run src/modules/scenarioeditor/useScenarioDraw.test.ts`
- `pnpm vitest run src/modules/scenarioeditor/useControlMeasureDrawSession.test.ts src/modules/scenarioeditor/controlMeasureAuthoring.test.ts`
- `pnpm test:unit` (1,525 passed, 5 skipped)