### PR TITLE
Make control-measure styling sticky

### DIFF
--- a/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.test.ts
@@ -1,0 +1,134 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { defineComponent, nextTick } from "vue";
+import { mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import ControlMeasureDefaultsPopover from "@/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue";
+import ControlMeasureStyleSettings from "@/modules/scenarioeditor/ControlMeasureStyleSettings.vue";
+import { activeScenarioKey, scenarioDrawKey } from "@/components/injects";
+import { useSelectedItems } from "@/stores/selectedStore";
+import { useControlMeasureToolStore } from "@/stores/controlMeasureToolStore";
+import type { NTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
+
+vi.mock("@/components/ui/popover", () => ({
+  Popover: defineComponent({ template: "<div><slot /></div>" }),
+  PopoverTrigger: defineComponent({ template: "<div><slot /></div>" }),
+  PopoverContent: defineComponent({ template: "<div><slot /></div>" }),
+}));
+
+vi.mock("@/modules/scenarioeditor/ControlMeasureColorPicker.vue", () => ({
+  default: defineComponent({
+    name: "ControlMeasureColorPicker",
+    props: { modelValue: { type: String, default: "" } },
+    emits: ["update:modelValue"],
+    template: "<div />",
+  }),
+}));
+
+function item(
+  id: string,
+  graphicKind: NTacticalGraphicLayerItem["graphicKind"],
+  style: NTacticalGraphicLayerItem["style"] = {},
+): NTacticalGraphicLayerItem {
+  return {
+    kind: "tacticalGraphic",
+    id,
+    _pid: "layer-1",
+    graphicKind,
+    controlPoints: [],
+    style,
+  };
+}
+
+function mountPopover(items: NTacticalGraphicLayerItem[]) {
+  const byId = new Map(items.map((value) => [value.id, value]));
+  const updateControlMeasure = vi.fn();
+  const groupUpdate = vi.fn((action: () => void) => action());
+  const wrapper = mount(ControlMeasureDefaultsPopover, {
+    global: {
+      plugins: [createPinia()],
+      provide: {
+        [activeScenarioKey as symbol]: {
+          geo: {
+            getLayerItemById: (id: string) => ({ layerItem: byId.get(id) }),
+          },
+          store: { groupUpdate },
+        },
+        [scenarioDrawKey as symbol]: { updateControlMeasure },
+      },
+    },
+  });
+  return { wrapper, updateControlMeasure, groupUpdate };
+}
+
+describe("ControlMeasureDefaultsPopover", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+    useSelectedItems().clear();
+  });
+
+  it("edits defaults for the currently chosen kind without a selection", async () => {
+    const { wrapper, updateControlMeasure } = mountPopover([]);
+    const store = useControlMeasureToolStore();
+    store.lastKind = "phase-line";
+    await nextTick();
+
+    const settings = wrapper.findComponent(ControlMeasureStyleSettings);
+    expect(settings.props("graphicKind")).toBe("phase-line");
+    expect(settings.props("editingDefaults")).toBe(true);
+
+    settings.vm.$emit("update", { status: "planned" });
+    await nextTick();
+    expect(store.defaults.status).toBe("planned");
+    expect(updateControlMeasure).not.toHaveBeenCalled();
+
+    settings.vm.$emit("update", { options: { smooth: true } });
+    await nextTick();
+    expect(store.defaults.options).toEqual({ smooth: true });
+  });
+
+  it("applies settings to the selected control measure instead of defaults", async () => {
+    const selected = item("cm-1", "polygon", { color: "#112233" });
+    const { wrapper, updateControlMeasure } = mountPopover([selected]);
+    useSelectedItems().selectedFeatureIds.value = new Set([selected.id]);
+    await nextTick();
+
+    const settings = wrapper.findComponent(ControlMeasureStyleSettings);
+    expect(settings.props("graphicKind")).toBe("polygon");
+    expect(settings.props("editingDefaults")).toBe(false);
+    expect(wrapper.text()).toContain("Selected control measure");
+
+    settings.vm.$emit("update", { style: { color: "#ff0000" } });
+    expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
+      style: { color: "#ff0000" },
+    });
+    expect(useControlMeasureToolStore().defaults.style).toEqual({ color: "#ff0000" });
+  });
+
+  it("preserves unrelated styling when changing a multi-selection", async () => {
+    const first = item("cm-1", "polygon", {
+      color: "#112233",
+      strokeWidth: 2,
+    });
+    const second = item("cm-2", "polygon", {
+      color: "#445566",
+      strokeWidth: 5,
+    });
+    const { wrapper, updateControlMeasure, groupUpdate } = mountPopover([first, second]);
+    useSelectedItems().selectedFeatureIds.value = new Set([first.id, second.id]);
+    await nextTick();
+
+    wrapper.findComponent(ControlMeasureStyleSettings).vm.$emit("update", {
+      style: { color: "#ff0000", strokeWidth: 2 },
+    });
+
+    expect(groupUpdate).toHaveBeenCalledOnce();
+    expect(updateControlMeasure).toHaveBeenNthCalledWith(1, "cm-1", {
+      style: { color: "#ff0000", strokeWidth: 2 },
+    });
+    expect(updateControlMeasure).toHaveBeenNthCalledWith(2, "cm-2", {
+      style: { color: "#ff0000", strokeWidth: 5 },
+    });
+  });
+});

--- a/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue
@@ -1,29 +1,151 @@
 <script setup lang="ts">
 /**
- * The defaults a newly drawn control measure is born with: identity, colour mode,
- * status, and — for the kinds the styling UI lets you author — colour and fill pattern.
+ * The draw toolbar's compact control-measure style panel. With a control measure
+ * selection it edits that selection; otherwise it edits the defaults a newly drawn
+ * measure is born with.
  *
- * Session-sticky Pinia UI state, never scenario data (ADR-0006): changing a default
- * changes nothing that already exists, and nothing here is persisted into a scenario.
+ * Defaults remain session-sticky Pinia UI state (ADR-0006), while selection edits go
+ * through the scenario draw owner so they retain the normal settle and undo behavior.
  * The controls are the same component the details panel uses, so "what a new graphic
  * looks like" and "what this graphic looks like" cannot drift apart.
  */
 import { IconPaletteOutline as DefaultsIcon } from "@iconify-prerendered/vue-mdi";
 import { storeToRefs } from "pinia";
+import { computed, inject } from "vue";
 import MainToolbarButton from "@/components/MainToolbarButton.vue";
 import PanelDataGrid from "@/components/PanelDataGrid.vue";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useControlMeasureToolStore } from "@/stores/controlMeasureToolStore";
 import ControlMeasureStyleSettings from "@/modules/scenarioeditor/ControlMeasureStyleSettings.vue";
 import type { ControlMeasureStyleUpdate } from "@/modules/scenarioeditor/controlMeasureStyleOptions";
+import { activeScenarioKey, scenarioDrawKey } from "@/components/injects";
+import { useSelectedItems } from "@/stores/selectedStore";
+import {
+  isNTacticalGraphicLayerItem,
+  type NTacticalGraphicLayerItem,
+  type TacticalGraphicLayerItemUpdate,
+} from "@/types/scenarioLayerItems";
+import { resolveControlMeasureOptions } from "@/geo/controlMeasures";
 
 withDefaults(defineProps<{ disabled?: boolean }>(), { disabled: false });
 
 const store = useControlMeasureToolStore();
-const { defaults } = storeToRefs(store);
+const { defaults, lastKind } = storeToRefs(store);
+const { selectedFeatureIds } = useSelectedItems();
+// Optional keeps the component independently mountable; both are present in the
+// scenario editor where the toolbar is rendered.
+const scenario = inject(activeScenarioKey, null);
+const scenarioDraw = inject(scenarioDrawKey, null);
 
-function updateDefaults(data: ControlMeasureStyleUpdate) {
-  store.setDefaults(data);
+const selectedItems = computed<NTacticalGraphicLayerItem[]>(() => {
+  if (!scenario || selectedFeatureIds.value.size === 0) return [];
+  const items = [...selectedFeatureIds.value].map(
+    (id) => scenario.geo.getLayerItemById(id).layerItem,
+  );
+  // Mixed selections follow the ordinary feature path, just like the details panel.
+  if (!items.every(isNTacticalGraphicLayerItem)) return [];
+  return items;
+});
+
+const primaryItem = computed(() => selectedItems.value[0]);
+const editsSelection = computed(() => selectedItems.value.length > 0);
+
+function changedFields(
+  before: Record<string, unknown> | undefined,
+  after: Record<string, unknown>,
+) {
+  return [...new Set([...Object.keys(before ?? {}), ...Object.keys(after)])].filter(
+    (key) => before?.[key] !== after[key],
+  );
+}
+
+/**
+ * The settings component emits a complete style/options object for its primary item.
+ * For a multi-selection, carry only the fields that actually changed onto every other
+ * item so their unrelated authored styling and generator options are preserved.
+ */
+function updateForItem(
+  item: NTacticalGraphicLayerItem,
+  data: ControlMeasureStyleUpdate,
+  primaryStyle: Record<string, unknown>,
+  primaryOptions: Record<string, unknown> | undefined,
+): TacticalGraphicLayerItemUpdate {
+  const update: TacticalGraphicLayerItemUpdate = { ...data };
+  if (data.style) {
+    const style = { ...item.style } as Record<string, unknown>;
+    for (const key of changedFields(primaryStyle, data.style)) {
+      const value = (data.style as Record<string, unknown>)[key];
+      if (value === undefined) delete style[key];
+      else style[key] = value;
+    }
+    update.style = style;
+  }
+  if (data.options) {
+    const options = { ...resolveControlMeasureOptions(item) } as Record<string, unknown>;
+    for (const key of changedFields(primaryOptions, data.options)) {
+      const value = (data.options as Record<string, unknown>)[key];
+      if (value === undefined) delete options[key];
+      else options[key] = value;
+    }
+    update.options = options;
+  }
+  return update;
+}
+
+function updateSettings(data: ControlMeasureStyleUpdate) {
+  const primary = primaryItem.value;
+  if (!primary) {
+    store.setDefaults(data);
+    return;
+  }
+
+  // Every settled toolbar choice becomes the starting point for the next graphic.
+  // Merge only the field changed on the selected primary, preserving sticky settings
+  // that this kind cannot display (for example a polygon fill while editing a line).
+  const sticky: ControlMeasureStyleUpdate = { ...data };
+  if (data.style) {
+    const style = { ...defaults.value.style } as Record<string, unknown>;
+    for (const key of changedFields(primary.style, data.style)) {
+      const value = (data.style as Record<string, unknown>)[key];
+      if (value === undefined) delete style[key];
+      else style[key] = value;
+    }
+    sticky.style = style;
+  }
+  if (data.options) {
+    const primaryOptions = resolveControlMeasureOptions(primary);
+    const options = { ...defaults.value.options } as Record<string, unknown>;
+    for (const key of changedFields(primaryOptions, data.options)) {
+      const value = (data.options as Record<string, unknown>)[key];
+      if (value === undefined) delete options[key];
+      else options[key] = value;
+    }
+    sticky.options = options;
+  }
+  store.setDefaults(sticky);
+
+  if (!scenarioDraw) return;
+  // Snapshot before the first synchronous store write mutates the primary proxy.
+  const primaryStyle = { ...primary.style } as Record<string, unknown>;
+  const primaryOptions = data.options
+    ? ({ ...resolveControlMeasureOptions(primary) } as Record<string, unknown>)
+    : undefined;
+  const apply = () => {
+    for (const item of selectedItems.value) {
+      scenarioDraw.updateControlMeasure(
+        item.id,
+        updateForItem(item, data, primaryStyle, primaryOptions),
+      );
+    }
+  };
+  if (selectedItems.value.length > 1 && scenario) {
+    scenario.store.groupUpdate(apply, {
+      label: "updateFeature",
+      value: primary.id,
+    });
+  } else {
+    apply();
+  }
 }
 </script>
 
@@ -34,7 +156,9 @@ function updateDefaults(data: ControlMeasureStyleUpdate) {
         :title="
           disabled
             ? 'Control measures are not supported by this map engine'
-            : 'Control measure defaults'
+            : editsSelection
+              ? 'Style selected control measures'
+              : 'Control measure defaults'
         "
         :disabled="disabled"
       >
@@ -42,14 +166,30 @@ function updateDefaults(data: ControlMeasureStyleUpdate) {
       </MainToolbarButton>
     </PopoverTrigger>
     <PopoverContent :avoid-collisions="true">
-      <header class="text-sm font-bold">New control measures</header>
+      <header class="text-sm font-bold">
+        {{
+          editsSelection
+            ? selectedItems.length === 1
+              ? "Selected control measure"
+              : `${selectedItems.length} selected control measures`
+            : "New control measures"
+        }}
+      </header>
       <PanelDataGrid class="mt-4">
         <ControlMeasureStyleSettings
-          :measure-style="defaults.style"
-          :standard-identity="defaults.standardIdentity"
-          :color-mode="defaults.colorMode"
-          :status="defaults.status"
-          @update="updateDefaults"
+          :graphic-kind="primaryItem?.graphicKind ?? lastKind"
+          :graphic-kinds="selectedItems.map((item) => item.graphicKind)"
+          :editing-defaults="!editsSelection"
+          :measure-style="editsSelection ? primaryItem?.style : defaults.style"
+          :standard-identity="
+            editsSelection ? primaryItem?.standardIdentity : defaults.standardIdentity
+          "
+          :color-mode="editsSelection ? primaryItem?.colorMode : defaults.colorMode"
+          :status="editsSelection ? primaryItem?.status : defaults.status"
+          :options="
+            primaryItem ? resolveControlMeasureOptions(primaryItem) : defaults.options
+          "
+          @update="updateSettings"
         />
       </PanelDataGrid>
     </PopoverContent>

--- a/src/modules/scenarioeditor/ControlMeasureStyleSettings.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureStyleSettings.test.ts
@@ -47,10 +47,31 @@ describe("the UI-only styling gate", () => {
     expect(labels(wrapper)).not.toContain("Fill");
   });
 
-  it("offers everything for the defaults, which belong to no kind yet", () => {
-    const wrapper = mountSettings({});
+  it("gates defaults using the kind they will create", () => {
+    const wrapper = mount(ControlMeasureStyleSettings, {
+      props: { graphicKind: "phase-line", editingDefaults: true },
+    });
+    expect(labels(wrapper)).not.toContain("Color");
+    expect(labels(wrapper)).not.toContain("Fill");
+  });
+
+  it("offers supported styling for defaults of a generic kind", () => {
+    const wrapper = mount(ControlMeasureStyleSettings, {
+      props: { graphicKind: "polygon", editingDefaults: true },
+    });
     expect(labels(wrapper)).toContain("Color");
     expect(labels(wrapper)).toContain("Fill");
+  });
+
+  it("offers a capability only when every selected kind supports it", () => {
+    const wrapper = mount(ControlMeasureStyleSettings, {
+      props: {
+        graphicKind: "polygon",
+        graphicKinds: ["polygon", "phase-line"],
+      },
+    });
+    expect(labels(wrapper)).not.toContain("Color");
+    expect(labels(wrapper)).not.toContain("Fill");
   });
 
   it("still shows a doctrinal kind's imported colour, because it renders", () => {
@@ -123,8 +144,15 @@ describe("the smoothing toggle", () => {
     expect(smoothSwitch(wrapper).exists()).toBe(false);
   });
 
-  it("is not offered for the defaults, which belong to no kind", () => {
+  it("is not offered for defaults without a chosen kind", () => {
     expect(smoothSwitch(mountSettings({})).exists()).toBe(false);
+  });
+
+  it("is offered for defaults of a kind that supports smoothing", () => {
+    const wrapper = mount(ControlMeasureStyleSettings, {
+      props: { graphicKind: "phase-line", editingDefaults: true },
+    });
+    expect(smoothSwitch(wrapper).exists()).toBe(true);
   });
 
   it("reflects an authored option over the library default", () => {

--- a/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
+++ b/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
@@ -15,8 +15,8 @@
  *   symbology — the model and `toControlMeasure` stay uniform, so an imported colour
  *   on a doctrinal kind still renders.
  *
- * `graphicKind` is `undefined` when editing the defaults, which belong to no kind yet:
- * every control is offered, and the gate is applied per kind when a graphic is born.
+ * Defaults are edited for the toolbar's currently chosen kind, so the same capability
+ * gate applies before and after a graphic is born.
  */
 import { computed, toRaw } from "vue";
 import type {
@@ -47,8 +47,12 @@ import {
 } from "@/modules/scenarioeditor/controlMeasureStyleOptions";
 
 const props = defineProps<{
-  /** `undefined` while editing the defaults — see the block comment. */
+  /** The edited item kind, or the kind that the toolbar defaults will create. */
   graphicKind?: ControlMeasureKind;
+  /** All edited kinds, when the host applies one control to a multi-selection. */
+  graphicKinds?: ControlMeasureKind[];
+  /** Identifies toolbar-default mode for its explanatory copy. */
+  editingDefaults?: boolean;
   /** Named `measureStyle`, not `style`: Vue reserves `style` for the fallthrough attribute. */
   measureStyle?: ControlMeasureStyle;
   standardIdentity?: SidValue;
@@ -61,12 +65,24 @@ const props = defineProps<{
 
 const emit = defineEmits<{ (e: "update", value: ControlMeasureStyleUpdate): void }>();
 
-const isDefaults = computed(() => props.graphicKind === undefined);
+const isDefaults = computed(() => {
+  if (props.editingDefaults !== undefined) return props.editingDefaults;
+  return props.graphicKind === undefined;
+});
+const editedKinds = computed(() =>
+  props.graphicKinds?.length
+    ? props.graphicKinds
+    : props.graphicKind !== undefined
+      ? [props.graphicKind]
+      : [],
+);
 const showColor = computed(
-  () => isDefaults.value || isStyleableControlMeasureKind(props.graphicKind),
+  () =>
+    editedKinds.value.length > 0 &&
+    editedKinds.value.every(isStyleableControlMeasureKind),
 );
 const showFillPattern = computed(
-  () => isDefaults.value || canAuthorFillPattern(props.graphicKind),
+  () => editedKinds.value.length > 0 && editedKinds.value.every(canAuthorFillPattern),
 );
 
 /** What the graphic actually draws as, authored colour or identity projection. */
@@ -120,11 +136,12 @@ const statusModel = computed({
 /**
  * Smoothing is a generator *option*, not a style — the emit carries `options`, and the
  * whole object is replaced from a raw copy for the same reason `nextStyle` does it.
- * Offered only for the kinds whose registry entry declares a `smooth` param, and never
- * for the defaults, which belong to no kind (see `canSmoothControlMeasureKind`).
+ * Offered only for kinds whose registry entry declares a `smooth` param. Toolbar
+ * defaults now belong to the currently chosen kind, so smoothing can be sticky too.
  */
 const showSmooth = computed(
-  () => !isDefaults.value && canSmoothControlMeasureKind(props.graphicKind),
+  () =>
+    editedKinds.value.length > 0 && editedKinds.value.every(canSmoothControlMeasureKind),
 );
 
 const smoothModel = computed({
@@ -217,7 +234,6 @@ const fillPatternModel = computed({
   </template>
 
   <p v-if="isDefaults" class="text-muted-foreground col-span-2 text-xs">
-    Color and fill apply to the generic graphics only — every other kind takes its color
-    from its standard identity.
+    These settings apply to new {{ graphicKind ? "graphics of this kind" : "graphics" }}.
   </p>
 </template>

--- a/src/modules/scenarioeditor/controlMeasureDrawHelpers.test.ts
+++ b/src/modules/scenarioeditor/controlMeasureDrawHelpers.test.ts
@@ -8,6 +8,7 @@ import { isNTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
 import { CONTROL_MEASURE_LAYER_NAME } from "@/modules/scenarioeditor/controlMeasureLayers";
 import {
   addScenarioControlMeasure,
+  draftOptionsForNewControlMeasure,
   draftStyleForNewControlMeasure,
   toTacticalGraphicLayerItem,
 } from "@/modules/scenarioeditor/controlMeasureDrawHelpers";
@@ -76,6 +77,13 @@ describe("toTacticalGraphicLayerItem", () => {
     expect(item.status).toBe("planned");
   });
 
+  it("keeps sticky options when the engine snapshot does not replace them", () => {
+    const item = toTacticalGraphicLayerItem(measure(), {
+      options: { smooth: true },
+    });
+    expect(item.options).toEqual({ smooth: true });
+  });
+
   it("copies the control points out of the measure the engine still holds", () => {
     const source = measure();
     const item = toTacticalGraphicLayerItem(source);
@@ -106,6 +114,14 @@ describe("draftStyleForNewControlMeasure", () => {
         status: "planned",
       }),
     ).toEqual({ color: MONOCHROME_COLOR, strokeDash: [...PLANNED_STROKE_DASH] });
+  });
+});
+
+describe("draftOptionsForNewControlMeasure", () => {
+  it("overrides the library default with sticky options", () => {
+    expect(
+      draftOptionsForNewControlMeasure("phase-line", { options: { smooth: true } }),
+    ).toEqual(expect.objectContaining({ smooth: true }));
   });
 });
 

--- a/src/modules/scenarioeditor/controlMeasureDrawHelpers.ts
+++ b/src/modules/scenarioeditor/controlMeasureDrawHelpers.ts
@@ -39,18 +39,18 @@ import {
 /**
  * The fields a newly drawn control measure is born with.
  *
- * The three projections from ADR-0006 plus the authored `style`, which is the
- * library's `ControlMeasureStyle` **verbatim** and is stored as-is. Nothing derived
- * gets in: the identity/status projections still resolve at read time, and it is the
- * caller's job to have narrowed `style` to what the kind may be authored with — see
- * `newControlMeasureDefaults` in `controlMeasureStyleOptions.ts`, where that UI-only
- * gate lives.
+ * The three projections from ADR-0006 plus authored `style` and sticky generator
+ * `options`. Nothing derived gets in: identity/status still resolve at read time, and
+ * the caller narrows style/options to capabilities of the chosen kind — see
+ * `newControlMeasureDefaults` in `controlMeasureStyleOptions.ts`.
  */
 export interface NewControlMeasureDefaults {
   standardIdentity?: SidValue;
   colorMode?: TacticalGraphicColorMode;
   status?: TacticalGraphicStatus;
   style?: ControlMeasureStyle;
+  /** Sticky generator options are narrowed per kind before a draw starts. */
+  options?: TacticalGraphicOptions;
 }
 
 /**
@@ -75,6 +75,7 @@ function newItemShell(
     ...(defaults.colorMode !== undefined ? { colorMode: defaults.colorMode } : {}),
     ...(defaults.status !== undefined ? { status: defaults.status } : {}),
     ...(defaults.style !== undefined ? { style: { ...defaults.style } } : {}),
+    ...(defaults.options !== undefined ? { options: { ...defaults.options } } : {}),
   };
 }
 
@@ -95,7 +96,7 @@ export function draftStyleForNewControlMeasure(
 
 /**
  * The generator options a new control measure is drawn with: the kind's own registry
- * defaults, verbatim.
+ * defaults, with supported session-sticky options applied over them.
  *
  * This is what makes an echelon glyph or a label come out sized for the zoom it was
  * drawn at rather than at a fixed ground size. Several kinds declare both a meter and a
@@ -117,8 +118,12 @@ export function draftStyleForNewControlMeasure(
  */
 export function draftOptionsForNewControlMeasure(
   measureKind: ControlMeasure["kind"],
+  defaults: NewControlMeasureDefaults = {},
 ): TacticalGraphicOptions {
-  return { ...(getDefaultOptions(measureKind) as TacticalGraphicOptions) };
+  return {
+    ...(getDefaultOptions(measureKind) as TacticalGraphicOptions),
+    ...defaults.options,
+  };
 }
 
 /**

--- a/src/modules/scenarioeditor/controlMeasureStyleOptions.test.ts
+++ b/src/modules/scenarioeditor/controlMeasureStyleOptions.test.ts
@@ -68,6 +68,7 @@ describe("newControlMeasureDefaults", () => {
     colorMode: "identity",
     status: "planned",
     style: { color: "#ff0000", fillPattern: "hatch" },
+    options: { smooth: true },
   } as const;
 
   it("keeps the host-owned fields for every kind", () => {
@@ -75,6 +76,7 @@ describe("newControlMeasureDefaults", () => {
       standardIdentity: "3",
       colorMode: "identity",
       status: "planned",
+      options: { smooth: true },
     });
   });
 
@@ -89,6 +91,16 @@ describe("newControlMeasureDefaults", () => {
     expect(newControlMeasureDefaults(defaults, "line").style).toEqual({
       color: "#ff0000",
     });
+  });
+
+  it("drops sticky smoothing for kinds that do not support it", () => {
+    expect(newControlMeasureDefaults(defaults, "text").options).toBeUndefined();
+  });
+
+  it("copies sticky smoothing for kinds that support it", () => {
+    const result = newControlMeasureDefaults(defaults, "phase-line");
+    expect(result.options).toEqual({ smooth: true });
+    expect(result.options).not.toBe(defaults.options);
   });
 
   it("emits no style at all when nothing survives the gate", () => {

--- a/src/modules/scenarioeditor/controlMeasureStyleOptions.ts
+++ b/src/modules/scenarioeditor/controlMeasureStyleOptions.ts
@@ -128,13 +128,25 @@ export function newControlMeasureDefaults(
   defaults: NewControlMeasureDefaults,
   graphicKind: ControlMeasureKind,
 ): NewControlMeasureDefaults {
-  const { style, ...hostOwned } = defaults;
-  if (!style || !isStyleableControlMeasureKind(graphicKind)) return { ...hostOwned };
-  const authored: ControlMeasureStyle = {};
-  if (style.color !== undefined) authored.color = style.color;
-  if (style.fillPattern !== undefined && canAuthorFillPattern(graphicKind)) {
-    authored.fillPattern = style.fillPattern;
+  const { style, options, ...hostOwned } = defaults;
+  const narrowed: NewControlMeasureDefaults = { ...hostOwned };
+
+  if (style && isStyleableControlMeasureKind(graphicKind)) {
+    const authored: ControlMeasureStyle = {};
+    if (style.color !== undefined) authored.color = style.color;
+    if (style.fillPattern !== undefined && canAuthorFillPattern(graphicKind)) {
+      authored.fillPattern = style.fillPattern;
+    }
+    if (Object.keys(authored).length > 0) narrowed.style = authored;
   }
-  if (Object.keys(authored).length === 0) return { ...hostOwned };
-  return { ...hostOwned, style: authored };
+
+  if (
+    options &&
+    canSmoothControlMeasureKind(graphicKind) &&
+    typeof (options as Record<string, unknown>).smooth === "boolean"
+  ) {
+    narrowed.options = { smooth: options.smooth } as TacticalGraphicOptions;
+  }
+
+  return narrowed;
 }

--- a/src/modules/scenarioeditor/useControlMeasureDrawSession.test.ts
+++ b/src/modules/scenarioeditor/useControlMeasureDrawSession.test.ts
@@ -14,6 +14,7 @@ import type { TScenario } from "@/scenariostore";
 import { createTacticalDrawSurfaceFake } from "@/geo/engines/maplibre/tacticalDrawSurfaceFake";
 import { createTacticalGraphicRenderFeedFake } from "@/modules/maplibreview/tacticalGraphicRenderFeedFake";
 import { useControlMeasureDrawSession } from "@/modules/scenarioeditor/useControlMeasureDrawSession";
+import type { NewControlMeasureDefaults } from "@/modules/scenarioeditor/controlMeasureDrawHelpers";
 import { isNTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
 import { useSelectedItems } from "@/stores/selectedStore";
 import "@/dayjs";
@@ -42,7 +43,7 @@ function controlMeasureIds(scenario: TScenario): string[] {
   );
 }
 
-function setup() {
+function setup(defaults?: NewControlMeasureDefaults) {
   const scenario = createScenario();
   const fake = createTacticalDrawSurfaceFake({ generateId: () => "cm-1" });
   const { feed, renders } = createTacticalGraphicRenderFeedFake();
@@ -53,6 +54,7 @@ function setup() {
       scenario,
       surface: () => fake.surface,
       renderFeed: feed,
+      defaults: defaults ? () => defaults : undefined,
       onSettled: (result) => settled.push(result),
     }),
   )!;
@@ -76,6 +78,14 @@ describe("useControlMeasureDrawSession", () => {
       echelon: "battalion",
       echelonSizePixels: 16,
     });
+  });
+
+  it("applies sticky smoothing over the kind's default options", () => {
+    const { draw, fake } = setup({ options: { smooth: true } });
+    draw.start("phase-line");
+
+    const draft = fake.calls.draw[0] as { options?: Record<string, unknown> };
+    expect(draft.options).toMatchObject({ smooth: true });
   });
 
   it("draws ground-anchored, so the pixel size bakes to meters at commit", () => {

--- a/src/modules/scenarioeditor/useControlMeasureDrawSession.ts
+++ b/src/modules/scenarioeditor/useControlMeasureDrawSession.ts
@@ -159,15 +159,13 @@ export function useControlMeasureDrawSession(
     const destinationLayerId = options.destinationLayerId?.();
     const surface = options.surface();
     if (!surface) return false;
+    const defaults = options.defaults?.(graphicKind) ?? {};
     openDestinationLayerId.value =
       destinationLayerId == null ? null : String(destinationLayerId);
     const draft = {
       kind: graphicKind,
-      options: draftOptionsForNewControlMeasure(graphicKind),
-      style: draftStyleForNewControlMeasure(
-        graphicKind,
-        options.defaults?.(graphicKind) ?? {},
-      ),
+      options: draftOptionsForNewControlMeasure(graphicKind, defaults),
+      style: draftStyleForNewControlMeasure(graphicKind, defaults),
     } as DrawMeasureDraft;
     surface
       .draw(draft, {

--- a/src/stores/controlMeasureToolStore.test.ts
+++ b/src/stores/controlMeasureToolStore.test.ts
@@ -100,4 +100,10 @@ describe("authoring defaults", () => {
     store.setDefaults({ style: undefined });
     expect(store.defaults.style).toBeUndefined();
   });
+
+  it("keeps generator options sticky for later control measures", () => {
+    const store = useControlMeasureToolStore();
+    store.setDefaults({ options: { smooth: true } });
+    expect(store.defaults.options).toEqual({ smooth: true });
+  });
 });

--- a/src/stores/controlMeasureToolStore.ts
+++ b/src/stores/controlMeasureToolStore.ts
@@ -41,10 +41,9 @@ export const DEFAULT_NEW_CONTROL_MEASURE_DEFAULTS: NewControlMeasureDefaults = {
  * additionally persist across reloads via localStorage; the authoring defaults stay
  * session-only.
  *
- * `defaults.style` is the *authored* style a new graphic may be born with. It is kept
- * ungated here and narrowed per kind on the way out (`newControlMeasureDefaults`), so a
- * colour picked for a polygon stays remembered while the user draws a phase line in
- * between.
+ * Authored style and generator options are kept ungated here and narrowed per kind on
+ * the way out (`newControlMeasureDefaults`). A polygon fill or smoothing choice stays
+ * remembered while the user works with a kind that cannot expose that control.
  */
 export const useControlMeasureToolStore = defineStore("controlMeasureTool", {
   state: () => ({


### PR DESCRIPTION
## Summary
- Apply the draw-toolbar style panel to selected control measures, including multi-selection updates.
- Keep selected style changes sticky for subsequent control-measure drawings.
- Persist supported Smooth options into new control-measure draw defaults.
- Gate Color, Fill, and Smooth by graphic capabilities.

## Validation
- Focused Vitest suites pass.
- TypeScript checking, ESLint, Prettier, and diff checks pass.