### PR TITLE
Polish control-measure details and recording

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -109,8 +109,8 @@ An open control-measure interaction owned by tactical-draw. Transient — nothin
 reaches the scenario store while it is open.
 
 **Commit on settle**:
-Exactly one scenario-store update per settled session, so a whole drawn control
-measure is one undo step and an aborted session leaves none.
+At most one scenario-store update per settled session. A changed session is one undo
+step; an unchanged edit or aborted draw leaves none.
 
 **Settle-first**:
 The rule that anything feeding `render()` settles an open session before

--- a/docs/adr/0006-control-measures-on-tactical-draw.md
+++ b/docs/adr/0006-control-measures-on-tactical-draw.md
@@ -120,9 +120,9 @@ kinds, whose declared timed state has never actually projected.
 ## Commit on settle
 
 A tactical-draw **session** — an open draw or edit interaction — is transient and
-**never touches the scenario store**. Exactly one scenario-store update happens per
-settled session, so a whole drawn control measure is one undo step and an aborted
-session leaves zero undo steps by construction.
+**never touches the scenario store**. At most one scenario-store update happens per
+settled session: a changed edit or committed draw is one undo step, while an unchanged
+edit or aborted draw leaves zero undo steps by construction.
 
 While a session is open, Ctrl+Z drives tactical-draw's own `SessionHistory`; with no
 session open it drives scenario undo. During a **draw** session Ctrl+Z is swallowed

--- a/src/components/ui/native-select/NativeSelect.vue
+++ b/src/components/ui/native-select/NativeSelect.vue
@@ -12,6 +12,7 @@ defineOptions({
 const props = defineProps<{
   modelValue?: AcceptableValue | AcceptableValue[];
   class?: HTMLAttributes["class"];
+  wrapperClass?: HTMLAttributes["class"];
 }>();
 
 const emit = defineEmits<{
@@ -23,12 +24,17 @@ const modelValue = useVModel(props, "modelValue", emit, {
   defaultValue: "",
 });
 
-const delegatedProps = reactiveOmit(props, "class");
+const delegatedProps = reactiveOmit(props, "class", "wrapperClass");
 </script>
 
 <template>
   <div
-    class="group/native-select relative w-fit has-[select:disabled]:opacity-50"
+    :class="
+      cn(
+        'group/native-select relative w-fit has-[select:disabled]:opacity-50',
+        props.wrapperClass,
+      )
+    "
     data-slot="native-select-wrapper"
   >
     <select

--- a/src/modules/maplibreview/useTacticalGraphicRenderFeed.test.ts
+++ b/src/modules/maplibreview/useTacticalGraphicRenderFeed.test.ts
@@ -23,7 +23,7 @@ function graphic(id: string): NScenarioLayerItem {
 }
 
 function createHarness() {
-  const state = reactive({ featureStateCounter: 0 });
+  const state = reactive({ currentTime: 0, featureStateCounter: 0 });
   const featureLayerEvent = createEventHook<unknown>();
   const undoRedo = createEventHook<unknown>();
   const layers = reactive<{ value: unknown[] }>({ value: [] });
@@ -70,24 +70,29 @@ describe("useTacticalGraphicRenderFeed", () => {
 
     expect(h.render).toHaveBeenCalledTimes(1);
 
-    // The store's own render signal: time scrubbing, `_hidden` flips, item writes.
-    h.state.featureStateCounter++;
+    // Time is explicit: a graphic without timed state does not bump the counter below.
+    h.state.currentTime++;
     await nextTick();
     expect(h.render).toHaveBeenCalledTimes(2);
+
+    // The store's render signal for `_hidden` flips and item writes.
+    h.state.featureStateCounter++;
+    await nextTick();
+    expect(h.render).toHaveBeenCalledTimes(3);
 
     // A layer-visibility toggle must settle too — that is why the guard is on the
     // feed rather than on the clock.
     useUiStore().layersPanelActive = !useUiStore().layersPanelActive;
     await nextTick();
-    expect(h.render).toHaveBeenCalledTimes(3);
+    expect(h.render).toHaveBeenCalledTimes(4);
 
     // Layer add/remove/move/update bypass featureStateCounter entirely.
     await h.featureLayerEvent.trigger({ type: "addLayer" });
-    expect(h.render).toHaveBeenCalledTimes(4);
+    expect(h.render).toHaveBeenCalledTimes(5);
 
     // Undoing a top-level control-measure edit touches neither of the above.
     await h.undoRedo.trigger({});
-    expect(h.render).toHaveBeenCalledTimes(5);
+    expect(h.render).toHaveBeenCalledTimes(6);
 
     scope.stop();
   });

--- a/src/modules/maplibreview/useTacticalGraphicRenderFeed.ts
+++ b/src/modules/maplibreview/useTacticalGraphicRenderFeed.ts
@@ -129,13 +129,16 @@ export function useTacticalGraphicRenderFeed(
       ?.setHighlightedGraphics(highlightedIdsFor(lastPlan, selectedFeatureIds.value));
   }
 
-  // `featureStateCounter` is the store's own render signal — it is bumped by time
-  // scrubbing, by `_hidden` flips and by every layer-item write. Layer add/remove/
-  // move/update bypass it entirely and arrive as feature-layer events instead, so
-  // both are needed for the feed to be complete. The surface replays its last batch
-  // itself on `style.load`, so a basemap swap needs nothing here.
+  // Time is an input in its own right: a newly drawn graphic has no `state[]`, so its
+  // first time scrub may not bump `featureStateCounter`, but it must still settle an
+  // open recording edit. Counter changes made by the clock itself are batched with the
+  // time change; a settled edit's store write may schedule an authoritative follow-up
+  // render. Layer add/remove/move/update bypass both and arrive as feature-layer events
+  // instead. The surface replays its last batch itself on `style.load`, so a basemap
+  // swap needs nothing here.
   watch(
     [
+      () => scenario.store.state.currentTime,
       () => scenario.store.state.featureStateCounter,
       () => uiStore.layersPanelActive,
       options.surface,

--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts
@@ -8,7 +8,7 @@ import SymbolCodeSelect from "@/components/SymbolCodeSelect.vue";
 
 const PreviewStub = defineComponent({
   name: "ControlMeasurePreview",
-  props: ["kind", "textAmplifiers"],
+  props: ["kind", "textAmplifiers", "options"],
   template: "<div data-test='preview' />",
 });
 
@@ -71,6 +71,28 @@ describe("ControlMeasureAmplifiers", () => {
     await nextTick();
 
     expect(wrapper.emitted("update-options")).toEqual([[{ echelon: "brigade" }]]);
+  });
+
+  it("keeps strong-point preview geometry representative while reflecting its echelon", () => {
+    const wrapper = mount(ControlMeasureAmplifiers, {
+      props: {
+        graphicKind: "strong-point",
+        options: {
+          echelon: "battalion",
+          echelonSize: 750,
+          smooth: false,
+          smoothResolution: 16,
+        },
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: { ControlMeasurePreview: PreviewStub },
+      },
+    });
+
+    expect(wrapper.getComponent(PreviewStub).props("options")).toEqual({
+      echelon: "battalion",
+    });
   });
 
   it("does not show an echelon selector for measures without one", () => {

--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts
@@ -95,6 +95,41 @@ describe("ControlMeasureAmplifiers", () => {
     });
   });
 
+  it("edits generic text without losing its other options", async () => {
+    const wrapper = mount(ControlMeasureAmplifiers, {
+      props: {
+        graphicKind: "text",
+        options: { text: "ALPHA", textAlign: "right", sizePixels: 32 },
+      },
+      global: { stubs: { ControlMeasurePreview: PreviewStub } },
+    });
+    const textarea = wrapper.get("textarea");
+
+    expect((textarea.element as HTMLTextAreaElement).value).toBe("ALPHA");
+    expect(wrapper.text()).not.toContain("This control measure has no text amplifiers.");
+
+    (textarea.element as HTMLTextAreaElement).value = "BRAVO\nCHARLIE";
+    await textarea.trigger("input");
+    expect(wrapper.emitted("update-options")).toBeUndefined();
+    expect(wrapper.getComponent(PreviewStub).props("options")).toEqual({
+      text: "BRAVO\nCHARLIE",
+    });
+
+    await textarea.trigger("change");
+    expect(wrapper.emitted("update-options")).toEqual([
+      [{ text: "BRAVO\nCHARLIE", textAlign: "right", sizePixels: 32 }],
+    ]);
+  });
+
+  it("shows the generic text default when no text option is stored", () => {
+    const wrapper = mount(ControlMeasureAmplifiers, {
+      props: { graphicKind: "text" },
+      global: { stubs: { ControlMeasurePreview: PreviewStub } },
+    });
+
+    expect((wrapper.get("textarea").element as HTMLTextAreaElement).value).toBe("Text");
+  });
+
   it("does not show an echelon selector for measures without one", () => {
     const wrapper = mount(ControlMeasureAmplifiers, {
       props: { graphicKind: "phase-line" },

--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts
@@ -2,7 +2,9 @@
 import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import { defineComponent, nextTick } from "vue";
+import { createPinia } from "pinia";
 import ControlMeasureAmplifiers from "@/modules/scenarioeditor/ControlMeasureAmplifiers.vue";
+import SymbolCodeSelect from "@/components/SymbolCodeSelect.vue";
 
 const PreviewStub = defineComponent({
   name: "ControlMeasurePreview",
@@ -44,6 +46,40 @@ describe("ControlMeasureAmplifiers", () => {
     await nextTick();
 
     expect(wrapper.emitted("update")).toEqual([[{ N: "ENY" }]]);
+  });
+
+  it("shows and commits the echelon selector for echelon-bearing measures", async () => {
+    const wrapper = mount(ControlMeasureAmplifiers, {
+      props: {
+        graphicKind: "boundary",
+        options: { echelon: "battalion" },
+      },
+      global: {
+        plugins: [createPinia()],
+        stubs: { ControlMeasurePreview: PreviewStub },
+      },
+    });
+    const select = wrapper.findComponent(SymbolCodeSelect);
+    expect(select.props("label")).toBe("Echelon");
+    expect(
+      (select.props("items") as { code: string; sidc: string }[]).find(
+        (item) => item.code === "brigade",
+      )?.sidc,
+    ).toBe("10031000180000000000");
+
+    select.vm.$emit("update:modelValue", "brigade");
+    await nextTick();
+
+    expect(wrapper.emitted("update-options")).toEqual([[{ echelon: "brigade" }]]);
+  });
+
+  it("does not show an echelon selector for measures without one", () => {
+    const wrapper = mount(ControlMeasureAmplifiers, {
+      props: { graphicKind: "phase-line" },
+      global: { stubs: { ControlMeasurePreview: PreviewStub } },
+    });
+
+    expect(wrapper.findComponent(SymbolCodeSelect).exists()).toBe(false);
   });
 
   it("explains when a measure has no amplifier fields", () => {

--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
@@ -1,14 +1,19 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { CONTROL_MEASURE_METADATA } from "@orbat-mapper/control-measures";
+import {
+  CONTROL_MEASURE_METADATA,
+  getDefaultOptions,
+} from "@orbat-mapper/control-measures";
 import type {
   ControlMeasureId,
   TextAmplifierDescriptor,
   TextAmplifiers,
 } from "@orbat-mapper/control-measures";
 import { Input } from "@/components/ui/input";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
 import ControlMeasurePreview from "@/modules/scenarioeditor/ControlMeasurePreview.vue";
 import ControlMeasureEchelonSelect from "@/modules/scenarioeditor/ControlMeasureEchelonSelect.vue";
 import type { TacticalGraphicOptions } from "@/types/scenarioLayerItems";
@@ -32,12 +37,27 @@ const previewAmplifiers = computed<TextAmplifiers>(() =>
     descriptors.value.map((descriptor) => [descriptor.key, `<${descriptor.key}>`]),
   ),
 );
+const isGenericText = computed(() => props.graphicKind === "text");
+const genericText = ref("");
+
+watch(
+  () => [props.graphicKind, props.options?.text] as const,
+  ([graphicKind, text]) => {
+    const defaults = getDefaultOptions(graphicKind) as TacticalGraphicOptions;
+    genericText.value = String(text ?? defaults.text ?? "");
+  },
+  { immediate: true },
+);
+
 // The registry's representative sample owns preview-only geometry tuning (for
 // example Strong Point's rounded outline and compact tic/echelon sizing). Only
 // the option edited in this panel should override that sample.
-const previewOptions = computed<TacticalGraphicOptions | undefined>(() =>
-  props.options?.echelon === undefined ? undefined : { echelon: props.options.echelon },
-);
+const previewOptions = computed<TacticalGraphicOptions | undefined>(() => {
+  if (isGenericText.value) return { text: genericText.value };
+  return props.options?.echelon === undefined
+    ? undefined
+    : { echelon: props.options.echelon };
+});
 const values = ref<TextAmplifiers>({});
 
 watch(
@@ -67,6 +87,10 @@ function commit() {
 function setHostile(descriptor: TextAmplifierDescriptor, checked: boolean) {
   setValue(descriptor.key, checked ? (descriptor.placeholder ?? "ENY") : "");
   commit();
+}
+
+function commitGenericText() {
+  emit("update-options", { ...props.options, text: genericText.value });
 }
 </script>
 
@@ -101,6 +125,20 @@ function setHostile(descriptor: TextAmplifierDescriptor, checked: boolean) {
       @update="emit('update-options', $event)"
     />
 
+    <Field v-if="isGenericText">
+      <FieldLabel for="control-measure-generic-text">Text</FieldLabel>
+      <FieldDescription>
+        The text to render. Explicit line breaks are preserved.
+      </FieldDescription>
+      <Textarea
+        id="control-measure-generic-text"
+        :model-value="genericText"
+        placeholder="Text"
+        @update:model-value="genericText = String($event)"
+        @change="commitGenericText"
+      />
+    </Field>
+
     <div v-if="descriptors.length" class="space-y-4">
       <div v-for="descriptor in descriptors" :key="descriptor.key" class="space-y-1.5">
         <div class="flex items-baseline justify-between gap-3">
@@ -133,7 +171,7 @@ function setHostile(descriptor: TextAmplifierDescriptor, checked: boolean) {
         />
       </div>
     </div>
-    <p v-else class="text-muted-foreground text-sm">
+    <p v-else-if="!isGenericText" class="text-muted-foreground text-sm">
       This control measure has no text amplifiers.
     </p>
   </div>

--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
@@ -10,14 +10,18 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import ControlMeasurePreview from "@/modules/scenarioeditor/ControlMeasurePreview.vue";
+import ControlMeasureEchelonSelect from "@/modules/scenarioeditor/ControlMeasureEchelonSelect.vue";
+import type { TacticalGraphicOptions } from "@/types/scenarioLayerItems";
 
 const props = defineProps<{
   graphicKind: ControlMeasureId;
   textAmplifiers?: TextAmplifiers;
+  options?: TacticalGraphicOptions;
 }>();
 
 const emit = defineEmits<{
   update: [textAmplifiers: TextAmplifiers];
+  "update-options": [options: TacticalGraphicOptions];
 }>();
 
 const descriptors = computed<readonly TextAmplifierDescriptor[]>(
@@ -76,10 +80,17 @@ function setHostile(descriptor: TextAmplifierDescriptor, checked: boolean) {
           :height="116"
           :pad="14"
           :stroke-width="2"
+          :options="options"
           class="h-36 w-full"
         />
       </div>
     </div>
+
+    <ControlMeasureEchelonSelect
+      :graphic-kind="graphicKind"
+      :options="options"
+      @update="emit('update-options', $event)"
+    />
 
     <div v-if="descriptors.length" class="space-y-4">
       <div v-for="descriptor in descriptors" :key="descriptor.key" class="space-y-1.5">

--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
@@ -32,6 +32,12 @@ const previewAmplifiers = computed<TextAmplifiers>(() =>
     descriptors.value.map((descriptor) => [descriptor.key, `<${descriptor.key}>`]),
   ),
 );
+// The registry's representative sample owns preview-only geometry tuning (for
+// example Strong Point's rounded outline and compact tic/echelon sizing). Only
+// the option edited in this panel should override that sample.
+const previewOptions = computed<TacticalGraphicOptions | undefined>(() =>
+  props.options?.echelon === undefined ? undefined : { echelon: props.options.echelon },
+);
 const values = ref<TextAmplifiers>({});
 
 watch(
@@ -79,8 +85,11 @@ function setHostile(descriptor: TextAmplifierDescriptor, checked: boolean) {
           :width="232"
           :height="116"
           :pad="14"
-          :stroke-width="2"
-          :options="options"
+          :stroke-width="1"
+          :fallback-font-size="10"
+          :max-font-size="16"
+          non-scaling-stroke
+          :options="previewOptions"
           class="h-36 w-full"
         />
       </div>

--- a/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.test.ts
@@ -5,6 +5,7 @@ import { mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import ControlMeasureDefaultsPopover from "@/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue";
 import ControlMeasureStyleSettings from "@/modules/scenarioeditor/ControlMeasureStyleSettings.vue";
+import SymbolCodeSelect from "@/components/SymbolCodeSelect.vue";
 import { activeScenarioKey, scenarioDrawKey } from "@/components/injects";
 import { useSelectedItems } from "@/stores/selectedStore";
 import { useControlMeasureToolStore } from "@/stores/controlMeasureToolStore";
@@ -104,6 +105,28 @@ describe("ControlMeasureDefaultsPopover", () => {
       style: { color: "#ff0000" },
     });
     expect(useControlMeasureToolStore().defaults.style).toEqual({ color: "#ff0000" });
+  });
+
+  it("shows the echelon selector in the palette for echelon-bearing measures", async () => {
+    const selected = item("cm-1", "boundary", undefined);
+    const { wrapper, updateControlMeasure } = mountPopover([selected]);
+    useSelectedItems().selectedFeatureIds.value = new Set([selected.id]);
+    await nextTick();
+
+    const select = wrapper.findComponent(SymbolCodeSelect);
+    expect(select.props("label")).toBe("Echelon");
+    expect(select.classes()).toContain("col-span-2");
+    expect(
+      (select.props("items") as { code: string; sidc: string }[]).find(
+        (item) => item.code === "brigade",
+      )?.sidc,
+    ).toBe("10031000180000000000");
+    select.vm.$emit("update:modelValue", "brigade");
+    await nextTick();
+
+    expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
+      options: { echelon: "brigade" },
+    });
   });
 
   it("preserves unrelated styling when changing a multi-selection", async () => {

--- a/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.test.ts
@@ -89,6 +89,16 @@ describe("ControlMeasureDefaultsPopover", () => {
     expect(store.defaults.options).toEqual({ smooth: true });
   });
 
+  it("shows stroke-width presets in the palette popover", async () => {
+    const { wrapper } = mountPopover([]);
+    const store = useControlMeasureToolStore();
+    store.lastKind = "phase-line";
+    await nextTick();
+
+    await wrapper.get("button[aria-label='Heavy stroke, 4 pixels']").trigger("click");
+    expect(store.defaults.style?.strokeWidth).toBe(4);
+  });
+
   it("applies settings to the selected control measure instead of defaults", async () => {
     const selected = item("cm-1", "polygon", { color: "#112233" });
     const { wrapper, updateControlMeasure } = mountPopover([selected]);

--- a/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.test.ts
@@ -125,7 +125,7 @@ describe("ControlMeasureDefaultsPopover", () => {
 
     const select = wrapper.findComponent(SymbolCodeSelect);
     expect(select.props("label")).toBe("Echelon");
-    expect(select.classes()).toContain("col-span-2");
+    expect(select.classes()).toContain("contents");
     expect(
       (select.props("items") as { code: string; sidc: string }[]).find(
         (item) => item.code === "brigade",

--- a/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue
@@ -51,10 +51,7 @@ const selectedItems = computed<NTacticalGraphicLayerItem[]>(() => {
 const primaryItem = computed(() => selectedItems.value[0]);
 const editsSelection = computed(() => selectedItems.value.length > 0);
 
-function changedFields(
-  before: object | undefined,
-  after: object,
-) {
+function changedFields(before: object | undefined, after: object) {
   const beforeValues = before as Record<string, unknown> | undefined;
   const afterValues = after as Record<string, unknown>;
   return [...new Set([...Object.keys(before ?? {}), ...Object.keys(after)])].filter(
@@ -196,7 +193,10 @@ function updateSettings(data: ControlMeasureStyleUpdate) {
         />
         <ControlMeasureEchelonSelect
           :graphic-kind="primaryItem?.graphicKind ?? lastKind"
-          :options="primaryItem ? resolveControlMeasureOptions(primaryItem) : defaults.options"
+          :options="
+            primaryItem ? resolveControlMeasureOptions(primaryItem) : defaults.options
+          "
+          inline
           @update="updateSettings({ options: $event })"
         />
       </PanelDataGrid>

--- a/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue
@@ -17,6 +17,7 @@ import PanelDataGrid from "@/components/PanelDataGrid.vue";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useControlMeasureToolStore } from "@/stores/controlMeasureToolStore";
 import ControlMeasureStyleSettings from "@/modules/scenarioeditor/ControlMeasureStyleSettings.vue";
+import ControlMeasureEchelonSelect from "@/modules/scenarioeditor/ControlMeasureEchelonSelect.vue";
 import type { ControlMeasureStyleUpdate } from "@/modules/scenarioeditor/controlMeasureStyleOptions";
 import { activeScenarioKey, scenarioDrawKey } from "@/components/injects";
 import { useSelectedItems } from "@/stores/selectedStore";
@@ -192,6 +193,11 @@ function updateSettings(data: ControlMeasureStyleUpdate) {
             primaryItem ? resolveControlMeasureOptions(primaryItem) : defaults.options
           "
           @update="updateSettings"
+        />
+        <ControlMeasureEchelonSelect
+          :graphic-kind="primaryItem?.graphicKind ?? lastKind"
+          :options="primaryItem ? resolveControlMeasureOptions(primaryItem) : defaults.options"
+          @update="updateSettings({ options: $event })"
         />
       </PanelDataGrid>
     </PopoverContent>

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -215,6 +215,25 @@ describe("ControlMeasureDetails tabs", () => {
     });
   });
 
+  it("writes generic text options through the amplifiers tab", async () => {
+    const { wrapper, updateControlMeasure } = mountDetails({
+      graphicKind: "text",
+      options: { text: "ALPHA", textAlign: "center" },
+    });
+    const settings = wrapper.findComponent(ControlMeasureAmplifiersStub);
+
+    expect(settings.props("graphicKind")).toBe("text");
+    expect(settings.props("options")).toEqual({ text: "ALPHA", textAlign: "center" });
+    await settings.vm.$emit("update-options", {
+      text: "BRAVO",
+      textAlign: "center",
+    });
+
+    expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
+      options: { text: "BRAVO", textAlign: "center" },
+    });
+  });
+
   it("writes echelon options through the settle-first control-measure path", async () => {
     const { wrapper, updateControlMeasure } = mountDetails({
       graphicKind: "boundary",

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -40,8 +40,8 @@ const ControlMeasureStyleSettingsStub = defineComponent({
 
 const ControlMeasureAmplifiersStub = defineComponent({
   name: "ControlMeasureAmplifiers",
-  props: ["graphicKind", "textAmplifiers"],
-  emits: ["update"],
+  props: ["graphicKind", "textAmplifiers", "options"],
+  emits: ["update", "update-options"],
   template: "<div data-test='amplifier-settings' />",
 });
 
@@ -200,6 +200,21 @@ describe("ControlMeasureDetails tabs", () => {
     await settings.vm.$emit("update", { T: "BRAVO" });
     expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
       textAmplifiers: { T: "BRAVO" },
+    });
+  });
+
+  it("writes echelon options through the settle-first control-measure path", async () => {
+    const { wrapper, updateControlMeasure } = mountDetails({
+      graphicKind: "boundary",
+      options: { echelon: "battalion" },
+    });
+    const settings = wrapper.findComponent(ControlMeasureAmplifiersStub);
+
+    expect(settings.props("options")).toEqual({ echelon: "battalion" });
+    await settings.vm.$emit("update-options", { echelon: "brigade" });
+
+    expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
+      options: { echelon: "brigade" },
     });
   });
 

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -45,6 +45,17 @@ const ControlMeasureAmplifiersStub = defineComponent({
   template: "<div data-test='amplifier-settings' />",
 });
 
+const ControlMeasureEchelonSelectStub = defineComponent({
+  name: "ControlMeasureEchelonSelect",
+  props: {
+    graphicKind: String,
+    options: Object,
+    inline: Boolean,
+  },
+  emits: ["update"],
+  template: "<div data-test='echelon-select' />",
+});
+
 const baseStubs = {
   DetailsPanelHeader: {
     template:
@@ -57,6 +68,7 @@ const baseStubs = {
   TabsContent: { template: "<section><slot /></section>" },
   ControlMeasureStyleSettings: ControlMeasureStyleSettingsStub,
   ControlMeasureAmplifiers: ControlMeasureAmplifiersStub,
+  ControlMeasureEchelonSelect: ControlMeasureEchelonSelectStub,
   ScenarioLayerItemState: true,
   EditMetaForm: true,
   IconButton: {
@@ -208,10 +220,12 @@ describe("ControlMeasureDetails tabs", () => {
       graphicKind: "boundary",
       options: { echelon: "battalion" },
     });
-    const settings = wrapper.findComponent(ControlMeasureAmplifiersStub);
+    const settings = wrapper.findComponent(ControlMeasureEchelonSelectStub);
 
+    expect(settings.props("graphicKind")).toBe("boundary");
     expect(settings.props("options")).toEqual({ echelon: "battalion" });
-    await settings.vm.$emit("update-options", { echelon: "brigade" });
+    expect(settings.props("inline")).toBe(true);
+    await settings.vm.$emit("update", { echelon: "brigade" });
 
     expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
       options: { echelon: "brigade" },

--- a/src/modules/scenarioeditor/ControlMeasureDetails.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.vue
@@ -54,6 +54,7 @@ import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue"
 import PanelTitle from "@/modules/scenarioeditor/PanelTitle.vue";
 import PanelDataGrid from "@/components/PanelDataGrid.vue";
 import ControlMeasureStyleSettings from "@/modules/scenarioeditor/ControlMeasureStyleSettings.vue";
+import ControlMeasureEchelonSelect from "@/modules/scenarioeditor/ControlMeasureEchelonSelect.vue";
 import ControlMeasureAmplifiers from "@/modules/scenarioeditor/ControlMeasureAmplifiers.vue";
 import EditableLabel from "@/components/EditableLabel.vue";
 import EditMetaForm from "@/modules/scenarioeditor/EditMetaForm.vue";
@@ -185,7 +186,7 @@ function doAmplifierUpdate(textAmplifiers: NTacticalGraphicLayerItem["textAmplif
   if (item.value) scenarioDraw.updateControlMeasure(item.value.id, { textAmplifiers });
 }
 
-function doAmplifierOptionsUpdate(options: TacticalGraphicOptions) {
+function doControlMeasureOptionsUpdate(options: TacticalGraphicOptions) {
   if (item.value) scenarioDraw.updateControlMeasure(item.value.id, { options });
 }
 
@@ -362,6 +363,12 @@ function doDelete() {
               :show-heading="false"
               @update="doStyleUpdate"
             />
+            <ControlMeasureEchelonSelect
+              :graphic-kind="item.graphicKind as ControlMeasureId"
+              :options="resolvedOptions"
+              inline
+              @update="doControlMeasureOptionsUpdate"
+            />
           </PanelDataGrid>
         </TabsContent>
         <TabsContent value="1" class="mx-4">
@@ -371,7 +378,7 @@ function doDelete() {
             :text-amplifiers="item.textAmplifiers"
             :options="resolvedOptions"
             @update="doAmplifierUpdate"
-            @update-options="doAmplifierOptionsUpdate"
+            @update-options="doControlMeasureOptionsUpdate"
           />
           <p v-else class="text-muted-foreground pt-4 text-sm">
             Amplifiers are unavailable for this unsupported control measure.

--- a/src/modules/scenarioeditor/ControlMeasureDetails.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.vue
@@ -46,7 +46,10 @@ import {
 import { isSupportedGraphicKind } from "@/scenariostore/tacticalGraphics";
 import type { ControlMeasureStyleUpdate } from "@/modules/scenarioeditor/controlMeasureStyleOptions";
 import { isNTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
-import type { NTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
+import type {
+  NTacticalGraphicLayerItem,
+  TacticalGraphicOptions,
+} from "@/types/scenarioLayerItems";
 import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue";
 import PanelTitle from "@/modules/scenarioeditor/PanelTitle.vue";
 import PanelDataGrid from "@/components/PanelDataGrid.vue";
@@ -180,6 +183,10 @@ function doStyleUpdate(data: ControlMeasureStyleUpdate) {
 
 function doAmplifierUpdate(textAmplifiers: NTacticalGraphicLayerItem["textAmplifiers"]) {
   if (item.value) scenarioDraw.updateControlMeasure(item.value.id, { textAmplifiers });
+}
+
+function doAmplifierOptionsUpdate(options: TacticalGraphicOptions) {
+  if (item.value) scenarioDraw.updateControlMeasure(item.value.id, { options });
 }
 
 function resetLabelPositions() {
@@ -362,7 +369,9 @@ function doDelete() {
             v-if="supported"
             :graphic-kind="item.graphicKind as ControlMeasureId"
             :text-amplifiers="item.textAmplifiers"
+            :options="resolvedOptions"
             @update="doAmplifierUpdate"
+            @update-options="doAmplifierOptionsUpdate"
           />
           <p v-else class="text-muted-foreground pt-4 text-sm">
             Amplifiers are unavailable for this unsupported control measure.

--- a/src/modules/scenarioeditor/ControlMeasureEchelonSelect.vue
+++ b/src/modules/scenarioeditor/ControlMeasureEchelonSelect.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import {
+  CONTROL_MEASURE_METADATA,
+  getDefaultOptions,
+} from "@orbat-mapper/control-measures";
+import type { ControlMeasureId } from "@orbat-mapper/control-measures";
+import SymbolCodeSelect from "@/components/SymbolCodeSelect.vue";
+import { SID, UNIT_SYMBOLSET_VALUE } from "@/symbology/values";
+import type { SymbolItem } from "@/types/constants";
+import type { TacticalGraphicOptions } from "@/types/scenarioLayerItems";
+
+const ECHELON_CODE_BY_VALUE: Record<string, string> = {
+  none: "00",
+  team: "11",
+  squad: "12",
+  section: "13",
+  platoon: "14",
+  company: "15",
+  battalion: "16",
+  regiment: "17",
+  brigade: "18",
+  division: "21",
+  corps: "22",
+  army: "23",
+  "army-group": "24",
+  region: "25",
+  command: "26",
+};
+
+const props = defineProps<{
+  graphicKind?: ControlMeasureId;
+  options?: TacticalGraphicOptions;
+}>();
+
+const emit = defineEmits<{
+  update: [options: TacticalGraphicOptions];
+}>();
+
+const echelonParam = computed(() =>
+  props.graphicKind === undefined
+    ? undefined
+    : CONTROL_MEASURE_METADATA[props.graphicKind]?.params?.find(
+        (param) => param.key === "echelon" && param.type === "enum",
+      ),
+);
+const echelonOptions = computed(() =>
+  echelonParam.value?.type === "enum" ? echelonParam.value.options : [],
+);
+
+function echelonSidc(code: string): string {
+  return `100${SID.Friend}${UNIT_SYMBOLSET_VALUE}00${code}0000000000`;
+}
+
+const echelonItems = computed<SymbolItem[]>(() => {
+  const items = new Map<string, SymbolItem>();
+  items.set("none", {
+    code: "none",
+    text: "None",
+    sidc: echelonSidc("00"),
+  });
+  for (const option of echelonOptions.value) {
+    const value = String(option.value);
+    items.set(value, {
+      code: value,
+      text: option.label,
+      sidc: echelonSidc(ECHELON_CODE_BY_VALUE[value] ?? "00"),
+    });
+  }
+  return [...items.values()];
+});
+
+const defaultEchelon = computed(() => {
+  if (!props.graphicKind) return "none";
+  const defaults = getDefaultOptions(props.graphicKind) as Record<string, unknown>;
+  return String(defaults.echelon ?? "none");
+});
+
+const selectedEchelon = computed({
+  get: () => String(props.options?.echelon ?? defaultEchelon.value),
+  set: (value: string | null) => {
+    if (value) emit("update", { ...props.options, echelon: value });
+  },
+});
+</script>
+
+<template>
+  <SymbolCodeSelect
+    v-if="echelonOptions.length"
+    v-model="selectedEchelon"
+    class="col-span-2 w-full"
+    label="Echelon"
+    :items="echelonItems"
+  />
+</template>

--- a/src/modules/scenarioeditor/ControlMeasureEchelonSelect.vue
+++ b/src/modules/scenarioeditor/ControlMeasureEchelonSelect.vue
@@ -9,6 +9,7 @@ import SymbolCodeSelect from "@/components/SymbolCodeSelect.vue";
 import { SID, UNIT_SYMBOLSET_VALUE } from "@/symbology/values";
 import type { SymbolItem } from "@/types/constants";
 import type { TacticalGraphicOptions } from "@/types/scenarioLayerItems";
+import { cn } from "@/lib/utils";
 
 const ECHELON_CODE_BY_VALUE: Record<string, string> = {
   none: "00",
@@ -31,6 +32,7 @@ const ECHELON_CODE_BY_VALUE: Record<string, string> = {
 const props = defineProps<{
   graphicKind?: ControlMeasureId;
   options?: TacticalGraphicOptions;
+  inline?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -88,7 +90,7 @@ const selectedEchelon = computed({
   <SymbolCodeSelect
     v-if="echelonOptions.length"
     v-model="selectedEchelon"
-    class="col-span-2 w-full"
+    :class="cn(inline ? 'contents' : 'w-full')"
     label="Echelon"
     :items="echelonItems"
   />

--- a/src/modules/scenarioeditor/ControlMeasurePreview.vue
+++ b/src/modules/scenarioeditor/ControlMeasurePreview.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, useId } from "vue";
 import {
+  previewLabelBackgroundWidth,
   PREVIEW_FILL_PATTERNS,
   PREVIEW_PATTERN_DOT_RADIUS,
   PREVIEW_PATTERN_TILE,
@@ -31,8 +32,11 @@ const props = withDefaults(
     width?: number;
     height?: number;
     pad?: number;
+    fallbackFontSize?: number;
+    maxFontSize?: number;
+    nonScalingStroke?: boolean;
   }>(),
-  { strokeWidth: 4, width: 100, height: 100, pad: 8 },
+  { strokeWidth: 4, width: 100, height: 100, pad: 8, fallbackFontSize: 14 },
 );
 
 const preview = computed(() =>
@@ -41,12 +45,16 @@ const preview = computed(() =>
     { width: props.width, height: props.height, pad: props.pad },
     props.textAmplifiers,
     props.options,
+    {
+      fallbackFontSize: props.fallbackFontSize,
+      maxFontSize: props.maxFontSize,
+    },
   ),
 );
 const geometry = computed(() => CONTROL_MEASURE_METADATA[props.kind]?.geometry);
 
 // Pattern ids are document-global, so every instance gets its own prefix.
-const patternPrefix = useId();
+const patternPrefix = useId().replace(/:/g, "-");
 const usedPatterns = computed(() =>
   PREVIEW_FILL_PATTERNS.filter((pattern) =>
     preview.value.shapes.some((shape) => shape.fillPattern === pattern.id),
@@ -56,6 +64,17 @@ const usedPatterns = computed(() =>
 function fillFor(shape: PreviewShape): string {
   if (shape.fillPattern) return `url(#${patternPrefix}-${shape.fillPattern})`;
   return shape.filled ? "currentColor" : "none";
+}
+
+function labelFontSize(shape: PreviewShape): number {
+  return previewFontSize(shape, {
+    fallbackFontSize: props.fallbackFontSize,
+    maxFontSize: props.maxFontSize,
+  });
+}
+
+function textBackgroundWidth(shape: PreviewShape): number {
+  return previewLabelBackgroundWidth(shape.text, labelFontSize(shape));
 }
 </script>
 
@@ -100,6 +119,7 @@ function fillFor(shape: PreviewShape): string {
         :d="shape.d"
         stroke="currentColor"
         :stroke-width="strokeWidth"
+        :vector-effect="nonScalingStroke ? 'non-scaling-stroke' : undefined"
       />
       <path
         v-else-if="shape.type === 'polygon'"
@@ -107,6 +127,7 @@ function fillFor(shape: PreviewShape): string {
         stroke="currentColor"
         :stroke-width="strokeWidth"
         :fill="fillFor(shape)"
+        :vector-effect="nonScalingStroke ? 'non-scaling-stroke' : undefined"
       />
       <circle
         v-else-if="shape.type === 'circle'"
@@ -115,20 +136,34 @@ function fillFor(shape: PreviewShape): string {
         :r="PREVIEW_VERTEX_RADIUS"
         fill="currentColor"
       />
-      <text
+      <g
         v-else-if="shape.type === 'text' && shape.cx !== undefined"
-        :x="shape.cx"
-        :y="shape.cy"
-        :font-size="previewFontSize(shape)"
-        :text-anchor="shape.textAnchor ?? 'middle'"
         :transform="svgTextTransform(shape)"
-        :font-style="shape.textStyle === 'italic' ? 'italic' : undefined"
-        dominant-baseline="central"
-        fill="currentColor"
-        stroke="none"
       >
-        {{ shape.text }}
-      </text>
+        <rect
+          v-if="shape.textBackground"
+          :x="Number(shape.cx) - textBackgroundWidth(shape) / 2"
+          :y="Number(shape.cy) - (labelFontSize(shape) + 4) / 2"
+          :width="textBackgroundWidth(shape)"
+          :height="labelFontSize(shape) + 4"
+          rx="1.5"
+          fill="var(--background)"
+        />
+        <text
+          :x="shape.cx"
+          :y="shape.cy"
+          :font-size="labelFontSize(shape)"
+          :text-anchor="shape.textAnchor ?? 'middle'"
+          :font-style="shape.textStyle === 'italic' ? 'italic' : undefined"
+          font-family="sans-serif"
+          font-weight="600"
+          dominant-baseline="central"
+          fill="currentColor"
+          stroke="none"
+        >
+          {{ shape.text }}
+        </text>
+      </g>
     </template>
 
     <!-- Degenerate render (an empty sample, or a kind the library could not draw):
@@ -147,6 +182,7 @@ function fillFor(shape: PreviewShape): string {
         stroke="currentColor"
         :stroke-width="strokeWidth"
         stroke-dasharray="10 8"
+        :vector-effect="nonScalingStroke ? 'non-scaling-stroke' : undefined"
       />
       <path
         v-else
@@ -154,6 +190,7 @@ function fillFor(shape: PreviewShape): string {
         stroke="currentColor"
         :stroke-width="strokeWidth"
         stroke-dasharray="10 8"
+        :vector-effect="nonScalingStroke ? 'non-scaling-stroke' : undefined"
       />
     </template>
   </svg>

--- a/src/modules/scenarioeditor/ControlMeasurePreview.vue
+++ b/src/modules/scenarioeditor/ControlMeasurePreview.vue
@@ -9,6 +9,7 @@ import {
 import type { PreviewShape } from "@orbat-mapper/control-measures/preview";
 import { CONTROL_MEASURE_METADATA } from "@orbat-mapper/control-measures";
 import type { ControlMeasureId, TextAmplifiers } from "@orbat-mapper/control-measures";
+import type { TacticalGraphicOptions } from "@/types/scenarioLayerItems";
 import {
   PREVIEW_VERTEX_RADIUS,
   buildControlMeasurePreview,
@@ -26,6 +27,7 @@ const props = withDefaults(
     kind: ControlMeasureId;
     strokeWidth?: number;
     textAmplifiers?: TextAmplifiers;
+    options?: TacticalGraphicOptions;
     width?: number;
     height?: number;
     pad?: number;
@@ -38,6 +40,7 @@ const preview = computed(() =>
     props.kind,
     { width: props.width, height: props.height, pad: props.pad },
     props.textAmplifiers,
+    props.options,
   ),
 );
 const geometry = computed(() => CONTROL_MEASURE_METADATA[props.kind]?.geometry);

--- a/src/modules/scenarioeditor/ControlMeasurePreview.vue.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasurePreview.vue.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { CONTROL_MEASURE_METADATA } from "@orbat-mapper/control-measures";
+import ControlMeasurePreview from "@/modules/scenarioeditor/ControlMeasurePreview.vue";
+
+function amplifierPlaceholders(kind: "no-fire-area-irregular" | "boundary") {
+  return Object.fromEntries(
+    (CONTROL_MEASURE_METADATA[kind]?.textAmplifiers ?? []).map(({ key }) => [
+      key,
+      `<${key}>`,
+    ]),
+  );
+}
+
+describe("ControlMeasurePreview", () => {
+  it("keeps amplifier labels readable over a patterned area", () => {
+    const wrapper = mount(ControlMeasurePreview, {
+      props: {
+        kind: "no-fire-area-irregular",
+        textAmplifiers: amplifierPlaceholders("no-fire-area-irregular"),
+        width: 232,
+        height: 116,
+        pad: 14,
+        strokeWidth: 1,
+        nonScalingStroke: true,
+      },
+    });
+
+    const labels = wrapper.findAll("text");
+    expect(labels.map((text) => text.text())).toContain("NFA");
+    expect(wrapper.findAll("g rect")).toHaveLength(5);
+    expect(
+      wrapper
+        .findAll("g rect")
+        .every((rect) => rect.attributes("fill") === "var(--background)"),
+    ).toBe(true);
+    const geometryPaths = wrapper
+      .findAll("path[d]")
+      .filter((path) => !path.element.closest("defs"));
+    expect(
+      geometryPaths.every(
+        (path) => path.attributes("vector-effect") === "non-scaling-stroke",
+      ),
+    ).toBe(true);
+  });
+
+  it("caps ground-sized labels in the wide amplifier preview", () => {
+    const wrapper = mount(ControlMeasurePreview, {
+      props: {
+        kind: "boundary",
+        textAmplifiers: amplifierPlaceholders("boundary"),
+        width: 232,
+        height: 116,
+        pad: 14,
+        fallbackFontSize: 10,
+        maxFontSize: 16,
+      },
+    });
+
+    const fontSizes = wrapper
+      .findAll("text")
+      .map((text) => Number(text.attributes("font-size")));
+    expect(Math.max(...fontSizes)).toBe(16);
+  });
+});

--- a/src/modules/scenarioeditor/ControlMeasureStrokeWidthChoices.vue
+++ b/src/modules/scenarioeditor/ControlMeasureStrokeWidthChoices.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { CONTROL_MEASURE_STROKE_WIDTH_PRESETS } from "@/modules/scenarioeditor/controlMeasureStyleOptions";
+
+defineProps<{ modelValue: number }>();
+const emit = defineEmits<{ "update:modelValue": [value: number] }>();
+
+function choose(value: unknown) {
+  if (typeof value === "number") emit("update:modelValue", value);
+}
+</script>
+
+<template>
+  <ToggleGroup
+    type="single"
+    :disable-deselection="true"
+    :model-value="modelValue"
+    variant="outline"
+    class="grid w-full grid-cols-3 gap-1"
+    aria-label="Stroke width"
+    @update:model-value="choose"
+  >
+    <ToggleGroupItem
+      v-for="preset in CONTROL_MEASURE_STROKE_WIDTH_PRESETS"
+      :key="preset.value"
+      :value="preset.value"
+      class="w-full px-2"
+      :aria-label="`${preset.label} stroke, ${preset.value} ${preset.value === 1 ? 'pixel' : 'pixels'}`"
+      :title="preset.label"
+    >
+      <span
+        class="block w-10 max-w-full border-t border-current"
+        aria-hidden="true"
+        :style="{ borderTopWidth: `${preset.value}px` }"
+      />
+    </ToggleGroupItem>
+  </ToggleGroup>
+</template>

--- a/src/modules/scenarioeditor/ControlMeasureStyleSettings.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureStyleSettings.test.ts
@@ -109,7 +109,9 @@ describe("what it emits", () => {
       graphicKind: "polygon",
       measureStyle: { strokeWidth: 3, color: "#ff0000" },
     });
-    await wrapper.find("button").trigger("click");
+    await wrapper
+      .get("button[title='Use the color the standard identity resolves to']")
+      .trigger("click");
     expect(wrapper.emitted("update")).toEqual([[{ style: { strokeWidth: 3 } }]]);
   });
 
@@ -120,6 +122,45 @@ describe("what it emits", () => {
     });
     await wrapper.findAll("select")[3]!.setValue("");
     expect(wrapper.emitted("update")).toEqual([[{ style: {} }]]);
+  });
+});
+
+describe("the stroke-width presets", () => {
+  it("offers Thin, Medium, and Heavy for a stroked control measure", () => {
+    const wrapper = mountSettings({ graphicKind: "phase-line" });
+    const choices = wrapper.get("[aria-label='Stroke width']");
+
+    expect(
+      choices.findAll("button").map((button) => button.attributes("aria-label")),
+    ).toEqual([
+      "Thin stroke, 1 pixel",
+      "Medium stroke, 2 pixels",
+      "Heavy stroke, 4 pixels",
+    ]);
+    expect(
+      choices
+        .findAll("button")
+        .find((button) => button.attributes("aria-label") === "Medium stroke, 2 pixels")
+        ?.attributes("data-state"),
+    ).toBe("on");
+  });
+
+  it("hides stroke width for a text-only graphic", () => {
+    const wrapper = mountSettings({ graphicKind: "text" });
+    expect(wrapper.find("[aria-label='Stroke width']").exists()).toBe(false);
+  });
+
+  it("merges a chosen preset into the authored style", async () => {
+    const wrapper = mountSettings({
+      graphicKind: "phase-line",
+      measureStyle: { color: "#123456" },
+    });
+
+    await wrapper.get("button[aria-label='Heavy stroke, 4 pixels']").trigger("click");
+
+    expect(wrapper.emitted("update")).toEqual([
+      [{ style: { color: "#123456", strokeWidth: 4 } }],
+    ]);
   });
 });
 

--- a/src/modules/scenarioeditor/ControlMeasureStyleSettings.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureStyleSettings.test.ts
@@ -29,6 +29,18 @@ function labels(wrapper: ReturnType<typeof mountSettings>): string[] {
 }
 
 describe("the UI-only styling gate", () => {
+  it("gives every native select the full control-column width", () => {
+    const wrapper = mountSettings({ graphicKind: "phase-line" });
+    const nativeSelectWrappers = wrapper.findAll("[data-slot='native-select-wrapper']");
+
+    expect(nativeSelectWrappers).toHaveLength(3);
+    expect(
+      nativeSelectWrappers.every((selectWrapper) =>
+        selectWrapper.classes().includes("w-full"),
+      ),
+    ).toBe(true);
+  });
+
   it("offers colour and fill on a Generic Graphics kind that can be filled", () => {
     const wrapper = mountSettings({ graphicKind: "polygon" });
     expect(labels(wrapper)).toContain("Color");

--- a/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
+++ b/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
@@ -177,7 +177,12 @@ const fillPatternModel = computed({
   </div>
 
   <label for="cm-identity" class="self-center">Identity</label>
-  <NativeSelect id="cm-identity" class="w-full" v-model="identityModel">
+  <NativeSelect
+    id="cm-identity"
+    class="w-full"
+    wrapper-class="w-full"
+    v-model="identityModel"
+  >
     <NativeSelectOption
       v-for="identity in standardIdentityValues"
       :key="identity.code"
@@ -188,13 +193,23 @@ const fillPatternModel = computed({
   </NativeSelect>
 
   <label for="cm-color-mode" class="self-center">Colors</label>
-  <NativeSelect id="cm-color-mode" class="w-full" v-model="colorModeModel">
+  <NativeSelect
+    id="cm-color-mode"
+    class="w-full"
+    wrapper-class="w-full"
+    v-model="colorModeModel"
+  >
     <NativeSelectOption value="identity">Identity</NativeSelectOption>
     <NativeSelectOption value="monochrome">Monochrome</NativeSelectOption>
   </NativeSelect>
 
   <label for="cm-status" class="self-center">Status</label>
-  <NativeSelect id="cm-status" class="w-full" v-model="statusModel">
+  <NativeSelect
+    id="cm-status"
+    class="w-full"
+    wrapper-class="w-full"
+    v-model="statusModel"
+  >
     <NativeSelectOption value="present">Present</NativeSelectOption>
     <NativeSelectOption value="planned">Planned</NativeSelectOption>
   </NativeSelect>
@@ -226,7 +241,12 @@ const fillPatternModel = computed({
 
   <template v-if="showFillPattern">
     <label for="cm-fill-pattern" class="self-center">Fill</label>
-    <NativeSelect id="cm-fill-pattern" class="w-full" v-model="fillPatternModel">
+    <NativeSelect
+      id="cm-fill-pattern"
+      class="w-full"
+      wrapper-class="w-full"
+      v-model="fillPatternModel"
+    >
       <NativeSelectOption value="">Default</NativeSelectOption>
       <NativeSelectOption
         v-for="pattern in CONTROL_MEASURE_FILL_PATTERNS"

--- a/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
+++ b/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
@@ -11,9 +11,9 @@
  *   slider drags and rolls back on commit; nothing here ever writes mid-gesture, so
  *   every emit is already one settled change and the host can write it undoably once.
  * - **No gating anywhere but here.** Colour and fill pattern are offered only for the
- *   7 Generic Graphics kinds (ADR-0006), but that is a UI judgement about doctrinal
- *   symbology — the model and `toControlMeasure` stay uniform, so an imported colour
- *   on a doctrinal kind still renders.
+ *   7 Generic Graphics kinds (ADR-0006), while stroke width follows the registry's
+ *   paint capability. Those are UI judgements — the model and `toControlMeasure` stay
+ *   uniform, so imported styling still renders.
  *
  * Defaults are edited for the toolbar's currently chosen kind, so the same capability
  * gate applies before and after a graphic is born.
@@ -35,11 +35,14 @@ import type {
 } from "@/types/scenarioLayerItems";
 import { resolveControlMeasureColorFrom } from "@/geo/controlMeasures";
 import ControlMeasureColorPicker from "@/modules/scenarioeditor/ControlMeasureColorPicker.vue";
+import ControlMeasureStrokeWidthChoices from "@/modules/scenarioeditor/ControlMeasureStrokeWidthChoices.vue";
 import {
   CONTROL_MEASURE_FILL_PATTERNS,
+  CONTROL_MEASURE_STROKE_WIDTH_DEFAULT,
   type ControlMeasureFillPattern,
   type ControlMeasureStyleUpdate,
   canAuthorFillPattern,
+  canAuthorStrokeWidth,
   canSmoothControlMeasureKind,
   fillPatternLabel,
   isControlMeasureSmoothed,
@@ -83,6 +86,9 @@ const showColor = computed(
 );
 const showFillPattern = computed(
   () => editedKinds.value.length > 0 && editedKinds.value.every(canAuthorFillPattern),
+);
+const showStrokeWidth = computed(
+  () => editedKinds.value.length > 0 && editedKinds.value.every(canAuthorStrokeWidth),
 );
 
 /** What the graphic actually draws as, authored colour or identity projection. */
@@ -131,6 +137,11 @@ const colorModeModel = computed({
 const statusModel = computed({
   get: () => props.status ?? "present",
   set: (value: string) => emit("update", { status: value as TacticalGraphicStatus }),
+});
+
+const strokeWidthModel = computed({
+  get: () => props.measureStyle?.strokeWidth ?? CONTROL_MEASURE_STROKE_WIDTH_DEFAULT,
+  set: (value: number) => updateStyle({ strokeWidth: value }),
 });
 
 /**
@@ -187,6 +198,11 @@ const fillPatternModel = computed({
     <NativeSelectOption value="present">Present</NativeSelectOption>
     <NativeSelectOption value="planned">Planned</NativeSelectOption>
   </NativeSelect>
+
+  <template v-if="showStrokeWidth">
+    <div class="self-center">Stroke width</div>
+    <ControlMeasureStrokeWidthChoices v-model="strokeWidthModel" />
+  </template>
 
   <template v-if="showColor">
     <div class="self-center">Color</div>

--- a/src/modules/scenarioeditor/controlMeasureAuthoring.test.ts
+++ b/src/modules/scenarioeditor/controlMeasureAuthoring.test.ts
@@ -16,6 +16,7 @@ import { defineComponent, nextTick, ref, shallowRef } from "vue";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useNewScenarioStore } from "@/scenariostore/newScenarioStore";
 import { useGeo } from "@/scenariostore/geo";
+import { useScenarioTime } from "@/scenariostore/time";
 import type { TScenario } from "@/scenariostore";
 import { useScenarioDraw } from "@/modules/scenarioeditor/useScenarioDraw";
 import { useMainToolbarStore } from "@/stores/mainToolbarStore";
@@ -479,6 +480,45 @@ describe("changing control-measure options while editing its shape", () => {
 });
 
 describe("recording a control measure's shape", () => {
+  it("updates the timeline histogram when time settles the first recorded edit", async () => {
+    const { draw, scenario } = setup({ realFeed: true });
+    useRecordingStore().isRecordingGeometry = true;
+    const time = useScenarioTime(scenario.store);
+    const recordedAt = Date.parse("2025-01-02T00:00:00Z");
+
+    draw.arm({ kind: "cmEdit", featureId: "cm-1" });
+    time.setCurrentTime(recordedAt);
+    await nextTick();
+    await nextTick();
+
+    expect(storedItem(scenario).state).toHaveLength(1);
+    expect(time.computeTimeHistogram().histogram).toEqual([{ t: recordedAt, count: 1 }]);
+  });
+
+  it("does not record unchanged geometry when a time scrub settles the edit", async () => {
+    const { draw, scenario, fake } = setup({ realFeed: true });
+    useRecordingStore().isRecordingGeometry = true;
+    // The shared fake opens edits on EDITED_POINTS. Align both the stored base and its
+    // initial timed projection so the session is genuinely unchanged when settled.
+    scenario.geo.updateTacticalGraphic("cm-1", { controlPoints: EDITED_POINTS });
+    scenario.geo.addTacticalGraphicStateControlPoints(
+      "cm-1",
+      EDITED_POINTS,
+      Date.parse("2025-01-01T00:00:00Z"),
+    );
+    await nextTick();
+
+    draw.arm({ kind: "cmEdit", featureId: "cm-1" });
+    useScenarioTime(scenario.store).setCurrentTime(Date.parse("2025-01-02T00:00:00Z"));
+    await nextTick();
+    await nextTick();
+
+    // The protective render still reopens persistent Edit, but it must not create a
+    // second entry containing the exact same control points at the new timestamp.
+    expect(fake.calls.edit).toHaveLength(2);
+    expect(storedItem(scenario).state).toHaveLength(1);
+  });
+
   it("puts controlPoints in timed state while everything else stays top-level", async () => {
     const { draw, scenario, fake } = setup();
     useRecordingStore().isRecordingGeometry = true;

--- a/src/modules/scenarioeditor/controlMeasureEditHelpers.ts
+++ b/src/modules/scenarioeditor/controlMeasureEditHelpers.ts
@@ -3,8 +3,9 @@
  * `controlMeasureDrawHelpers.ts`, and pure in the same way: no map, no session, just
  * the fold from a settled `ControlMeasure` back onto the stored item.
  *
- * ADR-0006: exactly one store write per settled session, so an edit is one undo step
- * however many vertex drags it contained.
+ * ADR-0006: at most one store write per settled session, so a changed edit is one undo
+ * step however many vertex drags it contained. The session owner filters unchanged
+ * settles before reaching this helper.
  */
 import { cloneControlMeasure } from "@orbat-mapper/control-measures";
 import type { ControlMeasure } from "@orbat-mapper/control-measures";
@@ -67,13 +68,13 @@ export interface ApplyControlMeasureEditOptions {
 }
 
 /**
- * The one store write a settled edit session performs.
+ * The one store write a changed, settled edit session performs.
  *
  * With recording off it is a single top-level write. With recording on **shape only**
  * becomes timed: `controlPoints` goes into a `state[]` patch at the current time, while
  * option and amplifier edits stay top-level and timeless — there is no sensible reading
  * of "this graphic was a different *kind of option* at T". The two writes are grouped so
- * a settled session is still exactly one undo step (ADR-0006).
+ * a changed session is still exactly one undo step (ADR-0006).
  *
  * Creation deliberately ignores recording, exactly as `addScenarioDrawFeature` does.
  */

--- a/src/modules/scenarioeditor/controlMeasurePreview.ts
+++ b/src/modules/scenarioeditor/controlMeasurePreview.ts
@@ -37,8 +37,17 @@ export const PREVIEW_FALLBACK_FONT_SIZE = 14;
 /** Radius of a `circle` shape, which the library leaves to the consumer. */
 export const PREVIEW_VERTEX_RADIUS = 3;
 
-export function previewFontSize(shape: PreviewShape): number {
-  return shape.heightPx ?? PREVIEW_FALLBACK_FONT_SIZE;
+export interface PreviewFontSizing {
+  fallbackFontSize?: number;
+  maxFontSize?: number;
+}
+
+export function previewFontSize(
+  shape: PreviewShape,
+  sizing: PreviewFontSizing = {},
+): number {
+  const size = shape.heightPx ?? sizing.fallbackFontSize ?? PREVIEW_FALLBACK_FONT_SIZE;
+  return Math.min(size, sizing.maxFontSize ?? Number.POSITIVE_INFINITY);
 }
 
 export interface ControlMeasurePreviewModel {
@@ -53,11 +62,16 @@ export function buildControlMeasurePreview(
   dims: ProjectDimensions = CONTROL_MEASURE_PREVIEW_DIMENSIONS,
   textAmplifiers?: TextAmplifiers,
   options?: TacticalGraphicOptions,
+  fontSizing?: PreviewFontSizing,
 ): ControlMeasurePreviewModel {
   const { shapes, ok } = projectRenderToShapes(
     renderRepresentative(kind, { textAmplifiers, options }),
     dims,
   );
   // The plain box fits geometry only, so an anchored label can hang outside it.
-  return { shapes, ok, viewBox: viewBoxString(shapes, dims, previewFontSize) };
+  return {
+    shapes,
+    ok,
+    viewBox: viewBoxString(shapes, dims, (shape) => previewFontSize(shape, fontSizing)),
+  };
 }

--- a/src/modules/scenarioeditor/controlMeasurePreview.ts
+++ b/src/modules/scenarioeditor/controlMeasurePreview.ts
@@ -18,6 +18,7 @@ import type {
   ProjectDimensions,
 } from "@orbat-mapper/control-measures/preview";
 import type { ControlMeasureId, TextAmplifiers } from "@orbat-mapper/control-measures";
+import type { TacticalGraphicOptions } from "@/types/scenarioLayerItems";
 
 /**
  * The box every preview is fit into. Unitless — the SVG scales to whatever size the
@@ -51,9 +52,10 @@ export function buildControlMeasurePreview(
   kind: ControlMeasureId,
   dims: ProjectDimensions = CONTROL_MEASURE_PREVIEW_DIMENSIONS,
   textAmplifiers?: TextAmplifiers,
+  options?: TacticalGraphicOptions,
 ): ControlMeasurePreviewModel {
   const { shapes, ok } = projectRenderToShapes(
-    renderRepresentative(kind, { textAmplifiers }),
+    renderRepresentative(kind, { textAmplifiers, options }),
     dims,
   );
   // The plain box fits geometry only, so an anchored label can hang outside it.

--- a/src/modules/scenarioeditor/controlMeasureStyleOptions.test.ts
+++ b/src/modules/scenarioeditor/controlMeasureStyleOptions.test.ts
@@ -9,6 +9,7 @@ import {
   CONTROL_MEASURE_FILL_PATTERNS,
   GENERIC_GRAPHICS_ENTITY,
   canAuthorFillPattern,
+  canAuthorStrokeWidth,
   fillPatternLabel,
   isStyleableControlMeasureKind,
   newControlMeasureDefaults,
@@ -46,6 +47,12 @@ describe("the styling gate", () => {
     expect(canAuthorFillPattern("classic-arrow")).toBe(false);
     expect(canAuthorFillPattern("line")).toBe(false);
   });
+
+  it("offers stroke width exactly where the registry paints a stroke", () => {
+    expect(canAuthorStrokeWidth("phase-line")).toBe(true);
+    expect(canAuthorStrokeWidth("polygon")).toBe(true);
+    expect(canAuthorStrokeWidth("text")).toBe(false);
+  });
 });
 
 describe("fill pattern options", () => {
@@ -67,7 +74,7 @@ describe("newControlMeasureDefaults", () => {
     standardIdentity: "3",
     colorMode: "identity",
     status: "planned",
-    style: { color: "#ff0000", fillPattern: "hatch" },
+    style: { color: "#ff0000", fillPattern: "hatch", strokeWidth: 4 },
     options: { smooth: true },
   } as const;
 
@@ -76,6 +83,7 @@ describe("newControlMeasureDefaults", () => {
       standardIdentity: "3",
       colorMode: "identity",
       status: "planned",
+      style: { strokeWidth: 4 },
       options: { smooth: true },
     });
   });
@@ -84,12 +92,14 @@ describe("newControlMeasureDefaults", () => {
     expect(newControlMeasureDefaults(defaults, "polygon").style).toEqual({
       color: "#ff0000",
       fillPattern: "hatch",
+      strokeWidth: 4,
     });
   });
 
   it("drops the fill pattern where it would be inert, but keeps the colour", () => {
     expect(newControlMeasureDefaults(defaults, "line").style).toEqual({
       color: "#ff0000",
+      strokeWidth: 4,
     });
   });
 

--- a/src/modules/scenarioeditor/controlMeasureStyleOptions.ts
+++ b/src/modules/scenarioeditor/controlMeasureStyleOptions.ts
@@ -9,9 +9,10 @@
  * control measure with an authored colour on a doctrinal kind still renders with it.
  * Nothing here may ever be consulted by the store or by `toControlMeasure`.
  *
- * Everything is derived from the library's own metadata (`entity` and `paints`), so
- * there is no parallel list of kinds or of fill patterns to drift out of step with
- * the registry.
+ * Stroke width follows `paints.stroke`; colour and fill remain restricted by entity
+ * and fill capability. Everything is derived from the library's own metadata, so
+ * there is no parallel list of kinds or patterns to drift out of step with the
+ * registry.
  */
 import {
   CONTROL_MEASURE_METADATA,
@@ -44,6 +45,13 @@ export type ControlMeasureStyleUpdate = Pick<
 /** The registry entity holding the kinds that carry no doctrinal colour of their own. */
 export const GENERIC_GRAPHICS_ENTITY = "Generic Graphics";
 
+export const CONTROL_MEASURE_STROKE_WIDTH_DEFAULT = 2;
+export const CONTROL_MEASURE_STROKE_WIDTH_PRESETS = [
+  { label: "Thin", value: 1 },
+  { label: "Medium", value: CONTROL_MEASURE_STROKE_WIDTH_DEFAULT },
+  { label: "Heavy", value: 4 },
+] as const;
+
 function metadataFor(kind: ControlMeasureKind | undefined) {
   if (kind === undefined) return undefined;
   return CONTROL_MEASURE_METADATA[kind as ControlMeasureId];
@@ -65,6 +73,11 @@ export function isStyleableControlMeasureKind(
  */
 export function canAuthorFillPattern(kind: ControlMeasureKind | undefined): boolean {
   return isStyleableControlMeasureKind(kind) && metadataFor(kind)?.paints.fill === "user";
+}
+
+/** Stroke width is meaningful for every kind whose registry output paints a stroke. */
+export function canAuthorStrokeWidth(kind: ControlMeasureKind | undefined): boolean {
+  return metadataFor(kind)?.paints.stroke === true;
 }
 
 /**
@@ -131,11 +144,16 @@ export function newControlMeasureDefaults(
   const { style, options, ...hostOwned } = defaults;
   const narrowed: NewControlMeasureDefaults = { ...hostOwned };
 
-  if (style && isStyleableControlMeasureKind(graphicKind)) {
+  if (style) {
     const authored: ControlMeasureStyle = {};
-    if (style.color !== undefined) authored.color = style.color;
-    if (style.fillPattern !== undefined && canAuthorFillPattern(graphicKind)) {
-      authored.fillPattern = style.fillPattern;
+    if (canAuthorStrokeWidth(graphicKind) && style.strokeWidth !== undefined) {
+      authored.strokeWidth = style.strokeWidth;
+    }
+    if (isStyleableControlMeasureKind(graphicKind)) {
+      if (style.color !== undefined) authored.color = style.color;
+      if (style.fillPattern !== undefined && canAuthorFillPattern(graphicKind)) {
+        authored.fillPattern = style.fillPattern;
+      }
     }
     if (Object.keys(authored).length > 0) narrowed.style = authored;
   }

--- a/src/modules/scenarioeditor/useControlMeasureEditSession.test.ts
+++ b/src/modules/scenarioeditor/useControlMeasureEditSession.test.ts
@@ -223,7 +223,7 @@ describe("useControlMeasureEditSession", () => {
     expect(settled).toEqual([{ committed: true, featureId: "cm-1" }]);
     expect(edit.featureId.value).toBeNull();
 
-    // One settled session, one undo step.
+    // One changed, settled session; one undo step.
     scenario.store.undo();
     expect(storedControlPoints(scenario)).toEqual([
       [10, 60],

--- a/src/modules/scenarioeditor/useControlMeasureEditSession.ts
+++ b/src/modules/scenarioeditor/useControlMeasureEditSession.ts
@@ -5,9 +5,10 @@
  * Two things make it *not* a copy of the draw session:
  *
  * 1. **An edit closes and keeps its work; only a draw aborts.** Every settle path —
- *    a time scrub, a layer-visibility toggle, arming another tool, Escape — folds the
- *    working geometry into the store. There is deliberately no discard gesture: the
- *    fold is one undo step, so scenario undo *is* the discard.
+ *    a time scrub, a layer-visibility toggle, arming another tool, Escape — closes the
+ *    session and folds changed work into the store. An unchanged edit writes nothing.
+ *    There is deliberately no discard gesture: a changed fold is one undo step, so
+ *    scenario undo *is* the discard.
  * 2. **Its lifecycle has an explicit owner.** A details-panel gesture owns a one-off
  *    session; persistent toolbar Edit owns sessions opened or transferred by selection
  *    changes. An unarmed map click still only selects — it never creates an edit.
@@ -20,6 +21,7 @@
  */
 import { onScopeDispose, ref } from "vue";
 import type { Ref } from "vue";
+import { isEqual } from "es-toolkit";
 import { getSizeAnchor, isTacticalDrawAbortError } from "@orbat-mapper/tactical-draw";
 import type {
   EditMode,
@@ -38,6 +40,7 @@ import { isNTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
 import { isSupportedGraphicKind } from "@/scenariostore/tacticalGraphics";
 import {
   applyScenarioControlMeasureEdit,
+  toControlMeasureEditUpdate,
   toEditStartMeasure,
 } from "@/modules/scenarioeditor/controlMeasureEditHelpers";
 
@@ -156,10 +159,19 @@ export function useControlMeasureEditSession(
     live.close();
   }
 
-  function fold(measure: Parameters<typeof applyScenarioControlMeasureEdit>[1]) {
-    applyScenarioControlMeasureEdit(options.scenario, measure, {
-      recordShape: options.recordShape?.() ?? false,
-    });
+  function fold(
+    measure: Parameters<typeof applyScenarioControlMeasureEdit>[1],
+    startUpdate: ReturnType<typeof toControlMeasureEditUpdate>,
+  ) {
+    // A render settle closes even an untouched session. Compare against the snapshot
+    // captured when this particular session opened, not against the store's current
+    // projection: a time scrub may already have projected a different timed state by
+    // the time the feed reaches us.
+    if (!isEqual(startUpdate, toControlMeasureEditUpdate(measure))) {
+      applyScenarioControlMeasureEdit(options.scenario, measure, {
+        recordShape: options.recordShape?.() ?? false,
+      });
+    }
     if (closingFromSettle) return;
     // Required by the library's contract, not an optimisation: it hands the override
     // back and expects the host's next render to be authoritative.
@@ -192,6 +204,9 @@ export function useControlMeasureEditSession(
 
     featureId.value = itemId;
     const startMeasure = toEditStartMeasure(layerItem);
+    // Detached from the object tactical-draw receives, so a library-owned mutation of
+    // its working graphic cannot move the comparison baseline along with the edit.
+    const startUpdate = toControlMeasureEditUpdate(startMeasure);
     surface
       .edit(startMeasure, {
         // Whatever the graphic already encodes, so an edit never silently re-anchors
@@ -213,7 +228,7 @@ export function useControlMeasureEditSession(
           editSession.history.subscribe(readHistory);
           // The fold channel. Fires exactly once, synchronously from within the
           // `close()` that produced it, and never on abort.
-          editSession.onCommit((snapshot) => fold(snapshot.graphic));
+          editSession.onCommit((snapshot) => fold(snapshot.graphic, startUpdate));
         },
       })
       .then(() => {


### PR DESCRIPTION
## Summary

- improve control-measure previews, echelon controls, style layouts, and stroke-width presets
- support editing generic control-measure text
- avoid store writes and duplicate timed states when an edit settles unchanged
- settle the first recorded geometry edit on time changes so timeline indicators update before deselection

## Verification

- pnpm test:unit — 1,585 passed, 5 skipped
- pnpm type-check
- Prettier checks for changed files