### PR TITLE
Add duplication actions for scenario graphics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ All notable changes to this project will be documented in this file.
 - Added control-measure authoring and editing in MapLibre mode. Choose from a searchable catalogue, draw measures with snapping, organize them in scenario layers, and edit their geometry from the map or details panel.
 - Added control-measure styling and labels, including identity colours, line width, echelon, text amplifiers, and free-form text where supported. Defaults can be configured before drawing, with live previews.
 - Added GeoJSON import, export, clipboard, undo/redo, and scenario persistence support for control measures.
+- Added feature and control-measure duplication actions to the details panel and draw toolbar. Control-measure details now also show the doctrinal description for the selected measure.
 
 ### Changed
 
 - Newly drawn control measures now enter edit mode automatically. A selected control measure can also be edited by clicking it again.
+- Duplicated graphics are offset by 24 screen pixels, receive an incrementing name, and become selected. A duplicated control measure enters edit mode immediately.
 - Combined the scenario feature drawing tools and control-measure tools into compact split buttons that retain the most recently used tool.
 - OpenLayers mode now shows a once-per-session notice that the legacy map is deprecated.
 
@@ -20,6 +22,7 @@ All notable changes to this project will be documented in this file.
 
 - Fixed zooming to a circle feature so the view frames the full circle instead of only its centre point.
 - Fixed MapLibre control measures being drawn beneath image layers instead of above them according to the scenario layer stack.
+- Fixed duplicating a control measure after dragging a previous copy, which could create the next copy at an invalid position.
 
 ## July 2026
 

--- a/src/composables/geoMapLocation.test.ts
+++ b/src/composables/geoMapLocation.test.ts
@@ -79,6 +79,12 @@ function createFakeMapAdapter(initialCursor = ""): FakeMapAdapter {
     fromLonLat(position) {
       return position;
     },
+    getPixelFromCoordinate(position) {
+      return [position[0], position[1]];
+    },
+    getCoordinateFromPixel(pixel) {
+      return [pixel[0], pixel[1]];
+    },
     getEventCoordinate: getEventCoordinateSpy,
     getTargetElement() {
       return targetElement;

--- a/src/composables/scenarioActions.ts
+++ b/src/composables/scenarioActions.ts
@@ -342,7 +342,7 @@ export function useScenarioFeatureActions(
     const isArray = Array.isArray(featureOrFeaturesId);
     if (isArray && (action === "zoom" || action === "pan")) {
       zoomToFeatures(featureOrFeaturesId, 17);
-      return;
+      return duplicatedIds;
     }
     groupUpdate(
       () => {

--- a/src/composables/scenarioActions.ts
+++ b/src/composables/scenarioActions.ts
@@ -338,6 +338,7 @@ export function useScenarioFeatureActions(
     featureOrFeaturesId: FeatureId | FeatureId[],
     action: "zoom" | "pan" | "delete" | string,
   ) {
+    const duplicatedIds: FeatureId[] = [];
     const isArray = Array.isArray(featureOrFeaturesId);
     if (isArray && (action === "zoom" || action === "pan")) {
       zoomToFeatures(featureOrFeaturesId, 17);
@@ -350,12 +351,14 @@ export function useScenarioFeatureActions(
           if (action === "pan") panToFeature(featureId);
           if (action === "delete") geo.deleteFeature(featureId);
           if (action === "duplicate") {
-            geo.duplicateFeature(featureId);
+            const duplicatedId = geo.duplicateFeature(featureId, geoStore.mapAdapter);
+            if (duplicatedId !== undefined) duplicatedIds.push(duplicatedId);
           }
         });
       },
       { label: "batchLayer", value: "dummy" },
     );
+    return duplicatedIds;
   }
 
   return { onFeatureAction };

--- a/src/geo/contracts/mapAdapter.ts
+++ b/src/geo/contracts/mapAdapter.ts
@@ -71,6 +71,8 @@ export interface MapAdapter {
   toLonLat(coordinate: number[]): Position;
   fromLonLat(position: Position): number[];
   getEventCoordinate(event: MouseEvent): Position;
+  getPixelFromCoordinate(coordinate: Position): [number, number] | undefined;
+  getCoordinateFromPixel(pixel: [number, number]): Position | undefined;
 
   // DOM
   getTargetElement(): HTMLElement | undefined;

--- a/src/geo/engines/openlayers/olMapAdapter.ts
+++ b/src/geo/engines/openlayers/olMapAdapter.ts
@@ -142,6 +142,18 @@ export class OlMapAdapter implements MapAdapter {
     return toLonLat(this.olMap.getEventCoordinate(event), this.projection) as Position;
   }
 
+  getPixelFromCoordinate(coordinate: Position): [number, number] | undefined {
+    const pixel = this.olMap.getPixelFromCoordinate(
+      fromLonLat(coordinate, this.projection),
+    );
+    return pixel ? [pixel[0], pixel[1]] : undefined;
+  }
+
+  getCoordinateFromPixel(pixel: [number, number]): Position | undefined {
+    const coordinate = this.olMap.getCoordinateFromPixel(pixel);
+    return coordinate ? (toLonLat(coordinate, this.projection) as Position) : undefined;
+  }
+
   getTargetElement(): HTMLElement | undefined {
     return this.olMap.getTargetElement() ?? undefined;
   }

--- a/src/geo/mapLibreMapAdapter.ts
+++ b/src/geo/mapLibreMapAdapter.ts
@@ -154,6 +154,16 @@ export class MapLibreMapAdapter implements MapAdapter {
     return [lngLat.lng, lngLat.lat];
   }
 
+  getPixelFromCoordinate(coordinate: Position): [number, number] {
+    const point = this.mlMap.project(coordinate as [number, number]);
+    return [point.x, point.y];
+  }
+
+  getCoordinateFromPixel(pixel: [number, number]): Position {
+    const lngLat = this.mlMap.unproject(pixel);
+    return [lngLat.lng, lngLat.lat];
+  }
+
   getTargetElement(): HTMLElement | undefined {
     return this.mlMap.getContainer() ?? undefined;
   }

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -3,6 +3,7 @@ import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 import { defineComponent, nextTick, ref, shallowRef } from "vue";
+import { CONTROL_MEASURE_METADATA } from "@orbat-mapper/control-measures";
 
 import ControlMeasureDetails from "@/modules/scenarioeditor/ControlMeasureDetails.vue";
 import {
@@ -185,6 +186,24 @@ describe("ControlMeasureDetails tabs", () => {
     mountDetails();
 
     expect(tabStore.controlMeasureDetailsTab).toBe(0);
+  });
+
+  it("shows the control measure metadata description in the Details tab", () => {
+    const { wrapper } = mountDetails();
+
+    expect(wrapper.get("[data-test='control-measure-kind-description']").text()).toBe(
+      CONTROL_MEASURE_METADATA["phase-line"].description,
+    );
+  });
+
+  it("does not show a metadata description for an unsupported kind", () => {
+    const { wrapper } = mountDetails({
+      graphicKind: "phase-line-from-the-future" as NTacticalGraphicLayerItem["graphicKind"],
+    });
+
+    expect(wrapper.find("[data-test='control-measure-kind-description']").exists()).toBe(
+      false,
+    );
   });
 
   it("uses independent tab state for the palette and edit-data actions", async () => {

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -14,6 +14,7 @@ import {
 import { useTabStore } from "@/stores/tabStore";
 import { useUiStore } from "@/stores/uiStore";
 import type { NTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
+import { useSelectedItems } from "@/stores/selectedStore";
 
 let pinia: ReturnType<typeof createPinia>;
 
@@ -108,6 +109,7 @@ function mountDetails(
 ) {
   const item = controlMeasure(itemOverrides);
   const updateControlMeasure = vi.fn();
+  const duplicateFeature = vi.fn();
   const scenarioDraw = {
     updateControlMeasure,
     controlMeasureEditFeatureId: ref<string | number | null>(
@@ -129,6 +131,7 @@ function mountDetails(
           geo: {
             getLayerItemById: vi.fn(() => ({ layerItem: item })),
             updateLayerItem: vi.fn(),
+            duplicateFeature,
           },
         },
         [activeScenarioMapEngineKey as symbol]: shallowRef({
@@ -141,13 +144,14 @@ function mountDetails(
     },
   });
 
-  return { wrapper, updateControlMeasure };
+  return { wrapper, updateControlMeasure, duplicateFeature, scenarioDraw };
 }
 
 describe("ControlMeasureDetails tabs", () => {
   beforeEach(() => {
     pinia = createPinia();
     setActivePinia(pinia);
+    useSelectedItems().clear();
   });
 
   it("shows Style, Amplifiers, Details and State, with Debug gated by debug mode", async () => {
@@ -194,6 +198,36 @@ describe("ControlMeasureDetails tabs", () => {
     expect(wrapper.get("[data-test='control-measure-kind-description']").text()).toBe(
       CONTROL_MEASURE_METADATA["phase-line"].description,
     );
+  });
+
+  it("duplicates the selected control measure from the details toolbar", async () => {
+    const { wrapper, duplicateFeature, scenarioDraw } = mountDetails();
+    duplicateFeature.mockReturnValue("cm-copy");
+
+    await wrapper.find("button[title='Duplicate control measure']").trigger("click");
+
+    expect(duplicateFeature).toHaveBeenCalledWith("cm-1", undefined);
+    expect(useSelectedItems().activeFeatureId.value).toBe("cm-copy");
+    expect(scenarioDraw.startControlMeasureEdit).toHaveBeenCalledWith("cm-copy");
+  });
+
+  it("settles a dragged clone before duplicating it again", async () => {
+    const { wrapper, duplicateFeature, scenarioDraw } = mountDetails({}, true);
+    const originalPoints = [[10, 60], [11, 61]];
+    const draggedPoints = [[20, 70], [21, 71]];
+    let storedPoints = originalPoints;
+    let copiedPoints: number[][] | undefined;
+    scenarioDraw.cancel.mockImplementation(() => {
+      storedPoints = draggedPoints;
+    });
+    duplicateFeature.mockImplementation(() => {
+      copiedPoints = structuredClone(storedPoints);
+      return "cm-copy-2";
+    });
+
+    await wrapper.find("button[title='Duplicate control measure']").trigger("click");
+
+    expect(copiedPoints).toEqual(draggedPoints);
   });
 
   it("does not show a metadata description for an unsupported kind", () => {

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -109,7 +109,6 @@ function mountDetails(
 ) {
   const item = controlMeasure(itemOverrides);
   const updateControlMeasure = vi.fn();
-  const duplicateFeature = vi.fn();
   const scenarioDraw = {
     updateControlMeasure,
     controlMeasureEditFeatureId: ref<string | number | null>(
@@ -120,6 +119,7 @@ function mountDetails(
     cancel: vi.fn(),
     startControlMeasureEdit: vi.fn(),
     deleteSelected: vi.fn(),
+    duplicateSelected: vi.fn(),
   };
 
   const wrapper = mount(ControlMeasureDetails, {
@@ -131,7 +131,6 @@ function mountDetails(
           geo: {
             getLayerItemById: vi.fn(() => ({ layerItem: item })),
             updateLayerItem: vi.fn(),
-            duplicateFeature,
           },
         },
         [activeScenarioMapEngineKey as symbol]: shallowRef({
@@ -144,7 +143,7 @@ function mountDetails(
     },
   });
 
-  return { wrapper, updateControlMeasure, duplicateFeature, scenarioDraw };
+  return { wrapper, updateControlMeasure, scenarioDraw };
 }
 
 describe("ControlMeasureDetails tabs", () => {
@@ -200,39 +199,20 @@ describe("ControlMeasureDetails tabs", () => {
     );
   });
 
+  // Duplication goes through the armed-tool owner, which owns settling the open
+  // shape session. The behaviour itself is covered by useScenarioDraw.test.ts.
   it("duplicates the selected control measure from the details toolbar", async () => {
-    const { wrapper, duplicateFeature, scenarioDraw } = mountDetails();
-    duplicateFeature.mockReturnValue("cm-copy");
+    const { wrapper, scenarioDraw } = mountDetails();
 
     await wrapper.find("button[title='Duplicate control measure']").trigger("click");
 
-    expect(duplicateFeature).toHaveBeenCalledWith("cm-1", undefined);
-    expect(useSelectedItems().activeFeatureId.value).toBe("cm-copy");
-    expect(scenarioDraw.startControlMeasureEdit).toHaveBeenCalledWith("cm-copy");
-  });
-
-  it("settles a dragged clone before duplicating it again", async () => {
-    const { wrapper, duplicateFeature, scenarioDraw } = mountDetails({}, true);
-    const originalPoints = [[10, 60], [11, 61]];
-    const draggedPoints = [[20, 70], [21, 71]];
-    let storedPoints = originalPoints;
-    let copiedPoints: number[][] | undefined;
-    scenarioDraw.cancel.mockImplementation(() => {
-      storedPoints = draggedPoints;
-    });
-    duplicateFeature.mockImplementation(() => {
-      copiedPoints = structuredClone(storedPoints);
-      return "cm-copy-2";
-    });
-
-    await wrapper.find("button[title='Duplicate control measure']").trigger("click");
-
-    expect(copiedPoints).toEqual(draggedPoints);
+    expect(scenarioDraw.duplicateSelected).toHaveBeenCalled();
   });
 
   it("does not show a metadata description for an unsupported kind", () => {
     const { wrapper } = mountDetails({
-      graphicKind: "phase-line-from-the-future" as NTacticalGraphicLayerItem["graphicKind"],
+      graphicKind:
+        "phase-line-from-the-future" as NTacticalGraphicLayerItem["graphicKind"],
     });
 
     expect(wrapper.find("[data-test='control-measure-kind-description']").exists()).toBe(

--- a/src/modules/scenarioeditor/ControlMeasureDetails.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.vue
@@ -75,7 +75,7 @@ const props = defineProps<Props>();
 const { geo } = injectStrict(activeScenarioKey);
 const engineRef = injectStrict(activeScenarioMapEngineKey);
 const scenarioDraw = injectStrict(scenarioDrawKey);
-const { activeFeatureId, clear: clearSelection } = useSelectedItems();
+const { clear: clearSelection } = useSelectedItems();
 const uiStore = useUiStore();
 const { controlMeasureDetailsTab: selectedTab } = storeToRefs(useTabStore());
 
@@ -246,15 +246,9 @@ function doZoom() {
 }
 
 function doDuplicate() {
-  if (!item.value) return;
-  // The tactical-draw edit is transient until it settles. Fold a dragged clone into
-  // the scenario store before duplicateFeature reads it; otherwise the next copy is
-  // made from the position at which the edit session originally opened.
-  if (isEditingShape.value) scenarioDraw.cancel();
-  const duplicatedId = geo.duplicateFeature(item.value.id, engineRef.value?.map);
-  if (duplicatedId === undefined) return;
-  activeFeatureId.value = duplicatedId;
-  scenarioDraw.startControlMeasureEdit(duplicatedId);
+  // Goes through the armed-tool owner so any open shape session settles before the
+  // write; otherwise the copy is made from the position the edit session opened at.
+  scenarioDraw.duplicateSelected();
 }
 
 function doDelete() {

--- a/src/modules/scenarioeditor/ControlMeasureDetails.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.vue
@@ -19,6 +19,7 @@
 import { computed, ref, watch } from "vue";
 import {
   IconAlertOutline,
+  IconContentCopy as DuplicateIcon,
   IconMagnifyExpand as ZoomIcon,
   IconPalette as StyleIcon,
   IconPencil as EditIcon,
@@ -74,7 +75,7 @@ const props = defineProps<Props>();
 const { geo } = injectStrict(activeScenarioKey);
 const engineRef = injectStrict(activeScenarioMapEngineKey);
 const scenarioDraw = injectStrict(scenarioDrawKey);
-const { clear: clearSelection } = useSelectedItems();
+const { activeFeatureId, clear: clearSelection } = useSelectedItems();
 const uiStore = useUiStore();
 const { controlMeasureDetailsTab: selectedTab } = storeToRefs(useTabStore());
 
@@ -244,6 +245,18 @@ function doZoom() {
   if (first !== undefined) engineRef.value?.layers.zoomToFeature(first);
 }
 
+function doDuplicate() {
+  if (!item.value) return;
+  // The tactical-draw edit is transient until it settles. Fold a dragged clone into
+  // the scenario store before duplicateFeature reads it; otherwise the next copy is
+  // made from the position at which the edit session originally opened.
+  if (isEditingShape.value) scenarioDraw.cancel();
+  const duplicatedId = geo.duplicateFeature(item.value.id, engineRef.value?.map);
+  if (duplicatedId === undefined) return;
+  activeFeatureId.value = duplicatedId;
+  scenarioDraw.startControlMeasureEdit(duplicatedId);
+}
+
 function doDelete() {
   // Goes through the armed-tool owner so any open session settles before the write.
   scenarioDraw.deleteSelected();
@@ -295,6 +308,9 @@ function doDelete() {
       <template #actions>
         <IconButton title="Zoom to control measure" @click="doZoom()">
           <ZoomIcon class="size-5" />
+        </IconButton>
+        <IconButton v-if="item" title="Duplicate control measure" @click="doDuplicate()">
+          <DuplicateIcon class="size-5" />
         </IconButton>
         <IconButton
           v-if="item"

--- a/src/modules/scenarioeditor/ControlMeasureDetails.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.vue
@@ -132,6 +132,12 @@ const kindName = computed(() => {
   return CONTROL_MEASURE_METADATA[kind as ControlMeasureId]?.name ?? String(kind);
 });
 
+const kindDescription = computed(() => {
+  const kind = item.value?.graphicKind;
+  if (!kind || !supported.value) return "";
+  return CONTROL_MEASURE_METADATA[kind as ControlMeasureId]?.description ?? "";
+});
+
 // The **projected** points, like `strokeColor` above and like the map: a recorded
 // shape patch replaces `controlPoints` at the current time, so the top-level array
 // would disagree with what is drawn.
@@ -391,6 +397,14 @@ function doDelete() {
             <div class="text-muted-foreground">Points</div>
             <div>{{ controlPointCount }}</div>
           </PanelDataGrid>
+
+          <p
+            v-if="kindDescription"
+            data-test="control-measure-kind-description"
+            class="text-muted-foreground mt-4 text-sm"
+          >
+            {{ kindDescription }}
+          </p>
 
           <div v-if="isEditMode" class="mt-4">
             <EditMetaForm

--- a/src/modules/scenarioeditor/MapEditorDrawToolbar.test.ts
+++ b/src/modules/scenarioeditor/MapEditorDrawToolbar.test.ts
@@ -12,6 +12,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import MapEditorDrawToolbar from "@/modules/scenarioeditor/MapEditorDrawToolbar.vue";
 import DrawToolSplitButton from "@/modules/scenarioeditor/DrawToolSplitButton.vue";
 import { useMainToolbarStore } from "@/stores/mainToolbarStore";
+import { useSelectedItems } from "@/stores/selectedStore";
 import { scenarioDrawKey } from "@/components/injects";
 import type { ArmedTool } from "@/modules/scenarioeditor/useScenarioDraw";
 
@@ -34,6 +35,7 @@ function mountToolbar({
     startModify: vi.fn(),
     isModifying: computed(() => false),
     cancel: vi.fn(),
+    duplicateSelected: vi.fn(),
     deleteSelected: vi.fn(),
     snap: ref(true),
     translate: ref(false),
@@ -63,7 +65,20 @@ function buttonByTitle(
 const NO_ENGINE_SUPPORT = "Control measures are not supported by this map engine";
 
 describe("MapEditorDrawToolbar capability gating", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSelectedItems().clear();
+  });
+
+  it("duplicates the current selection from the draw toolbar", async () => {
+    const { wrapper, scenarioDraw } = mountToolbar();
+    useSelectedItems().selectedFeatureIds.value.add("feature-1");
+    await wrapper.vm.$nextTick();
+
+    await buttonByTitle(wrapper, "Duplicate selected")[0]!.trigger("click");
+
+    expect(scenarioDraw.duplicateSelected).toHaveBeenCalledOnce();
+  });
 
   it("renders the control-measure buttons disabled, not hidden, without a surface", () => {
     const { wrapper } = mountToolbar({ canControlMeasures: false });

--- a/src/modules/scenarioeditor/MapEditorDrawToolbar.vue
+++ b/src/modules/scenarioeditor/MapEditorDrawToolbar.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import {
+  IconContentCopy as DuplicateIcon,
   IconCursorDefaultOutline as SelectIcon,
   IconCursorMove as MoveIcon,
   IconLockOpenVariantOutline,
@@ -48,6 +49,7 @@ const {
   startModify,
   isModifying,
   cancel,
+  duplicateSelected,
   deleteSelected,
   snap,
   translate,
@@ -148,6 +150,13 @@ const toggleFreehand = useToggle(freehand);
       :active="translate"
     >
       <MoveIcon class="size-5" />
+    </MainToolbarButton>
+    <MainToolbarButton
+      title="Duplicate selected"
+      :disabled="selectedFeatureIds.size === 0"
+      @click="duplicateSelected()"
+    >
+      <DuplicateIcon class="size-5" />
     </MainToolbarButton>
     <MainToolbarButton
       title="Delete"

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.test.ts
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.test.ts
@@ -55,7 +55,10 @@ describe("ScenarioFeatureDetails", () => {
   const baseStubs = {
     GlobalEvents: true,
     EditableLabel: true,
-    IconButton: true,
+    IconButton: {
+      props: ["title"],
+      template: "<button :title='title' @click='$emit(\"click\")'><slot /></button>",
+    },
     ItemMedia: true,
     ScenarioFeatureDropdownMenu: true,
     ScenarioLayerItemState: true,
@@ -112,9 +115,7 @@ describe("ScenarioFeatureDetails", () => {
       },
     });
 
-    await wrapper
-      .findComponent('[title="Duplicate feature"]')
-      .vm.$emit("click");
+    await wrapper.find('button[title="Duplicate feature"]').trigger("click");
 
     expect(onFeatureAction).toHaveBeenCalledWith(["feature-1"], "duplicate");
     expect([...useSelectedItems().selectedFeatureIds.value]).toEqual(["feature-copy"]);

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.test.ts
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.test.ts
@@ -6,10 +6,12 @@ import { shallowRef } from "vue";
 import { defineComponent } from "vue";
 import ScenarioFeatureDetails from "@/modules/scenarioeditor/ScenarioFeatureDetails.vue";
 import { activeScenarioKey, activeScenarioMapEngineKey } from "@/components/injects";
+import { useSelectedItems } from "@/stores/selectedStore";
 
+const onFeatureAction = vi.fn();
 vi.mock("@/composables/scenarioActions", () => ({
   useScenarioFeatureActions: () => ({
-    onFeatureAction: vi.fn(),
+    onFeatureAction,
   }),
 }));
 
@@ -20,6 +22,8 @@ vi.mock("@/composables/formatting", () => ({
 describe("ScenarioFeatureDetails", () => {
   beforeEach(() => {
     setActivePinia(createPinia());
+    onFeatureAction.mockReset();
+    useSelectedItems().clear();
   });
 
   function makeScenarioProvide(overrides: Record<string, unknown> = {}) {
@@ -76,6 +80,45 @@ describe("ScenarioFeatureDetails", () => {
         "<button data-test='toggle-field' @click=\"$emit('update:modelValue', !modelValue)\"><slot /></button>",
     }),
   };
+
+  it("duplicates the selected feature from the details toolbar", async () => {
+    onFeatureAction.mockReturnValue(["feature-copy"]);
+    const feature = {
+      id: "feature-1",
+      kind: "geometry",
+      _pid: "layer-1",
+      geometry: { type: "Point", coordinates: [10, 20] },
+      geometryMeta: { geometryKind: "Point" },
+      name: "Alpha",
+      style: {},
+    };
+    const scenario = makeScenarioProvide({
+      geo: {
+        getGeometryLayerItemById: vi.fn(() => ({ layerItem: feature })),
+        updateFeature: vi.fn(),
+      },
+    });
+    const wrapper = mount(ScenarioFeatureDetails, {
+      props: { selectedIds: new Set(["feature-1"]) },
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeScenarioKey as symbol]: scenario,
+          [activeScenarioMapEngineKey as symbol]: shallowRef({
+            layers: { capabilities: { featureTransform: false } },
+          }),
+        },
+        stubs: baseStubs,
+      },
+    });
+
+    await wrapper
+      .findComponent('[title="Duplicate feature"]')
+      .vm.$emit("click");
+
+    expect(onFeatureAction).toHaveBeenCalledWith(["feature-1"], "duplicate");
+    expect([...useSelectedItems().selectedFeatureIds.value]).toEqual(["feature-copy"]);
+  });
 
   it("updates feature styling without requiring an OpenLayers select interaction", async () => {
     const updateFeature = vi.fn();

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
@@ -290,7 +290,7 @@ function doDuplicate() {
     [...props.selectedIds],
     "duplicate",
   );
-  if (!duplicatedIds?.length) return;
+  if (!duplicatedIds.length) return;
   selectedFeatureIds.value.clear();
   duplicatedIds.forEach((id) => selectedFeatureIds.value.add(id));
 }

--- a/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
+++ b/src/modules/scenarioeditor/ScenarioFeatureDetails.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import {
+  IconContentCopy as DuplicateIcon,
   IconImage as ImageIcon,
   IconMagnifyExpand as ZoomIcon,
   IconPalette as StyleIcon,
@@ -284,6 +285,16 @@ function doZoom() {
   featureActions.onFeatureAction([...props.selectedIds], "zoom");
 }
 
+function doDuplicate() {
+  const duplicatedIds = featureActions.onFeatureAction(
+    [...props.selectedIds],
+    "duplicate",
+  );
+  if (!duplicatedIds?.length) return;
+  selectedFeatureIds.value.clear();
+  duplicatedIds.forEach((id) => selectedFeatureIds.value.add(id));
+}
+
 function onAction(action: ScenarioFeatureActions) {
   if (action === "removeMedia") {
     removeMedia();
@@ -376,6 +387,9 @@ function assignFeatureToUnit() {
       <template #actions>
         <IconButton @click="doZoom()" title="Zoom to feature">
           <ZoomIcon class="size-5" />
+        </IconButton>
+        <IconButton title="Duplicate feature" @click="doDuplicate()">
+          <DuplicateIcon class="size-5" />
         </IconButton>
         <IconButton @click="showStylePanel()" title="Change feature style">
           <StyleIcon class="size-5" />

--- a/src/modules/scenarioeditor/ScenarioLayersTabPanel.test.ts
+++ b/src/modules/scenarioeditor/ScenarioLayersTabPanel.test.ts
@@ -468,7 +468,10 @@ describe("ScenarioLayersTabPanel control-measures section", () => {
         provide: {
           [activeLayerKey as symbol]: activeLayerId,
           [activeScenarioMapEngineKey as symbol]: shallowRef({
-            map: {} as never,
+            map: {
+              getPixelFromCoordinate: ([lon, lat]: number[]) => [lon * 100, lat * -100],
+              getCoordinateFromPixel: ([x, y]: number[]) => [x / 100, y / -100],
+            } as never,
             layers: { capabilities: {} },
           }),
           [activeScenarioKey as symbol]: {

--- a/src/modules/scenarioeditor/ScenarioLayersTabPanel.vue
+++ b/src/modules/scenarioeditor/ScenarioLayersTabPanel.vue
@@ -278,7 +278,7 @@ function onControlMeasureAction(itemId: FeatureId, action: ScenarioFeatureAction
     geo.moveFeature(itemId, action === "moveUp" ? index - 1 : index + 1);
   }
   if (action === "duplicate") {
-    const newId = geo.duplicateFeature(itemId);
+    const newId = geo.duplicateFeature(itemId, engineRef.value?.map);
     if (newId) activeFeatureId.value = newId;
   }
   if (action === "copyAsGeoJson") {
@@ -482,7 +482,7 @@ function onFeatureAction(
         }
 
         if (action === "duplicate") {
-          const newId = geo.duplicateFeature(featureId);
+          const newId = geo.duplicateFeature(featureId, engineRef.value?.map);
           if (selectedFeatureIds.value.size === 1) {
             activeFeatureId.value = newId;
           }

--- a/src/modules/scenarioeditor/useScenarioDraw.test.ts
+++ b/src/modules/scenarioeditor/useScenarioDraw.test.ts
@@ -82,6 +82,7 @@ function createScenario() {
           : { id, kind: "geometry" },
       })),
       updateTacticalGraphic: vi.fn(),
+      duplicateFeature: vi.fn(),
       deleteFeature: vi.fn(),
     },
   };
@@ -247,6 +248,22 @@ describe("useScenarioDraw", () => {
     draw.startModify();
     expect(draw.armed.value).toEqual({ kind: "none" });
     expect(draw.isModifying.value).toBe(false);
+  });
+
+  it("duplicates, selects, and edits a control measure from the draw toolbar action", async () => {
+    const scenario = createScenario();
+    scenario.geo.duplicateFeature.mockReturnValue("cm-copy");
+    const { draw, engineRef } = mountHarness({ scenario });
+    const engine = createEngine();
+    engineRef.value = engine;
+    await nextTick();
+    useSelectedItems().activeFeatureId.value = "cm-1";
+
+    draw.duplicateSelected();
+
+    expect(scenario.geo.duplicateFeature).toHaveBeenCalledWith("cm-1", engine.map);
+    expect([...useSelectedItems().selectedFeatureIds.value]).toEqual(["cm-copy"]);
+    expect(draw.armed.value).toEqual({ kind: "cmEdit", featureId: "cm-copy" });
   });
 
   it("lets Edit mode select a control measure and starts editing it", async () => {

--- a/src/modules/scenarioeditor/useScenarioDraw.ts
+++ b/src/modules/scenarioeditor/useScenarioDraw.ts
@@ -823,6 +823,45 @@ export function useScenarioDraw(options: UseScenarioDrawOptions = {}) {
     );
   }
 
+  function duplicateSelected() {
+    const selectedIds = [...selectedFeatureIds.value];
+    if (!selectedIds.length) return;
+
+    // A tactical-draw edit is transient. Fold it before duplicateFeature reads the
+    // authoritative item, matching the details-panel duplicate action.
+    if (
+      controlMeasureEdit.featureId.value !== null &&
+      selectedIds.includes(controlMeasureEdit.featureId.value)
+    ) {
+      renderFeed?.settle("arm");
+    }
+
+    const duplicatedIds: FeatureId[] = [];
+    activeScenario.store.groupUpdate(
+      () => {
+        selectedIds.forEach((featureId) => {
+          const duplicatedId = activeScenario.geo.duplicateFeature(
+            featureId,
+            mapAdapter.value,
+          );
+          if (duplicatedId !== undefined) duplicatedIds.push(duplicatedId);
+        });
+      },
+      { label: "batchLayer", value: "dummy" },
+    );
+    if (!duplicatedIds.length) return;
+
+    selectedFeatureIds.value.clear();
+    duplicatedIds.forEach((featureId) => selectedFeatureIds.value.add(featureId));
+
+    if (duplicatedIds.length === 1) {
+      const duplicate = activeScenario.geo.getLayerItemById(duplicatedIds[0]).layerItem;
+      if (duplicate && isNTacticalGraphicLayerItem(duplicate)) {
+        arm({ kind: "cmEdit", featureId: duplicate.id });
+      }
+    }
+  }
+
   /**
    * Update host-owned control-measure fields without letting an open shape session
    * fold its older snapshot over the new values. Settling first is synchronous; the
@@ -1032,6 +1071,7 @@ export function useScenarioDraw(options: UseScenarioDrawOptions = {}) {
     /** `engine.draw` is defined — control measures can be authored on this engine. */
     canControlMeasures,
     updateControlMeasure,
+    duplicateSelected,
     deleteSelected,
     handleEscape,
     handleEnter,

--- a/src/scenariostore/geo.test.ts
+++ b/src/scenariostore/geo.test.ts
@@ -53,6 +53,124 @@ function createUnitScenario() {
 }
 
 describe("scenario geo item accessors", () => {
+  it("offsets duplicates and gives them incrementing names", () => {
+    const store = useNewScenarioStore({
+      id: "scenario-1",
+      type: "ORBAT-mapper",
+      version: "3.4.0",
+      name: "Scenario",
+      startTime: 0,
+      sides: [],
+      events: [],
+      layerStack: [
+        {
+          id: "layer-1",
+          kind: "overlay",
+          name: "Features",
+          items: [
+            {
+              id: "feature-1",
+              kind: "geometry",
+              name: "Route",
+              geometry: { type: "Point", coordinates: [10, 60] },
+              geometryMeta: { geometryKind: "Point" },
+              style: {},
+              state: [
+                {
+                  id: "state-1",
+                  t: 100,
+                  patch: { geometry: { type: "Point", coordinates: [11, 61] } },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      mapLayers: [],
+      settings: {
+        rangeRingGroups: [],
+        statuses: [],
+        supplyClasses: [],
+        supplyUoMs: [],
+        symbolFillColors: [],
+      },
+    } as any);
+    const geo = useGeo(store);
+
+    const mapAdapter = {
+      getPixelFromCoordinate: ([longitude, latitude]: number[]) => [
+        longitude * 100,
+        latitude * -100,
+      ],
+      getCoordinateFromPixel: ([x, y]: number[]) => [x / 100, y / -100],
+    } as any;
+    const firstId = geo.duplicateFeature("feature-1", mapAdapter)!;
+    const secondId = geo.duplicateFeature("feature-1", mapAdapter)!;
+    const first = geo.getGeometryLayerItemById(firstId).layerItem!;
+    const second = geo.getGeometryLayerItemById(secondId).layerItem!;
+
+    expect(first.name).toBe("Route (2)");
+    expect(second.name).toBe("Route (3)");
+    expect(first.geometry).toEqual({ type: "Point", coordinates: [10.24, 59.76] });
+    expect(first.state?.[0].patch.geometry).toEqual({
+      type: "Point",
+      coordinates: [11.24, 60.76],
+    });
+  });
+
+  it("offsets duplicated control points and custom label positions", () => {
+    const store = useNewScenarioStore({
+      id: "scenario-1",
+      type: "ORBAT-mapper",
+      version: "3.4.0",
+      name: "Scenario",
+      startTime: 0,
+      sides: [],
+      events: [],
+      layerStack: [
+        {
+          id: "layer-1",
+          kind: "overlay",
+          specialization: "controlMeasure",
+          name: "Control measures",
+          items: [
+            {
+              id: "cm-1",
+              kind: "tacticalGraphic",
+              name: "Phase Line Alpha",
+              graphicKind: "phase-line",
+              controlPoints: [[10, 60], [11, 61]],
+              amplifierPlacements: { T: { position: [10.5, 60.5] } },
+            },
+          ],
+        },
+      ],
+      mapLayers: [],
+      settings: {
+        rangeRingGroups: [],
+        statuses: [],
+        supplyClasses: [],
+        supplyUoMs: [],
+        symbolFillColors: [],
+      },
+    } as any);
+    const geo = useGeo(store);
+
+    const mapAdapter = {
+      getPixelFromCoordinate: ([longitude, latitude]: number[]) => [
+        longitude * 100,
+        latitude * -100,
+      ],
+      getCoordinateFromPixel: ([x, y]: number[]) => [x / 100, y / -100],
+    } as any;
+    const duplicatedId = geo.duplicateFeature("cm-1", mapAdapter)!;
+    const duplicate = geo.getLayerItemById(duplicatedId).layerItem as any;
+
+    expect(duplicate.name).toBe("Phase Line Alpha (2)");
+    expect(duplicate.controlPoints).toEqual([[10.24, 59.76], [11.24, 60.76]]);
+    expect(duplicate.amplifierPlacements.T.position).toEqual([10.74, 60.26]);
+  });
+
   it("keeps addUnitPosition redraw signal undo/redo aware", () => {
     const store = useNewScenarioStore(createUnitScenario());
     const geo = useGeo(store);

--- a/src/scenariostore/geo.ts
+++ b/src/scenariostore/geo.ts
@@ -49,6 +49,7 @@ import { createEventHook } from "@vueuse/core";
 import type { DropTarget } from "@/components/types";
 import type { Geometry } from "geojson";
 import { coordEach } from "@turf/meta";
+import type { AmplifierPlacements } from "@orbat-mapper/control-measures";
 import type { MapAdapter } from "@/geo/contracts/mapAdapter";
 
 const DUPLICATE_SCREEN_OFFSET_PX = 24;
@@ -59,7 +60,10 @@ function offsetPosition(position: Position, delta: readonly [number, number]) {
   position[1] += delta[1];
 }
 
-function offsetGeometry(geometry: Geometry | undefined, delta: readonly [number, number]) {
+function offsetGeometry(
+  geometry: Geometry | undefined,
+  delta: readonly [number, number],
+) {
   if (!geometry) return;
   coordEach(geometry, (coordinate) => offsetPosition(coordinate, delta));
 }
@@ -74,31 +78,34 @@ function duplicateName(feature: NScenarioLayerItem, siblings: NScenarioLayerItem
   return `${baseName} (${counter})`;
 }
 
+/** First position of a nested coordinate array, without walking the rest of it. */
+function firstPosition(coordinates: unknown): Position | undefined {
+  if (!Array.isArray(coordinates)) return;
+  if (typeof coordinates[0] === "number") return coordinates as Position;
+  return firstPosition(coordinates[0]);
+}
+
+function firstGeometryPosition(geometry: Geometry | undefined): Position | undefined {
+  if (!geometry) return;
+  if (geometry.type === "GeometryCollection")
+    return firstGeometryPosition(geometry.geometries[0]);
+  return firstPosition(geometry.coordinates);
+}
+
 function duplicateReference(feature: NScenarioLayerItem): Position | undefined {
   if (isNTacticalGraphicLayerItem(feature)) {
     return (feature._state?.controlPoints ?? feature.controlPoints)[0];
   }
   if (!isNGeometryLayerItem(feature)) return;
-  let reference: Position | undefined;
-  coordEach(feature._state?.geometry ?? feature.geometry, (coordinate) => {
-    reference ??= coordinate;
-  });
-  return reference;
+  return firstGeometryPosition(feature._state?.geometry ?? feature.geometry);
 }
 
 function duplicateDelta(
   feature: NScenarioLayerItem,
-  mapAdapter?: MapAdapter | null,
+  mapAdapter: MapAdapter | null | undefined,
 ): readonly [number, number] {
   const reference = duplicateReference(feature);
-  if (
-    !reference ||
-    !mapAdapter ||
-    typeof mapAdapter.getPixelFromCoordinate !== "function" ||
-    typeof mapAdapter.getCoordinateFromPixel !== "function"
-  ) {
-    return DUPLICATE_FALLBACK_DELTA;
-  }
+  if (!reference || !mapAdapter) return DUPLICATE_FALLBACK_DELTA;
   const pixel = mapAdapter.getPixelFromCoordinate(reference);
   if (!pixel) return DUPLICATE_FALLBACK_DELTA;
   const shifted = mapAdapter.getCoordinateFromPixel([
@@ -109,10 +116,7 @@ function duplicateDelta(
   return [shifted[0] - reference[0], shifted[1] - reference[1]];
 }
 
-function offsetDuplicate(
-  feature: NScenarioLayerItem,
-  delta: readonly [number, number],
-) {
+function offsetDuplicate(feature: NScenarioLayerItem, delta: readonly [number, number]) {
   if (isNGeometryLayerItem(feature)) {
     offsetGeometry(feature.geometry, delta);
     feature.state?.forEach(({ patch }) => offsetGeometry(patch.geometry, delta));
@@ -120,22 +124,23 @@ function offsetDuplicate(
     return;
   }
   if (!isNTacticalGraphicLayerItem(feature)) return;
-  feature.controlPoints.forEach((position) => offsetPosition(position, delta));
-  feature.state?.forEach(({ patch }) =>
-    patch.controlPoints?.forEach((position) => offsetPosition(position, delta)),
-  );
-  feature._state?.controlPoints?.forEach((position) => offsetPosition(position, delta));
-  Object.values(feature.amplifierPlacements ?? {}).forEach((placement) =>
-    offsetPosition(placement.position, delta),
-  );
-  feature.state?.forEach(({ patch }) =>
-    Object.values(patch.amplifierPlacements ?? {}).forEach((placement) =>
-      offsetPosition(placement.position, delta),
-    ),
-  );
-  Object.values(feature._state?.amplifierPlacements ?? {}).forEach((placement) =>
-    offsetPosition(placement.position, delta),
-  );
+  // The same positional fields live in three places: the current value, every timed
+  // patch, and the projected `_state`. Offset all of them so the copy moves as a whole.
+  const offsetSource = (source: {
+    controlPoints?: Position[];
+    amplifierPlacements?: AmplifierPlacements;
+  }) => {
+    source.controlPoints?.forEach((position) => offsetPosition(position, delta));
+    Object.values(source.amplifierPlacements ?? {}).forEach((placement) => {
+      if (!placement) return;
+      // A placement is either a bare `[lon, lat]` (legacy shorthand) or `{ position }`.
+      if (Array.isArray(placement)) offsetPosition(placement, delta);
+      else if (placement.position) offsetPosition(placement.position, delta);
+    });
+  };
+  offsetSource(feature);
+  feature.state?.forEach(({ patch }) => offsetSource(patch));
+  if (feature._state) offsetSource(feature._state);
 }
 
 export type ScenarioMapLayerEvent =
@@ -752,7 +757,10 @@ export function useGeo(store: NewScenarioStore) {
     featureLayerEvent.trigger({ type: "deleteFeature", id: featureId }).then();
   }
 
-  function duplicateFeature(featureId: FeatureId, mapAdapter?: MapAdapter | null) {
+  function duplicateFeature(
+    featureId: FeatureId,
+    mapAdapter: MapAdapter | null | undefined,
+  ) {
     const feature = state.layerItemMap[featureId];
     if (!feature) return;
     const owner = getOverlayLayerFromMap(state.layerStackMap, feature._pid);

--- a/src/scenariostore/geo.ts
+++ b/src/scenariostore/geo.ts
@@ -48,6 +48,95 @@ import { moveItemMutable, nanoid, removeElement } from "@/utils";
 import { createEventHook } from "@vueuse/core";
 import type { DropTarget } from "@/components/types";
 import type { Geometry } from "geojson";
+import { coordEach } from "@turf/meta";
+import type { MapAdapter } from "@/geo/contracts/mapAdapter";
+
+const DUPLICATE_SCREEN_OFFSET_PX = 24;
+const DUPLICATE_FALLBACK_DELTA: readonly [number, number] = [0.0001, -0.0001];
+
+function offsetPosition(position: Position, delta: readonly [number, number]) {
+  position[0] += delta[0];
+  position[1] += delta[1];
+}
+
+function offsetGeometry(geometry: Geometry | undefined, delta: readonly [number, number]) {
+  if (!geometry) return;
+  coordEach(geometry, (coordinate) => offsetPosition(coordinate, delta));
+}
+
+function duplicateName(feature: NScenarioLayerItem, siblings: NScenarioLayerItem[]) {
+  const sourceName = feature.name?.trim() || "Untitled";
+  const match = sourceName.match(/^(.*) \((\d+)\)$/);
+  const baseName = match ? match[1] : sourceName;
+  const siblingNames = new Set(siblings.map((item) => item.name));
+  let counter = match ? Number(match[2]) + 1 : 2;
+  while (siblingNames.has(`${baseName} (${counter})`)) counter++;
+  return `${baseName} (${counter})`;
+}
+
+function duplicateReference(feature: NScenarioLayerItem): Position | undefined {
+  if (isNTacticalGraphicLayerItem(feature)) {
+    return (feature._state?.controlPoints ?? feature.controlPoints)[0];
+  }
+  if (!isNGeometryLayerItem(feature)) return;
+  let reference: Position | undefined;
+  coordEach(feature._state?.geometry ?? feature.geometry, (coordinate) => {
+    reference ??= coordinate;
+  });
+  return reference;
+}
+
+function duplicateDelta(
+  feature: NScenarioLayerItem,
+  mapAdapter?: MapAdapter | null,
+): readonly [number, number] {
+  const reference = duplicateReference(feature);
+  if (
+    !reference ||
+    !mapAdapter ||
+    typeof mapAdapter.getPixelFromCoordinate !== "function" ||
+    typeof mapAdapter.getCoordinateFromPixel !== "function"
+  ) {
+    return DUPLICATE_FALLBACK_DELTA;
+  }
+  const pixel = mapAdapter.getPixelFromCoordinate(reference);
+  if (!pixel) return DUPLICATE_FALLBACK_DELTA;
+  const shifted = mapAdapter.getCoordinateFromPixel([
+    pixel[0] + DUPLICATE_SCREEN_OFFSET_PX,
+    pixel[1] + DUPLICATE_SCREEN_OFFSET_PX,
+  ]);
+  if (!shifted) return DUPLICATE_FALLBACK_DELTA;
+  return [shifted[0] - reference[0], shifted[1] - reference[1]];
+}
+
+function offsetDuplicate(
+  feature: NScenarioLayerItem,
+  delta: readonly [number, number],
+) {
+  if (isNGeometryLayerItem(feature)) {
+    offsetGeometry(feature.geometry, delta);
+    feature.state?.forEach(({ patch }) => offsetGeometry(patch.geometry, delta));
+    offsetGeometry(feature._state?.geometry, delta);
+    return;
+  }
+  if (!isNTacticalGraphicLayerItem(feature)) return;
+  feature.controlPoints.forEach((position) => offsetPosition(position, delta));
+  feature.state?.forEach(({ patch }) =>
+    patch.controlPoints?.forEach((position) => offsetPosition(position, delta)),
+  );
+  feature._state?.controlPoints?.forEach((position) => offsetPosition(position, delta));
+  Object.values(feature.amplifierPlacements ?? {}).forEach((placement) =>
+    offsetPosition(placement.position, delta),
+  );
+  feature.state?.forEach(({ patch }) =>
+    Object.values(patch.amplifierPlacements ?? {}).forEach((placement) =>
+      offsetPosition(placement.position, delta),
+    ),
+  );
+  Object.values(feature._state?.amplifierPlacements ?? {}).forEach((placement) =>
+    offsetPosition(placement.position, delta),
+  );
+}
 
 export type ScenarioMapLayerEvent =
   | {
@@ -663,13 +752,18 @@ export function useGeo(store: NewScenarioStore) {
     featureLayerEvent.trigger({ type: "deleteFeature", id: featureId }).then();
   }
 
-  function duplicateFeature(featureId: FeatureId) {
+  function duplicateFeature(featureId: FeatureId, mapAdapter?: MapAdapter | null) {
     const feature = state.layerItemMap[featureId];
     if (!feature) return;
     const owner = getOverlayLayerFromMap(state.layerStackMap, feature._pid);
     if (!owner || owner.locked || feature.locked) return;
     const copy = klona(feature);
     copy.id = nanoid();
+    copy.name = duplicateName(
+      feature,
+      owner.items.map((id) => state.layerItemMap[id]).filter((item) => !!item),
+    );
+    offsetDuplicate(copy, duplicateDelta(feature, mapAdapter));
     return addFeature(copy, feature._pid);
   }
 


### PR DESCRIPTION
## Summary

- Add duplication actions for features and control measures in details panels and the draw toolbar
- Offset duplicates by 24 screen pixels, assign incrementing names, and select the new items
- Enter duplicated control measures into edit mode and preserve dragged geometry
- Show doctrinal descriptions for supported control measures

## Testing

- Added and updated Vitest unit tests covering duplication, selection, editing, offsets, naming, metadata descriptions, and dragged-clone handling