### PR TITLE
Show current TO&E counts in ORBAT charts

### DIFF
--- a/src/scenariostore/unitManipulations.test.ts
+++ b/src/scenariostore/unitManipulations.test.ts
@@ -3,6 +3,7 @@ import { useNewScenarioStore } from "@/scenariostore/newScenarioStore";
 import { useUnitManipulations } from "@/scenariostore/unitManipulations";
 import { useScenarioTime } from "@/scenariostore/time";
 import { clearUnitStyleCache, unitStyleCache } from "@/geo/unitStyles";
+import issue663Scenario from "@/testdata/issue663Scenario.json";
 
 function createScenario() {
   return {
@@ -908,5 +909,24 @@ describe("expandUnitWithSymbolOptions", () => {
       useCurrentState: true,
     });
     expect(unit.sidc).toBe("10031000001100000000");
+  });
+
+  it("uses current on-hand resource counts for subordinate chart units", () => {
+    const store = useNewScenarioStore(issue663Scenario as any);
+    const actions = useUnitManipulations(store);
+    useScenarioTime(store).setCurrentTime(Date.parse("2026-08-08T10:00:00Z"));
+
+    expect(store.state.unitMap["alpha-battery"]._state?.equipment?.[0]).toMatchObject({
+      count: 12,
+      onHand: 3,
+    });
+
+    const unit = actions.expandUnitWithSymbolOptions(
+      store.state.unitMap["artillery-battalion"],
+      { useCurrentState: true },
+    );
+    expect(unit.subUnits?.[0]?.equipment).toEqual([
+      { name: "155 mm howitzer", count: 3 },
+    ]);
   });
 });

--- a/src/scenariostore/unitManipulations.ts
+++ b/src/scenariostore/unitManipulations.ts
@@ -60,7 +60,7 @@ export type NWalkSideGroupCallback = (
 ) => void | false | true;
 
 export interface ExpandUnitOptions {
-  /** Use the symbol projected for the current scenario time instead of the base sidc. */
+  /** Use symbol and resource values projected for the current scenario time. */
   useCurrentState?: boolean;
 }
 
@@ -1068,6 +1068,15 @@ export function useUnitManipulations(store: NewScenarioStore) {
     options: ExpandUnitOptions = {},
   ): Unit {
     const { useCurrentState = false } = options;
+    const equipment = useCurrentState
+      ? (unit._state?.equipment ?? unit.equipment)
+      : unit.equipment;
+    const personnel = useCurrentState
+      ? (unit._state?.personnel ?? unit.personnel)
+      : unit.personnel;
+    const supplies = useCurrentState
+      ? (unit._state?.supplies ?? unit.supplies)
+      : unit.supplies;
     return {
       ...unit,
       state: [],
@@ -1076,17 +1085,17 @@ export function useUnitManipulations(store: NewScenarioStore) {
       subUnits: unit.subUnits.map((subUnitId) =>
         expandUnitWithSymbolOptions(state.unitMap[subUnitId], options),
       ),
-      equipment: unit.equipment?.map(({ id, count }) => ({
+      equipment: equipment?.map(({ id, count, onHand }) => ({
         name: state.equipmentMap[id].name || "",
-        count,
+        count: useCurrentState ? (onHand ?? count) : count,
       })),
-      personnel: unit.personnel?.map(({ id, count }) => ({
+      personnel: personnel?.map(({ id, count, onHand }) => ({
         name: state.personnelMap[id].name || "",
-        count,
+        count: useCurrentState ? (onHand ?? count) : count,
       })),
-      supplies: unit.supplies?.map(({ id, count }) => ({
+      supplies: supplies?.map(({ id, count, onHand }) => ({
         name: state.supplyCategoryMap[id].name || "",
-        count,
+        count: useCurrentState ? (onHand ?? count) : count,
       })),
     };
   }

--- a/src/testdata/issue663Scenario.json
+++ b/src/testdata/issue663Scenario.json
@@ -1,0 +1,138 @@
+{
+  "id": "issue-663-repro",
+  "type": "ORBAT-mapper",
+  "version": "3.4.0",
+  "meta": {
+    "createdDate": "2026-08-08T08:00:00.000Z",
+    "lastModifiedDate": "2026-08-08T08:00:00.000Z"
+  },
+  "name": "Issue 663 — current TO&E counts",
+  "description": "Regression fixture for issue #663. At 10:00 UTC, each battery's available howitzers fall from 12 to 3 while the assigned count remains 12.",
+  "startTime": "2026-08-08T08:00:00Z",
+  "timeZone": "UTC",
+  "symbologyStandard": "2525d",
+  "sides": [
+    {
+      "id": "blue-side",
+      "name": "Blue force",
+      "standardIdentity": "3",
+      "symbolOptions": {},
+      "subUnits": [],
+      "groups": [
+        {
+          "id": "blue-units",
+          "name": "Blue units",
+          "symbolOptions": {},
+          "subUnits": [
+            {
+              "id": "artillery-battalion",
+              "name": "1st Artillery Battalion",
+              "shortName": "1 ARTY",
+              "sidc": "10031000161303000000",
+              "location": [10.75, 59.91],
+              "subUnits": [
+                {
+                  "id": "alpha-battery",
+                  "name": "Alpha Battery",
+                  "shortName": "A BTY",
+                  "sidc": "10031000151303000000",
+                  "location": [10.7, 59.89],
+                  "equipment": [
+                    {
+                      "name": "155 mm howitzer",
+                      "count": 12
+                    }
+                  ],
+                  "subUnits": [],
+                  "state": [
+                    {
+                      "id": "alpha-losses",
+                      "t": "2026-08-08T10:00:00Z",
+                      "update": {
+                        "equipment": [
+                          {
+                            "name": "155 mm howitzer",
+                            "onHand": 3
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "id": "bravo-battery",
+                  "name": "Bravo Battery",
+                  "shortName": "B BTY",
+                  "sidc": "10031000151303000000",
+                  "location": [10.8, 59.89],
+                  "equipment": [
+                    {
+                      "name": "155 mm howitzer",
+                      "count": 12
+                    }
+                  ],
+                  "subUnits": [],
+                  "state": [
+                    {
+                      "id": "bravo-losses",
+                      "t": "2026-08-08T10:00:00Z",
+                      "update": {
+                        "equipment": [
+                          {
+                            "name": "155 mm howitzer",
+                            "onHand": 3
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ],
+              "state": []
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "events": [
+    {
+      "id": "availability-reduced",
+      "title": "Battery availability reduced to 25%",
+      "subTitle": "Assigned: 12; available: 3",
+      "description": "Both batteries retain 12 assigned howitzers but only 3 are currently available.",
+      "startTime": "2026-08-08T10:00:00Z",
+      "where": {
+        "type": "units",
+        "units": ["alpha-battery", "bravo-battery"]
+      }
+    }
+  ],
+  "layerStack": [
+    {
+      "id": "features",
+      "kind": "overlay",
+      "name": "Features",
+      "items": []
+    }
+  ],
+  "equipment": [
+    {
+      "name": "155 mm howitzer",
+      "description": "Generic artillery piece used by the reproduction scenario."
+    }
+  ],
+  "personnel": [],
+  "supplyCategories": [],
+  "settings": {
+    "rangeRingGroups": [],
+    "statuses": [],
+    "supplyClasses": [],
+    "supplyUoMs": [],
+    "symbolFillColors": [],
+    "customSymbols": [],
+    "map": {
+      "baseMapId": "osm"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- project time-indexed equipment, personnel, and supplies into chart units
- display current on-hand values while retaining assigned counts as the fallback
- add an importable issue reproduction scenario and regression coverage

## Testing

- pnpm type-check
- pnpm test:unit

Closes #663