### PR TITLE
Fix MapLibre scenario event zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed selecting a scenario event in MapLibre mode not zooming the map to the event area.
 - Fixed zooming to a circle feature so the view frames the full circle instead of only its centre point.
 - Fixed MapLibre control measures being drawn beneath image layers instead of above them according to the scenario layer stack.
 - Fixed duplicating a control measure after dragging a previous copy, which could create the next copy at an invalid position.

--- a/src/components/ScenarioMapLogic.vue
+++ b/src/components/ScenarioMapLogic.vue
@@ -116,7 +116,7 @@ const cleanupScenarioLayerBinding = scenarioLayerController.bindScenario(
 );
 const { rangeLayer, drawRangeRings } = useRangeRingsLayer();
 // Disable temporarily
-const {} = useScenarioEvents(olMap);
+useScenarioEvents();
 
 olMap.addLayer(rangeLayer);
 const { historyLayer, drawHistory, historyModify, waypointSelect, ctrlClickInteraction } =

--- a/src/modules/maplibreview/ScenarioEditorMaplibre.test.ts
+++ b/src/modules/maplibreview/ScenarioEditorMaplibre.test.ts
@@ -28,6 +28,7 @@ const destroyTacticalDrawSurface = vi.fn();
 const cleanupScenarioBinding = vi.fn();
 const setMapAdapter = vi.fn();
 const zoomToGeometry = vi.fn();
+const zoomToUnits = vi.fn();
 const initializeMaplibreLayers = vi.fn();
 let goToScenarioEventHandler: ((payload: { event: NScenarioEvent }) => void) | undefined;
 
@@ -115,6 +116,7 @@ vi.mock("@/stores/geoStore", () => ({
   useGeoStore: () => ({
     setMapAdapter,
     zoomToGeometry,
+    zoomToUnits,
   }),
 }));
 
@@ -260,6 +262,7 @@ describe("ScenarioEditorMaplibre", () => {
     destroyTacticalDrawSurface.mockReset();
     setMapAdapter.mockReset();
     zoomToGeometry.mockReset();
+    zoomToUnits.mockReset();
     goToScenarioEventHandler = undefined;
     initializeMaplibreLayers.mockReset();
     routingHandlers.addRouteLeg.mockReset();
@@ -321,6 +324,59 @@ describe("ScenarioEditorMaplibre", () => {
     expect(zoomToGeometry).toHaveBeenCalledWith(geometry, {
       duration: 900,
       maxZoom: 12,
+    });
+    wrapper.unmount();
+  });
+
+  it("pads unit-backed scenario events so their icons remain visible", async () => {
+    const activeScenario = createActiveScenario();
+    const units = [
+      { id: "unit-1", _state: { location: [10, 60] } },
+      { id: "unit-2", _state: { location: [11, 61] } },
+    ];
+    activeScenario.helpers.getUnitById
+      .mockReturnValueOnce(units[0])
+      .mockReturnValueOnce(units[1]);
+    const wrapper = mount(ScenarioEditorMaplibre, {
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeLayerKey as symbol]: ref("layer-1"),
+          [activeScenarioKey as symbol]: activeScenario,
+        },
+        stubs: {
+          ScenarioMapModeShell: ScenarioMapModeShellStub,
+          MaplibreContextMenu: { template: "<div><slot /></div>" },
+          MaplibreSearchScenarioActions: true,
+          MlMapLogic: true,
+          MapEditorMainToolbar: true,
+          MapEditorUnitTrackToolbar: true,
+          MapEditorDrawToolbar: true,
+          ToggleField: true,
+          Button: true,
+          Label: true,
+          Popover: true,
+          PopoverContent: true,
+          PopoverTrigger: true,
+          Slider: true,
+        },
+      },
+    });
+    await nextTick();
+
+    goToScenarioEventHandler!({
+      event: {
+        id: "event-1",
+        title: "Unit event",
+        startTime: 0,
+        where: { type: "units", units: ["unit-1", "unit-2"] },
+      } as NScenarioEvent,
+    });
+
+    expect(zoomToUnits).toHaveBeenCalledWith(units, {
+      duration: 900,
+      maxZoom: undefined,
+      padding: [50, 50, 50, 50],
     });
     wrapper.unmount();
   });

--- a/src/modules/maplibreview/ScenarioEditorMaplibre.test.ts
+++ b/src/modules/maplibreview/ScenarioEditorMaplibre.test.ts
@@ -7,6 +7,7 @@ import ScenarioEditorMaplibre from "@/modules/maplibreview/ScenarioEditorMaplibr
 import { activeLayerKey, activeScenarioKey, scenarioDrawKey } from "@/components/injects";
 import { useMainToolbarStore } from "@/stores/mainToolbarStore";
 import type { ScenarioMapViewSnapshot } from "@/modules/scenarioeditor/scenarioMapViewSnapshot";
+import type { NScenarioEvent } from "@/types/internalModels";
 
 const { mapModeState, routingHandlers, closeDetailsPanelMock } = vi.hoisted(() => ({
   mapModeState: { isMobile: false, hasRouteDetails: false },
@@ -26,7 +27,9 @@ const bindScenario = vi.fn();
 const destroyTacticalDrawSurface = vi.fn();
 const cleanupScenarioBinding = vi.fn();
 const setMapAdapter = vi.fn();
+const zoomToGeometry = vi.fn();
 const initializeMaplibreLayers = vi.fn();
+let goToScenarioEventHandler: ((payload: { event: NScenarioEvent }) => void) | undefined;
 
 vi.mock("@/geo/mapLibreMapAdapter", () => ({
   MapLibreMapAdapter: class MockMapLibreMapAdapter {
@@ -111,6 +114,7 @@ vi.mock("@/stores/maplibreLayersStore", () => ({
 vi.mock("@/stores/geoStore", () => ({
   useGeoStore: () => ({
     setMapAdapter,
+    zoomToGeometry,
   }),
 }));
 
@@ -234,6 +238,15 @@ describe("ScenarioEditorMaplibre", () => {
         ]),
         onFeatureLayerEvent: vi.fn(() => ({ off: vi.fn() })),
       },
+      helpers: {
+        getUnitById: vi.fn(),
+      },
+      time: {
+        onGoToScenarioEventEvent: vi.fn((handler) => {
+          goToScenarioEventHandler = handler;
+          return { off: vi.fn() };
+        }),
+      },
     };
   }
 
@@ -246,12 +259,70 @@ describe("ScenarioEditorMaplibre", () => {
     cleanupScenarioBinding.mockReset();
     destroyTacticalDrawSurface.mockReset();
     setMapAdapter.mockReset();
+    zoomToGeometry.mockReset();
+    goToScenarioEventHandler = undefined;
     initializeMaplibreLayers.mockReset();
     routingHandlers.addRouteLeg.mockReset();
     routingHandlers.clearCurrentLeg.mockReset();
     routingHandlers.finishRoute.mockReset();
     routingHandlers.closeRouting.mockReset();
     closeDetailsPanelMock.mockReset();
+  });
+
+  it("zooms to a selected scenario event area in maplibre mode", async () => {
+    const geometry = {
+      type: "Polygon",
+      coordinates: [
+        [
+          [10, 60],
+          [11, 60],
+          [11, 61],
+          [10, 60],
+        ],
+      ],
+    };
+    const wrapper = mount(ScenarioEditorMaplibre, {
+      global: {
+        plugins: [createPinia()],
+        provide: {
+          [activeLayerKey as symbol]: ref("layer-1"),
+          [activeScenarioKey as symbol]: createActiveScenario(),
+        },
+        stubs: {
+          ScenarioMapModeShell: ScenarioMapModeShellStub,
+          MaplibreContextMenu: { template: "<div><slot /></div>" },
+          MaplibreSearchScenarioActions: true,
+          MlMapLogic: true,
+          MapEditorMainToolbar: true,
+          MapEditorUnitTrackToolbar: true,
+          MapEditorDrawToolbar: true,
+          ToggleField: true,
+          Button: true,
+          Label: true,
+          Popover: true,
+          PopoverContent: true,
+          PopoverTrigger: true,
+          Slider: true,
+        },
+      },
+    });
+    await nextTick();
+
+    expect(goToScenarioEventHandler).toBeTypeOf("function");
+    goToScenarioEventHandler!({
+      event: {
+        id: "event-1",
+        title: "Geometry event",
+        startTime: 0,
+        where: { type: "geometry", geometry, maxZoom: 12 },
+      } as NScenarioEvent,
+    });
+
+    expect(zoomToGeometry).toHaveBeenCalledWith(geometry, {
+      duration: 900,
+      maxZoom: 12,
+    });
+    wrapper.unmount();
   });
 
   it("forwards the initial map view snapshot and emits one on unmount", async () => {

--- a/src/modules/maplibreview/ScenarioEditorMaplibre.vue
+++ b/src/modules/maplibreview/ScenarioEditorMaplibre.vue
@@ -52,6 +52,7 @@ import {
 } from "@/modules/scenarioeditor/scenarioMapViewSnapshot";
 import { useScenarioRouting } from "@/modules/scenarioeditor/useScenarioRouting";
 import { useMapLibreRoutingPreview } from "@/geo/routing/mapLibreRoutingPreview";
+import { useScenarioEvents } from "@/modules/scenarioeditor/scenarioEvents";
 
 const props = defineProps<{
   initialMapView?: ScenarioMapViewSnapshot;
@@ -63,6 +64,7 @@ const emit = defineEmits<{
 
 const activeScenario = injectStrict(activeScenarioKey);
 const toolbarStore = useMainToolbarStore();
+useScenarioEvents();
 
 const {
   store: { state },

--- a/src/modules/scenarioeditor/scenarioEvents.ts
+++ b/src/modules/scenarioeditor/scenarioEvents.ts
@@ -1,8 +1,7 @@
 import { useActiveScenario } from "@/composables/scenarioUtils";
-import OLMap from "ol/Map";
 import { useGeoStore } from "@/stores/geoStore";
 
-export function useScenarioEvents(olMap: OLMap) {
+export function useScenarioEvents() {
   const {
     time: { onGoToScenarioEventEvent },
     helpers: { getUnitById },

--- a/src/modules/scenarioeditor/scenarioEvents.ts
+++ b/src/modules/scenarioeditor/scenarioEvents.ts
@@ -1,6 +1,10 @@
 import { useActiveScenario } from "@/composables/scenarioUtils";
 import { useGeoStore } from "@/stores/geoStore";
 
+const SCENARIO_EVENT_UNIT_PADDING: [number, number, number, number] = [
+  50, 50, 50, 50,
+];
+
 export function useScenarioEvents() {
   const {
     time: { onGoToScenarioEventEvent },
@@ -15,7 +19,11 @@ export function useScenarioEvents() {
     if (where.type === "units") {
       const units = where.units.map((u) => getUnitById(u));
       if (units) {
-        geoStore.zoomToUnits(units, { duration: 900, maxZoom });
+        geoStore.zoomToUnits(units, {
+          duration: 900,
+          maxZoom,
+          padding: SCENARIO_EVENT_UNIT_PADDING,
+        });
       }
     } else if (where.type === "geometry") {
       geoStore.zoomToGeometry(where.geometry, { duration: 900, maxZoom });

--- a/src/stores/geoStore.test.ts
+++ b/src/stores/geoStore.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useGeoStore } from "@/stores/geoStore";
+import type { MapAdapter } from "@/geo/contracts/mapAdapter";
+import type { NUnit } from "@/types/internalModels";
+
+describe("geoStore", () => {
+  beforeEach(() => setActivePinia(createPinia()));
+
+  it("forwards padding when zooming to units", () => {
+    const store = useGeoStore();
+    const adapter = {
+      fitGeometry: vi.fn(),
+      getZoom: vi.fn(() => 5),
+      on: vi.fn(() => vi.fn()),
+    } as unknown as MapAdapter;
+    store.setMapAdapter(adapter);
+    const units = [
+      { _state: { location: [10, 60] } },
+      { _state: { location: [11, 61] } },
+    ] as NUnit[];
+
+    store.zoomToUnits(units, {
+      duration: 900,
+      maxZoom: 12,
+      padding: [50, 50, 50, 50],
+    });
+
+    expect(adapter.fitGeometry).toHaveBeenCalledWith(expect.any(Object), {
+      duration: 900,
+      maxZoom: 12,
+      padding: [50, 50, 50, 50],
+    });
+  });
+});

--- a/src/stores/geoStore.ts
+++ b/src/stores/geoStore.ts
@@ -40,7 +40,7 @@ export const useGeoStore = defineStore("geo", () => {
   }
 
   function zoomToUnits(units: NUnit[], options: ZoomOptions = {}) {
-    const { duration = 900, maxZoom = 15 } = options;
+    const { duration = 900, maxZoom = 15, padding } = options;
     const points = units
       .map((u) => u._state?.location)
       .filter((loc): loc is Position => !!loc)
@@ -48,7 +48,7 @@ export const useGeoStore = defineStore("geo", () => {
 
     if (!points.length) return;
     const c = featureCollection(points);
-    zoomToGeometry(c, { duration, maxZoom });
+    zoomToGeometry(c, { duration, maxZoom, padding });
   }
 
   function zoomToGeometry(geometry: AllGeoJSON, options: ZoomOptions = {}) {


### PR DESCRIPTION
## Summary
- register the shared scenario-event zoom handler in the MapLibre editor
- make the handler map-engine agnostic
- add regression coverage for geometry-backed event areas
- document the fix in the August 2026 changelog

## Testing
- pnpm vitest run src/modules/maplibreview/ScenarioEditorMaplibre.test.ts
- pnpm type-check
- git diff --check