### PR TITLE
Add control measure amplifier editor

### DIFF
--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { defineComponent, nextTick } from "vue";
+import ControlMeasureAmplifiers from "@/modules/scenarioeditor/ControlMeasureAmplifiers.vue";
+
+const PreviewStub = defineComponent({
+  name: "ControlMeasurePreview",
+  props: ["kind", "textAmplifiers"],
+  template: "<div data-test='preview' />",
+});
+
+describe("ControlMeasureAmplifiers", () => {
+  it("previews doctrinal field positions and commits a text field on change", async () => {
+    const wrapper = mount(ControlMeasureAmplifiers, {
+      props: {
+        graphicKind: "phase-line",
+        textAmplifiers: { T: "ALPHA" },
+      },
+      global: { stubs: { ControlMeasurePreview: PreviewStub } },
+    });
+    const input = wrapper.get("input[type='text']");
+
+    (input.element as HTMLInputElement).value = "BRAVO";
+    expect(wrapper.getComponent(PreviewStub).props("textAmplifiers")).toEqual({
+      T: "<T>",
+      N: "<N>",
+    });
+    await input.trigger("input");
+    expect(wrapper.emitted("update")).toBeUndefined();
+
+    await input.trigger("change");
+    expect(wrapper.emitted("update")).toEqual([[{ T: "BRAVO" }]]);
+  });
+
+  it("uses a toggle for the hostile marker", async () => {
+    const wrapper = mount(ControlMeasureAmplifiers, {
+      props: { graphicKind: "handover-line" },
+      global: { stubs: { ControlMeasurePreview: PreviewStub } },
+    });
+    const toggle = wrapper.get("button[role='switch']");
+
+    await toggle.trigger("click");
+    await nextTick();
+
+    expect(wrapper.emitted("update")).toEqual([[{ N: "ENY" }]]);
+  });
+
+  it("explains when a measure has no amplifier fields", () => {
+    const wrapper = mount(ControlMeasureAmplifiers, {
+      props: { graphicKind: "main-attack" },
+      global: { stubs: { ControlMeasurePreview: PreviewStub } },
+    });
+
+    expect(wrapper.text()).toContain("This control measure has no text amplifiers.");
+  });
+});

--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
@@ -1,0 +1,120 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import { CONTROL_MEASURE_METADATA } from "@orbat-mapper/control-measures";
+import type {
+  ControlMeasureId,
+  TextAmplifierDescriptor,
+  TextAmplifiers,
+} from "@orbat-mapper/control-measures";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import ControlMeasurePreview from "@/modules/scenarioeditor/ControlMeasurePreview.vue";
+
+const props = defineProps<{
+  graphicKind: ControlMeasureId;
+  textAmplifiers?: TextAmplifiers;
+}>();
+
+const emit = defineEmits<{
+  update: [textAmplifiers: TextAmplifiers];
+}>();
+
+const descriptors = computed<readonly TextAmplifierDescriptor[]>(
+  () => CONTROL_MEASURE_METADATA[props.graphicKind]?.textAmplifiers ?? [],
+);
+const previewAmplifiers = computed<TextAmplifiers>(() =>
+  Object.fromEntries(
+    descriptors.value.map((descriptor) => [descriptor.key, `<${descriptor.key}>`]),
+  ),
+);
+const values = ref<TextAmplifiers>({});
+
+watch(
+  () => [props.graphicKind, props.textAmplifiers] as const,
+  ([, textAmplifiers]) => {
+    values.value = { ...(textAmplifiers ?? {}) };
+  },
+  { immediate: true, deep: true },
+);
+
+function valueFor(descriptor: TextAmplifierDescriptor): string {
+  return values.value[descriptor.key] ?? "";
+}
+
+function setValue(key: TextAmplifierDescriptor["key"], value: string) {
+  values.value = { ...values.value, [key]: value };
+}
+
+function commit() {
+  const next = Object.fromEntries(
+    Object.entries(values.value).filter(([, value]) => value.trim().length > 0),
+  ) as TextAmplifiers;
+  values.value = next;
+  emit("update", next);
+}
+
+function setHostile(descriptor: TextAmplifierDescriptor, checked: boolean) {
+  setValue(descriptor.key, checked ? (descriptor.placeholder ?? "ENY") : "");
+  commit();
+}
+</script>
+
+<template>
+  <div class="space-y-5 pt-4">
+    <div class="space-y-2">
+      <p class="text-muted-foreground text-xs">
+        Preview of the doctrinal field positions.
+      </p>
+      <div
+        class="border-border bg-muted/30 text-foreground flex min-h-36 w-full items-center justify-center overflow-hidden rounded-md border p-3"
+      >
+        <ControlMeasurePreview
+          :kind="graphicKind"
+          :text-amplifiers="previewAmplifiers"
+          :width="232"
+          :height="116"
+          :pad="14"
+          :stroke-width="2"
+          class="h-36 w-full"
+        />
+      </div>
+    </div>
+
+    <div v-if="descriptors.length" class="space-y-4">
+      <div v-for="descriptor in descriptors" :key="descriptor.key" class="space-y-1.5">
+        <div class="flex items-baseline justify-between gap-3">
+          <Label :for="`control-measure-amplifier-${descriptor.key}`">
+            {{ descriptor.label }}
+          </Label>
+          <span class="text-muted-foreground font-mono text-xs">
+            {{ descriptor.key }}
+          </span>
+        </div>
+        <p v-if="descriptor.description" class="text-muted-foreground text-xs">
+          {{ descriptor.description }}
+        </p>
+
+        <Switch
+          v-if="descriptor.key === 'N'"
+          :id="`control-measure-amplifier-${descriptor.key}`"
+          :model-value="valueFor(descriptor) === (descriptor.placeholder ?? 'ENY')"
+          @update:model-value="setHostile(descriptor, Boolean($event))"
+        />
+        <Input
+          v-else
+          :id="`control-measure-amplifier-${descriptor.key}`"
+          type="text"
+          :model-value="valueFor(descriptor)"
+          :placeholder="descriptor.placeholder"
+          :maxlength="descriptor.maxLength"
+          @update:model-value="setValue(descriptor.key, String($event))"
+          @change="commit"
+        />
+      </div>
+    </div>
+    <p v-else class="text-muted-foreground text-sm">
+      This control measure has no text amplifiers.
+    </p>
+  </div>
+</template>

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -38,6 +38,13 @@ const ControlMeasureStyleSettingsStub = defineComponent({
   template: "<div data-test='style-settings' />",
 });
 
+const ControlMeasureAmplifiersStub = defineComponent({
+  name: "ControlMeasureAmplifiers",
+  props: ["graphicKind", "textAmplifiers"],
+  emits: ["update"],
+  template: "<div data-test='amplifier-settings' />",
+});
+
 const baseStubs = {
   DetailsPanelHeader: {
     template:
@@ -49,6 +56,7 @@ const baseStubs = {
   ScrollTabs: ScrollTabsStub,
   TabsContent: { template: "<section><slot /></section>" },
   ControlMeasureStyleSettings: ControlMeasureStyleSettingsStub,
+  ControlMeasureAmplifiers: ControlMeasureAmplifiersStub,
   ScenarioLayerItemState: true,
   EditMetaForm: true,
   IconButton: {
@@ -129,7 +137,7 @@ describe("ControlMeasureDetails tabs", () => {
     setActivePinia(pinia);
   });
 
-  it("shows Style, Details and State, with Debug gated by debug mode", async () => {
+  it("shows Style, Amplifiers, Details and State, with Debug gated by debug mode", async () => {
     const uiStore = useUiStore();
     const tabStore = useTabStore();
     const { wrapper } = mountDetails();
@@ -137,20 +145,22 @@ describe("ControlMeasureDetails tabs", () => {
 
     expect(tabs.props("items")).toEqual([
       { label: "Style", value: "0" },
-      { label: "Details", value: "1" },
-      { label: "State", value: "2" },
+      { label: "Amplifiers", value: "1" },
+      { label: "Details", value: "2" },
+      { label: "State", value: "3" },
     ]);
 
     uiStore.debugMode = true;
     await nextTick();
     expect(tabs.props("items")).toEqual([
       { label: "Style", value: "0" },
-      { label: "Details", value: "1" },
-      { label: "State", value: "2" },
-      { label: "Debug", value: "3" },
+      { label: "Amplifiers", value: "1" },
+      { label: "Details", value: "2" },
+      { label: "State", value: "3" },
+      { label: "Debug", value: "4" },
     ]);
 
-    tabStore.controlMeasureDetailsTab = 3;
+    tabStore.controlMeasureDetailsTab = 4;
     uiStore.debugMode = false;
     await nextTick();
     expect(tabStore.controlMeasureDetailsTab).toBe(0);
@@ -158,7 +168,7 @@ describe("ControlMeasureDetails tabs", () => {
 
   it("falls back from a remembered Debug tab when mounting outside debug mode", () => {
     const tabStore = useTabStore();
-    tabStore.controlMeasureDetailsTab = 3;
+    tabStore.controlMeasureDetailsTab = 4;
 
     mountDetails();
 
@@ -176,7 +186,21 @@ describe("ControlMeasureDetails tabs", () => {
     expect(tabStore.featureDetailsTab).toBe(2);
 
     await wrapper.find("button[title='Edit data']").trigger("click");
-    expect(tabStore.controlMeasureDetailsTab).toBe(1);
+    expect(tabStore.controlMeasureDetailsTab).toBe(2);
+  });
+
+  it("writes text amplifiers through the settle-first control-measure path", async () => {
+    const { wrapper, updateControlMeasure } = mountDetails({
+      textAmplifiers: { T: "ALPHA" },
+    });
+    const settings = wrapper.findComponent(ControlMeasureAmplifiersStub);
+
+    expect(settings.props("graphicKind")).toBe("phase-line");
+    expect(settings.props("textAmplifiers")).toEqual({ T: "ALPHA" });
+    await settings.vm.$emit("update", { T: "BRAVO" });
+    expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
+      textAmplifiers: { T: "BRAVO" },
+    });
   });
 
   it("keeps style writes on the settle-first control-measure path", async () => {

--- a/src/modules/scenarioeditor/ControlMeasureDetails.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.vue
@@ -51,6 +51,7 @@ import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue"
 import PanelTitle from "@/modules/scenarioeditor/PanelTitle.vue";
 import PanelDataGrid from "@/components/PanelDataGrid.vue";
 import ControlMeasureStyleSettings from "@/modules/scenarioeditor/ControlMeasureStyleSettings.vue";
+import ControlMeasureAmplifiers from "@/modules/scenarioeditor/ControlMeasureAmplifiers.vue";
 import EditableLabel from "@/components/EditableLabel.vue";
 import EditMetaForm from "@/modules/scenarioeditor/EditMetaForm.vue";
 import IconButton from "@/components/IconButton.vue";
@@ -76,10 +77,11 @@ const { controlMeasureDetailsTab: selectedTab } = storeToRefs(useTabStore());
 const tabList = computed(() => {
   const tabs = [
     { label: "Style", value: "0" },
-    { label: "Details", value: "1" },
-    { label: "State", value: "2" },
+    { label: "Amplifiers", value: "1" },
+    { label: "Details", value: "2" },
+    { label: "State", value: "3" },
   ];
-  if (uiStore.debugMode) tabs.push({ label: "Debug", value: "3" });
+  if (uiStore.debugMode) tabs.push({ label: "Debug", value: "4" });
   return tabs;
 });
 
@@ -93,7 +95,7 @@ const selectedTabString = computed({
 watch(
   () => uiStore.debugMode,
   (debugMode) => {
-    if (!debugMode && selectedTab.value === 3) selectedTab.value = 0;
+    if (!debugMode && selectedTab.value === 4) selectedTab.value = 0;
   },
   { immediate: true },
 );
@@ -151,7 +153,7 @@ watch(
 const isEditMode = ref(false);
 function toggleEditMode() {
   isEditMode.value = !isEditMode.value;
-  selectedTab.value = 1;
+  selectedTab.value = 2;
 }
 
 function showStylePanel() {
@@ -174,6 +176,10 @@ function updateName(name: string) {
  */
 function doStyleUpdate(data: ControlMeasureStyleUpdate) {
   if (item.value) scenarioDraw.updateControlMeasure(item.value.id, data);
+}
+
+function doAmplifierUpdate(textAmplifiers: NTacticalGraphicLayerItem["textAmplifiers"]) {
+  if (item.value) scenarioDraw.updateControlMeasure(item.value.id, { textAmplifiers });
 }
 
 function resetLabelPositions() {
@@ -352,6 +358,17 @@ function doDelete() {
           </PanelDataGrid>
         </TabsContent>
         <TabsContent value="1" class="mx-4">
+          <ControlMeasureAmplifiers
+            v-if="supported"
+            :graphic-kind="item.graphicKind as ControlMeasureId"
+            :text-amplifiers="item.textAmplifiers"
+            @update="doAmplifierUpdate"
+          />
+          <p v-else class="text-muted-foreground pt-4 text-sm">
+            Amplifiers are unavailable for this unsupported control measure.
+          </p>
+        </TabsContent>
+        <TabsContent value="2" class="mx-4">
           <PanelDataGrid class="mt-4">
             <div class="text-muted-foreground">Kind</div>
             <div class="truncate">{{ kindName }}</div>
@@ -370,12 +387,12 @@ function doDelete() {
             <div v-html="hDescription"></div>
           </div>
         </TabsContent>
-        <TabsContent value="2" class="mx-4">
+        <TabsContent value="3" class="mx-4">
           <ScenarioLayerItemState :item="item" heading="Control measure state" />
         </TabsContent>
         <TabsContent
           v-if="uiStore.debugMode"
-          value="3"
+          value="4"
           class="prose prose-sm dark:prose-invert mx-4 max-w-none"
         >
           <pre>{{ item }}</pre>

--- a/src/modules/scenarioeditor/ControlMeasurePreview.vue
+++ b/src/modules/scenarioeditor/ControlMeasurePreview.vue
@@ -8,7 +8,7 @@ import {
 } from "@orbat-mapper/control-measures/preview";
 import type { PreviewShape } from "@orbat-mapper/control-measures/preview";
 import { CONTROL_MEASURE_METADATA } from "@orbat-mapper/control-measures";
-import type { ControlMeasureId } from "@orbat-mapper/control-measures";
+import type { ControlMeasureId, TextAmplifiers } from "@orbat-mapper/control-measures";
 import {
   PREVIEW_VERTEX_RADIUS,
   buildControlMeasurePreview,
@@ -22,11 +22,24 @@ import {
  * colour the same way an icon component does.
  */
 const props = withDefaults(
-  defineProps<{ kind: ControlMeasureId; strokeWidth?: number }>(),
-  { strokeWidth: 4 },
+  defineProps<{
+    kind: ControlMeasureId;
+    strokeWidth?: number;
+    textAmplifiers?: TextAmplifiers;
+    width?: number;
+    height?: number;
+    pad?: number;
+  }>(),
+  { strokeWidth: 4, width: 100, height: 100, pad: 8 },
 );
 
-const preview = computed(() => buildControlMeasurePreview(props.kind));
+const preview = computed(() =>
+  buildControlMeasurePreview(
+    props.kind,
+    { width: props.width, height: props.height, pad: props.pad },
+    props.textAmplifiers,
+  ),
+);
 const geometry = computed(() => CONTROL_MEASURE_METADATA[props.kind]?.geometry);
 
 // Pattern ids are document-global, so every instance gets its own prefix.

--- a/src/modules/scenarioeditor/controlMeasurePreview.test.ts
+++ b/src/modules/scenarioeditor/controlMeasurePreview.test.ts
@@ -25,6 +25,21 @@ describe("the picker preview", () => {
     expect(width).toBeGreaterThan(CONTROL_MEASURE_PREVIEW_DIMENSIONS.width);
   });
 
+  it("applies authored text amplifiers to the representative preview", () => {
+    const { shapes } = buildControlMeasurePreview(
+      "phase-line",
+      CONTROL_MEASURE_PREVIEW_DIMENSIONS,
+      { T: "BLUE" },
+    );
+
+    expect(
+      shapes.some((shape) => shape.type === "text" && shape.text?.includes("BLUE")),
+    ).toBe(true);
+    expect(
+      shapes.some((shape) => shape.type === "text" && shape.text?.includes("ECHO")),
+    ).toBe(false);
+  });
+
   it("renders every registered kind without throwing", () => {
     for (const kind of CONTROL_MEASURE_IDS) {
       expect(() => buildControlMeasurePreview(kind)).not.toThrow();

--- a/src/modules/scenarioeditor/controlMeasurePreview.ts
+++ b/src/modules/scenarioeditor/controlMeasurePreview.ts
@@ -17,7 +17,7 @@ import type {
   PreviewShape,
   ProjectDimensions,
 } from "@orbat-mapper/control-measures/preview";
-import type { ControlMeasureId } from "@orbat-mapper/control-measures";
+import type { ControlMeasureId, TextAmplifiers } from "@orbat-mapper/control-measures";
 
 /**
  * The box every preview is fit into. Unitless — the SVG scales to whatever size the
@@ -50,8 +50,12 @@ export interface ControlMeasurePreviewModel {
 export function buildControlMeasurePreview(
   kind: ControlMeasureId,
   dims: ProjectDimensions = CONTROL_MEASURE_PREVIEW_DIMENSIONS,
+  textAmplifiers?: TextAmplifiers,
 ): ControlMeasurePreviewModel {
-  const { shapes, ok } = projectRenderToShapes(renderRepresentative(kind), dims);
+  const { shapes, ok } = projectRenderToShapes(
+    renderRepresentative(kind, { textAmplifiers }),
+    dims,
+  );
   // The plain box fits geometry only, so an anchored label can hang outside it.
   return { shapes, ok, viewBox: viewBoxString(shapes, dims, previewFontSize) };
 }


### PR DESCRIPTION
## Summary

- add an Amplifiers tab to control-measure details
- render a doctrinal field-position preview using placeholders such as `<T>` and `<N>`
- expose metadata-driven amplifier inputs and persist changes through the settle-safe control-measure update path
- extend representative previews with text-amplifier overrides

## Verification

- `pnpm exec vitest run src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts src/modules/scenarioeditor/ControlMeasureDetails.test.ts src/modules/scenarioeditor/controlMeasurePreview.test.ts`
- `pnpm type-check`
- ESLint on changed files
- `git diff --check`