### PR TITLE
Fix ORBAT chart layout and page fitting

### DIFF
--- a/src/modules/charteditor/orbatchart/horizontalTreeLayout.ts
+++ b/src/modules/charteditor/orbatchart/horizontalTreeLayout.ts
@@ -1,3 +1,6 @@
+/** Stop bisecting the gap once the interval is below half a pixel. */
+const GAP_PRECISION = 0.5;
+
 export interface HorizontalTreeItem<T> {
   value: T;
   leftExtent: number;
@@ -10,12 +13,6 @@ export interface HorizontalTreeLayoutOptions {
   margin: number;
   minimumGap: number;
   uniformNodeSlots: boolean;
-}
-
-export interface HorizontalTreeLayout<T> {
-  positions: Map<T, number>;
-  width: number;
-  gap: number;
 }
 
 interface MeasuredChild<T> {
@@ -88,10 +85,11 @@ function placeTree<T>(tree: MeasuredTree<T>, left: number, positions: Map<T, num
   tree.children.forEach((child) => placeTree(child.tree, left + child.offset, positions));
 }
 
+/** Assigns an x coordinate to every item in the tree, keyed by the item's value. */
 export function layoutHorizontalTree<T>(
   root: HorizontalTreeItem<T>,
   { viewportWidth, margin, minimumGap, uniformNodeSlots }: HorizontalTreeLayoutOptions,
-): HorizontalTreeLayout<T> {
+): Map<T, number> {
   let fixedExtents: { left: number; right: number } | null = null;
   if (uniformNodeSlots) {
     fixedExtents = { left: 0, right: 0 };
@@ -104,13 +102,14 @@ export function layoutHorizontalTree<T>(
   const safeMargin = Math.max(0, margin);
   const safeMinimumGap = Math.max(0, minimumGap);
   const availableWidth = Math.max(0, viewportWidth - safeMargin * 2);
-  let gap = safeMinimumGap;
-  let measured = measureTree(root, gap, fixedExtents);
+  let measured = measureTree(root, safeMinimumGap, fixedExtents);
 
+  // Widen the gap as much as the viewport allows. The width-to-gap relation is
+  // piecewise linear (subtrees clamp), so bisect rather than solve directly.
   if (measured.width < availableWidth) {
     let low = safeMinimumGap;
     let high = Math.max(safeMinimumGap, availableWidth);
-    for (let index = 0; index < 40; index += 1) {
+    while (high - low > GAP_PRECISION) {
       const candidate = (low + high) / 2;
       const candidateTree = measureTree(root, candidate, fixedExtents);
       if (candidateTree.width <= availableWidth) {
@@ -120,12 +119,11 @@ export function layoutHorizontalTree<T>(
         high = candidate;
       }
     }
-    gap = low;
   }
 
   const width = Math.max(viewportWidth, measured.width + safeMargin * 2);
   const positions = new Map<T, number>();
   placeTree(measured, (width - measured.width) / 2, positions);
 
-  return { positions, width, gap };
+  return positions;
 }

--- a/src/modules/charteditor/orbatchart/horizontalTreeLayout.ts
+++ b/src/modules/charteditor/orbatchart/horizontalTreeLayout.ts
@@ -1,0 +1,131 @@
+export interface HorizontalTreeItem<T> {
+  value: T;
+  leftExtent: number;
+  rightExtent: number;
+  children: HorizontalTreeItem<T>[];
+}
+
+export interface HorizontalTreeLayoutOptions {
+  viewportWidth: number;
+  margin: number;
+  minimumGap: number;
+  uniformNodeSlots: boolean;
+}
+
+export interface HorizontalTreeLayout<T> {
+  positions: Map<T, number>;
+  width: number;
+  gap: number;
+}
+
+interface MeasuredChild<T> {
+  offset: number;
+  tree: MeasuredTree<T>;
+}
+
+interface MeasuredTree<T> {
+  item: HorizontalTreeItem<T>;
+  width: number;
+  rootX: number;
+  children: MeasuredChild<T>[];
+}
+
+function walkItems<T>(
+  root: HorizontalTreeItem<T>,
+  visit: (item: HorizontalTreeItem<T>) => void,
+) {
+  visit(root);
+  root.children.forEach((child) => walkItems(child, visit));
+}
+
+function measureTree<T>(
+  item: HorizontalTreeItem<T>,
+  gap: number,
+  fixedExtents: { left: number; right: number } | null,
+): MeasuredTree<T> {
+  const leftExtent = fixedExtents?.left ?? item.leftExtent;
+  const rightExtent = fixedExtents?.right ?? item.rightExtent;
+  if (item.children.length === 0) {
+    return {
+      item,
+      width: leftExtent + rightExtent,
+      rootX: leftExtent,
+      children: [],
+    };
+  }
+
+  const measuredChildren = item.children.map((child) =>
+    measureTree(child, gap, fixedExtents),
+  );
+  const children: MeasuredChild<T>[] = [];
+  let cursor = 0;
+  for (const child of measuredChildren) {
+    children.push({ offset: cursor, tree: child });
+    cursor += child.width + gap;
+  }
+  const childrenWidth = cursor - gap;
+  const firstChildRoot = children[0].tree.rootX;
+  const lastChild = children[children.length - 1];
+  const lastChildRoot = lastChild.offset + lastChild.tree.rootX;
+  const rootX = (firstChildRoot + lastChildRoot) / 2;
+  const minX = Math.min(0, rootX - leftExtent);
+  const maxX = Math.max(childrenWidth, rootX + rightExtent);
+  const shift = -minX;
+
+  return {
+    item,
+    width: maxX - minX,
+    rootX: rootX + shift,
+    children: children.map((child) => ({
+      ...child,
+      offset: child.offset + shift,
+    })),
+  };
+}
+
+function placeTree<T>(tree: MeasuredTree<T>, left: number, positions: Map<T, number>) {
+  positions.set(tree.item.value, left + tree.rootX);
+  tree.children.forEach((child) => placeTree(child.tree, left + child.offset, positions));
+}
+
+export function layoutHorizontalTree<T>(
+  root: HorizontalTreeItem<T>,
+  { viewportWidth, margin, minimumGap, uniformNodeSlots }: HorizontalTreeLayoutOptions,
+): HorizontalTreeLayout<T> {
+  let fixedExtents: { left: number; right: number } | null = null;
+  if (uniformNodeSlots) {
+    fixedExtents = { left: 0, right: 0 };
+    walkItems(root, (item) => {
+      fixedExtents!.left = Math.max(fixedExtents!.left, item.leftExtent, 0);
+      fixedExtents!.right = Math.max(fixedExtents!.right, item.rightExtent, 0);
+    });
+  }
+
+  const safeMargin = Math.max(0, margin);
+  const safeMinimumGap = Math.max(0, minimumGap);
+  const availableWidth = Math.max(0, viewportWidth - safeMargin * 2);
+  let gap = safeMinimumGap;
+  let measured = measureTree(root, gap, fixedExtents);
+
+  if (measured.width < availableWidth) {
+    let low = safeMinimumGap;
+    let high = Math.max(safeMinimumGap, availableWidth);
+    for (let index = 0; index < 40; index += 1) {
+      const candidate = (low + high) / 2;
+      const candidateTree = measureTree(root, candidate, fixedExtents);
+      if (candidateTree.width <= availableWidth) {
+        low = candidate;
+        measured = candidateTree;
+      } else {
+        high = candidate;
+      }
+    }
+    gap = low;
+  }
+
+  const width = Math.max(viewportWidth, measured.width + safeMargin * 2);
+  const positions = new Map<T, number>();
+  placeTree(measured, (width - measured.width) / 2, positions);
+
+  return { positions, width, gap };
+}

--- a/src/modules/charteditor/orbatchart/orbchart.layout.test.ts
+++ b/src/modules/charteditor/orbatchart/orbchart.layout.test.ts
@@ -97,6 +97,29 @@ describe("horizontal layout bounds", () => {
     expect(contentRight * scale + translateX).toBeLessThanOrEqual(200);
   });
 
+  it("keeps the debug page boundary in page coordinates", () => {
+    const chart = new OrbatChart(
+      unit("A unit name that is wider than the requested chart viewport"),
+      {
+        debug: true,
+        maxLevels: 1,
+        symbolGenerator: createSymbol,
+      },
+    );
+
+    const svg = chart.toSVG(document.createElement("div"), {
+      width: 200,
+      height: 200,
+    });
+
+    const pageBoundary = svg.querySelector<SVGRectElement>(
+      ":scope > rect.o-page-boundary",
+    );
+    expect(pageBoundary).not.toBeNull();
+    expect(pageBoundary!.getAttribute("width")).toBe("200");
+    expect(pageBoundary!.getAttribute("height")).toBe("200");
+  });
+
   it("preserves a non-horizontal final level relative to its parent", () => {
     const root = unit("root", [
       unit("left", [unit("left-child")]),

--- a/src/modules/charteditor/orbatchart/orbchart.layout.test.ts
+++ b/src/modules/charteditor/orbatchart/orbchart.layout.test.ts
@@ -65,7 +65,7 @@ describe.each([UnitLevelDistances.Fixed, UnitLevelDistances.EqualPadding])(
 );
 
 describe("horizontal layout bounds", () => {
-  it("expands the viewBox instead of clipping an oversized label", () => {
+  it("fits an oversized label inside the requested page size", () => {
     const root = unit("A unit name that is wider than the requested chart viewport");
     const chart = new OrbatChart(root, {
       maxLevels: 1,
@@ -77,15 +77,24 @@ describe("horizontal layout bounds", () => {
       height: 200,
     });
 
-    const [viewLeft, , viewWidth] = svg.getAttribute("viewBox")!.split(" ").map(Number);
+    expect(svg.getAttribute("viewBox")).toBe("0 0 200 200");
+
+    const transform = svg
+      .querySelector<SVGGElement>("g.o-wrapper")!
+      .getAttribute("transform")!;
+    const match = transform.match(
+      /^translate\(([-\d.e]+) ([-\d.e]+)\) scale\(([-\d.e]+)\)$/,
+    )!;
+    const translateX = Number(match[1]);
+    const scale = Number(match[3]);
     const renderedRoot = chart.renderedChart.levels[0].branches[0].units[0];
     const contentLeft =
       renderedRoot.x - renderedRoot.octagonAnchor.x + renderedRoot.boundingBox.x;
     const contentRight = contentLeft + renderedRoot.boundingBox.width;
 
-    expect(viewWidth).toBeGreaterThan(200);
-    expect(contentLeft).toBeGreaterThanOrEqual(viewLeft);
-    expect(contentRight).toBeLessThanOrEqual(viewLeft + viewWidth);
+    expect(scale).toBeLessThan(1);
+    expect(contentLeft * scale + translateX).toBeGreaterThanOrEqual(0);
+    expect(contentRight * scale + translateX).toBeLessThanOrEqual(200);
   });
 
   it("preserves a non-horizontal final level relative to its parent", () => {

--- a/src/modules/charteditor/orbatchart/orbchart.layout.test.ts
+++ b/src/modules/charteditor/orbatchart/orbchart.layout.test.ts
@@ -1,0 +1,110 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { OrbatChart } from "./orbchart";
+import { UnitLevelDistances, type ChartUnit } from "./types";
+
+const sidc = "10031000151211004600";
+const originalGetBBox = Object.getOwnPropertyDescriptor(SVGElement.prototype, "getBBox");
+
+function unit(id: string, subUnits?: ChartUnit[]): ChartUnit {
+  return { id, name: id, sidc, subUnits };
+}
+
+function createSymbol() {
+  return {
+    getSize: () => ({ width: 40, height: 40 }),
+    getAnchor: () => ({ x: 20, y: 20 }),
+    getOctagonAnchor: () => ({ x: 20, y: 20 }),
+    asSVG: () => "<svg />",
+  } as never;
+}
+
+beforeAll(() => {
+  Object.defineProperty(SVGElement.prototype, "getBBox", {
+    configurable: true,
+    value(this: SVGElement) {
+      const label = this.querySelector("text")?.textContent ?? "";
+      const width = Math.max(40, label.length * 8);
+      return { x: 20 - width / 2, y: 0, width, height: 40 };
+    },
+  });
+});
+
+afterAll(() => {
+  if (originalGetBBox) {
+    Object.defineProperty(SVGElement.prototype, "getBBox", originalGetBBox);
+  } else {
+    delete (SVGElement.prototype as { getBBox?: unknown }).getBBox;
+  }
+});
+
+describe.each([UnitLevelDistances.Fixed, UnitLevelDistances.EqualPadding])(
+  "horizontal subtree layout (%s)",
+  (unitLevelDistance) => {
+    it("keeps an adjacent parent trunk outside another branch's connector bus", () => {
+      const root = unit("root", [
+        unit("wide", [unit("w1"), unit("w2"), unit("w3"), unit("w4"), unit("w5")]),
+        unit("narrow", [unit("n1")]),
+      ]);
+      const chart = new OrbatChart(root, {
+        maxLevels: 3,
+        symbolGenerator: createSymbol,
+        unitLevelDistance,
+      });
+
+      chart.toSVG(document.createElement("div"), { width: 600, height: 600 });
+
+      const wideChildren = chart.renderedChart.levels[2].branches[0].units;
+      const [wideParent, narrowParent] = chart.renderedChart.levels[1].branches[0].units;
+      const busLeft = wideChildren[0].x;
+      const busRight = wideChildren[wideChildren.length - 1].x;
+
+      expect(narrowParent.x >= busLeft && narrowParent.x <= busRight).toBe(false);
+      expect(wideParent.x).toBeCloseTo((busLeft + busRight) / 2);
+    });
+  },
+);
+
+describe("horizontal layout bounds", () => {
+  it("expands the viewBox instead of clipping an oversized label", () => {
+    const root = unit("A unit name that is wider than the requested chart viewport");
+    const chart = new OrbatChart(root, {
+      maxLevels: 1,
+      symbolGenerator: createSymbol,
+    });
+
+    const svg = chart.toSVG(document.createElement("div"), {
+      width: 200,
+      height: 200,
+    });
+
+    const [viewLeft, , viewWidth] = svg.getAttribute("viewBox")!.split(" ").map(Number);
+    const renderedRoot = chart.renderedChart.levels[0].branches[0].units[0];
+    const contentLeft =
+      renderedRoot.x - renderedRoot.octagonAnchor.x + renderedRoot.boundingBox.x;
+    const contentRight = contentLeft + renderedRoot.boundingBox.width;
+
+    expect(viewWidth).toBeGreaterThan(200);
+    expect(contentLeft).toBeGreaterThanOrEqual(viewLeft);
+    expect(contentRight).toBeLessThanOrEqual(viewLeft + viewWidth);
+  });
+
+  it("preserves a non-horizontal final level relative to its parent", () => {
+    const root = unit("root", [
+      unit("left", [unit("left-child")]),
+      unit("right", [unit("right-child")]),
+    ]);
+    const chart = new OrbatChart(root, {
+      lastLevelLayout: "TREE_RIGHT",
+      maxLevels: 3,
+      symbolGenerator: createSymbol,
+      treeOffset: 60,
+    });
+
+    chart.toSVG(document.createElement("div"), { width: 600, height: 600 });
+
+    const parents = chart.renderedChart.levels[1].branches[0].units;
+    const childBranches = chart.renderedChart.levels[2].branches;
+    expect(childBranches[0].units[0].x).toBe(parents[0].x + 60);
+    expect(childBranches[1].units[0].x).toBe(parents[1].x + 60);
+  });
+});

--- a/src/modules/charteditor/orbatchart/orbchart.ts
+++ b/src/modules/charteditor/orbatchart/orbchart.ts
@@ -25,6 +25,7 @@ import {
   addConnectorAttributes,
   addFontAttributes,
   calculateAnchorPoints,
+  getUnitBoxOrigin,
   createChartStyle,
   createGroupElement,
   createInitialNodeStructure,
@@ -410,27 +411,29 @@ class OrbatChart {
         : lastLevelIndex - 1;
     if (lastHorizontalLevel < 0) return;
 
-    const includedNodes = new Set<RenderedUnitNode>();
-    renderedChart.levels.slice(0, lastHorizontalLevel + 1).forEach((level) => {
-      level.branches.forEach((branch) => {
-        branch.units.forEach((unit) => includedNodes.add(unit));
-      });
-    });
-
     const root = renderedChart.levels[0].branches[0]?.units[0];
     if (!root) return;
+
+    // Levels are ordered top down, so a unit's parent is always visited before the
+    // unit itself and membership can be decided in a single pass.
+    const includedNodes = new Set<RenderedUnitNode>();
     const childrenByParent = new Map<RenderedUnitNode, RenderedUnitNode[]>();
-    includedNodes.forEach((unit) => {
-      if (!unit.parent || !includedNodes.has(unit.parent)) return;
-      const children = childrenByParent.get(unit.parent) ?? [];
-      children.push(unit);
-      childrenByParent.set(unit.parent, children);
+    renderedChart.levels.slice(0, lastHorizontalLevel + 1).forEach((level) => {
+      level.branches.forEach((branch) => {
+        branch.units.forEach((unit) => {
+          includedNodes.add(unit);
+          if (!unit.parent || !includedNodes.has(unit.parent)) return;
+          const children = childrenByParent.get(unit.parent) ?? [];
+          children.push(unit);
+          childrenByParent.set(unit.parent, children);
+        });
+      });
     });
 
     const toLayoutItem = (
       unit: RenderedUnitNode,
     ): HorizontalTreeItem<RenderedUnitNode> => {
-      const boxLeft = unit.x - unit.octagonAnchor.x + unit.boundingBox.x;
+      const boxLeft = getUnitBoxOrigin(unit).x;
       return {
         value: unit,
         leftExtent: unit.x - boxLeft,
@@ -439,7 +442,7 @@ class OrbatChart {
       };
     };
 
-    const layout = layoutHorizontalTree(toLayoutItem(root), {
+    const positions = layoutHorizontalTree(toLayoutItem(root), {
       viewportWidth: this.width,
       margin: HORIZONTAL_MARGIN,
       minimumGap: Math.max(
@@ -448,7 +451,7 @@ class OrbatChart {
       ),
       uniformNodeSlots: this.options.unitLevelDistance === UnitLevelDistances.Fixed,
     });
-    layout.positions.forEach((x, unit) => {
+    positions.forEach((x, unit) => {
       unit.x = x;
     });
   }
@@ -461,8 +464,7 @@ class OrbatChart {
     renderedChart.levels.forEach((level) => {
       level.branches.forEach((branch) => {
         branch.units.forEach((unit) => {
-          const unitLeft = unit.x - unit.octagonAnchor.x + unit.boundingBox.x;
-          const unitTop = unit.y - unit.octagonAnchor.y + unit.boundingBox.y;
+          const { x: unitLeft, y: unitTop } = getUnitBoxOrigin(unit);
           left = Math.min(left, unitLeft - HORIZONTAL_MARGIN);
           top = Math.min(top, unitTop - HORIZONTAL_MARGIN);
           right = Math.max(right, unitLeft + unit.boundingBox.width + HORIZONTAL_MARGIN);

--- a/src/modules/charteditor/orbatchart/orbchart.ts
+++ b/src/modules/charteditor/orbatchart/orbchart.ts
@@ -214,10 +214,10 @@ class OrbatChart {
     svg.append("style").text(createChartStyle(this.options));
     svg.attr("width", "100%");
     svg.attr("height", "100%");
-    this.wrapperGroup = createGroupElement(svg, "o-wrapper");
     if (this.options.debug) {
-      this.wrapperGroup
+      svg
         .append<SVGRectElement>("rect")
+        .attr("class", "o-page-boundary")
         .attr("fill", "none")
         .attr("stroke", "red")
         .attr("y", "0")
@@ -226,6 +226,7 @@ class OrbatChart {
         .attr("height", this.height);
     }
 
+    this.wrapperGroup = createGroupElement(svg, "o-wrapper");
     createGroupElement(this.wrapperGroup, "", "o-highlight-layer");
     this.svg = svg;
     return {

--- a/src/modules/charteditor/orbatchart/orbchart.ts
+++ b/src/modules/charteditor/orbatchart/orbchart.ts
@@ -1,5 +1,5 @@
 import { select } from "d3-selection";
-import { arrSum, flattenArray, walkTree } from "./utils";
+import { walkTree } from "./utils";
 import type {
   BasicUnitNode,
   ChartUnit,
@@ -36,6 +36,10 @@ import {
   putGroupAt,
 } from "./svgRender";
 import Panzoom, { type PanzoomObject } from "@panzoom/panzoom";
+import { layoutHorizontalTree, type HorizontalTreeItem } from "./horizontalTreeLayout";
+
+const HORIZONTAL_MARGIN = 20;
+const MINIMUM_HORIZONTAL_GAP = 16;
 
 function isStackedLayout(layout: LevelLayout) {
   return layout === LevelLayouts.Stacked;
@@ -124,6 +128,7 @@ class OrbatChart {
       this.specificOptions,
     );
     this._doNodeLayout(renderedChart);
+    this._fitViewBoxToNodes(renderedChart);
     this._drawConnectors(renderedChart);
     this.renderedChart = renderedChart;
     if (enablePanZoom) {
@@ -269,6 +274,7 @@ class OrbatChart {
   }
 
   private _doNodeLayout(renderedChart: RenderedChart) {
+    this._layoutHorizontalLevels(renderedChart);
     const numberOfLevels = this.groupedLevels.length;
     const maxLevels = this.options.maxLevels || numberOfLevels;
     const chartHeight = this.height;
@@ -298,16 +304,6 @@ class OrbatChart {
     const chartWidth = this.width;
     const wrapperGroup = this.wrapperGroup;
 
-    const renderGroups = renderedLevel.branches;
-    const unitsOnLevel = flattenArray<RenderedUnitNode>(
-      renderGroups.map((unitGroup) => unitGroup.units),
-    );
-    const numberOfUnitsOnLevel = unitsOnLevel.length;
-    const totalWidth = arrSum(unitsOnLevel.map((u) => u.boundingBox.width));
-
-    const availableSpace = chartWidth - totalWidth;
-    const padding = availableSpace / numberOfUnitsOnLevel;
-
     switch (levelLayout) {
       case LevelLayouts.Horizontal:
         _doHorizontalLayout();
@@ -327,29 +323,17 @@ class OrbatChart {
     if (levelOptions.debug) drawDebugRect(renderedLevel.groupElement);
 
     function _doHorizontalLayout() {
-      let xIdx = 0;
-      let prevX = -padding / 2;
-
-      renderedLevel.branches.forEach((unitBranch, groupIdx) => {
+      renderedLevel.branches.forEach((unitBranch) => {
         const branchOptions = { ...levelOptions, ...unitBranch.options };
         for (const unitNode of unitBranch.units) {
-          let x;
           const unitOptions = { ...branchOptions, ...unitNode.options };
-          if (unitOptions.unitLevelDistance === UnitLevelDistances.EqualPadding) {
-            x = prevX + unitNode.boundingBox.width / 2 + padding;
-          } else {
-            x = ((xIdx + 1) * chartWidth) / (numberOfUnitsOnLevel + 1);
-          }
-
-          unitNode.x = x;
+          const x = unitNode.x;
           unitNode.y = y;
           calculateAnchorPoints(unitNode);
 
-          prevX = unitNode.x + unitNode.boundingBox.width / 2;
           putGroupAt(unitNode.groupElement, unitNode, x, y, unitOptions.debug);
 
           if (unitOptions.debug) drawDebugAnchors(wrapperGroup, unitNode);
-          xIdx += 1;
         }
         if (branchOptions.debug) drawDebugRect(unitBranch.groupElement, "yellow");
       });
@@ -413,6 +397,85 @@ class OrbatChart {
         if (branchOptions.debug) drawDebugRect(unitBranch.groupElement, "yellow");
       });
     }
+  }
+
+  private _layoutHorizontalLevels(renderedChart: RenderedChart) {
+    if (renderedChart.levels.length === 0) return;
+    const lastLevelIndex = renderedChart.levels.length - 1;
+    const lastHorizontalLevel =
+      this.options.lastLevelLayout === LevelLayouts.Horizontal
+        ? lastLevelIndex
+        : lastLevelIndex - 1;
+    if (lastHorizontalLevel < 0) return;
+
+    const includedNodes = new Set<RenderedUnitNode>();
+    renderedChart.levels.slice(0, lastHorizontalLevel + 1).forEach((level) => {
+      level.branches.forEach((branch) => {
+        branch.units.forEach((unit) => includedNodes.add(unit));
+      });
+    });
+
+    const root = renderedChart.levels[0].branches[0]?.units[0];
+    if (!root) return;
+    const childrenByParent = new Map<RenderedUnitNode, RenderedUnitNode[]>();
+    includedNodes.forEach((unit) => {
+      if (!unit.parent || !includedNodes.has(unit.parent)) return;
+      const children = childrenByParent.get(unit.parent) ?? [];
+      children.push(unit);
+      childrenByParent.set(unit.parent, children);
+    });
+
+    const toLayoutItem = (
+      unit: RenderedUnitNode,
+    ): HorizontalTreeItem<RenderedUnitNode> => {
+      const boxLeft = unit.x - unit.octagonAnchor.x + unit.boundingBox.x;
+      return {
+        value: unit,
+        leftExtent: unit.x - boxLeft,
+        rightExtent: boxLeft + unit.boundingBox.width - unit.x,
+        children: (childrenByParent.get(unit) ?? []).map(toLayoutItem),
+      };
+    };
+
+    const layout = layoutHorizontalTree(toLayoutItem(root), {
+      viewportWidth: this.width,
+      margin: HORIZONTAL_MARGIN,
+      minimumGap: Math.max(
+        MINIMUM_HORIZONTAL_GAP,
+        this.options.connectorOffset * 2 + this.options.lineWidth,
+      ),
+      uniformNodeSlots: this.options.unitLevelDistance === UnitLevelDistances.Fixed,
+    });
+    layout.positions.forEach((x, unit) => {
+      unit.x = x;
+    });
+    if (layout.width > this.width) {
+      this.width = layout.width;
+      this.svg.attr("viewBox", `0 0 ${this.width} ${this.height}`);
+    }
+  }
+
+  private _fitViewBoxToNodes(renderedChart: RenderedChart) {
+    let left = 0;
+    let top = 0;
+    let right = this.width;
+    let bottom = this.height;
+    renderedChart.levels.forEach((level) => {
+      level.branches.forEach((branch) => {
+        branch.units.forEach((unit) => {
+          const unitLeft = unit.x - unit.octagonAnchor.x + unit.boundingBox.x;
+          const unitTop = unit.y - unit.octagonAnchor.y + unit.boundingBox.y;
+          left = Math.min(left, unitLeft - HORIZONTAL_MARGIN);
+          top = Math.min(top, unitTop - HORIZONTAL_MARGIN);
+          right = Math.max(right, unitLeft + unit.boundingBox.width + HORIZONTAL_MARGIN);
+          bottom = Math.max(
+            bottom,
+            unitTop + unit.boundingBox.height + HORIZONTAL_MARGIN,
+          );
+        });
+      });
+    });
+    this.svg.attr("viewBox", `${left} ${top} ${right - left} ${bottom - top}`);
   }
 
   private _drawConnectors(renderedChart: RenderedChart) {

--- a/src/modules/charteditor/orbatchart/orbchart.ts
+++ b/src/modules/charteditor/orbatchart/orbchart.ts
@@ -120,7 +120,8 @@ class OrbatChart {
 
     // Pass 1: Create g elements and other svg elements
     // Pass 2: Do unit layout
-    // Pass 3: Draw connectors
+    // Pass 3: Fit the completed layout to the requested page
+    // Pass 4: Draw connectors
     renderedChart.levels = createInitialNodeStructure(
       chartGroup,
       this.groupedLevels,
@@ -128,7 +129,7 @@ class OrbatChart {
       this.specificOptions,
     );
     this._doNodeLayout(renderedChart);
-    this._fitViewBoxToNodes(renderedChart);
+    this._fitChartToViewport(renderedChart);
     this._drawConnectors(renderedChart);
     this.renderedChart = renderedChart;
     if (enablePanZoom) {
@@ -449,13 +450,9 @@ class OrbatChart {
     layout.positions.forEach((x, unit) => {
       unit.x = x;
     });
-    if (layout.width > this.width) {
-      this.width = layout.width;
-      this.svg.attr("viewBox", `0 0 ${this.width} ${this.height}`);
-    }
   }
 
-  private _fitViewBoxToNodes(renderedChart: RenderedChart) {
+  private _fitChartToViewport(renderedChart: RenderedChart) {
     let left = 0;
     let top = 0;
     let right = this.width;
@@ -475,7 +472,15 @@ class OrbatChart {
         });
       });
     });
-    this.svg.attr("viewBox", `${left} ${top} ${right - left} ${bottom - top}`);
+    const contentWidth = right - left;
+    const contentHeight = bottom - top;
+    const scale = Math.min(1, this.width / contentWidth, this.height / contentHeight);
+    const translateX = (this.width - contentWidth * scale) / 2 - left * scale;
+    const translateY = -top * scale;
+    this.wrapperGroup.attr(
+      "transform",
+      `translate(${translateX} ${translateY}) scale(${scale})`,
+    );
   }
 
   private _drawConnectors(renderedChart: RenderedChart) {

--- a/src/modules/charteditor/orbatchart/svgRender.ts
+++ b/src/modules/charteditor/orbatchart/svgRender.ts
@@ -329,9 +329,11 @@ function aggregateData(unit: ChartUnit) {
 
 export function calculateAnchorPoints(unitNode: RenderedUnitNode) {
   const { x, y } = unitNode;
-  unitNode.ly = y + (unitNode.boundingBox.height - unitNode.octagonAnchor.y);
-  unitNode.lx = x - unitNode.boundingBox.width / 2;
-  unitNode.rx = x + unitNode.boundingBox.width / 2;
+  const boxLeft = x - unitNode.octagonAnchor.x + unitNode.boundingBox.x;
+  const boxTop = y - unitNode.octagonAnchor.y + unitNode.boundingBox.y;
+  unitNode.ly = boxTop + unitNode.boundingBox.height;
+  unitNode.lx = boxLeft;
+  unitNode.rx = boxLeft + unitNode.boundingBox.width;
   // Todo: should use octagon width instead
   unitNode.lsx = x - unitNode.symbolBoxSize.width / 2;
   unitNode.rsx = x + unitNode.symbolBoxSize.width / 2;

--- a/src/modules/charteditor/orbatchart/svgRender.ts
+++ b/src/modules/charteditor/orbatchart/svgRender.ts
@@ -327,10 +327,20 @@ function aggregateData(unit: ChartUnit) {
   return { aggregatedEquipment, aggregatedPersonnel };
 }
 
+/**
+ * Top left corner of the unit's bounding box (including label) in chart coordinates.
+ * The bounding box is relative to the symbol's octagon anchor, which sits at (x, y).
+ */
+export function getUnitBoxOrigin(unitNode: RenderedUnitNode) {
+  return {
+    x: unitNode.x - unitNode.octagonAnchor.x + unitNode.boundingBox.x,
+    y: unitNode.y - unitNode.octagonAnchor.y + unitNode.boundingBox.y,
+  };
+}
+
 export function calculateAnchorPoints(unitNode: RenderedUnitNode) {
   const { x, y } = unitNode;
-  const boxLeft = x - unitNode.octagonAnchor.x + unitNode.boundingBox.x;
-  const boxTop = y - unitNode.octagonAnchor.y + unitNode.boundingBox.y;
+  const { x: boxLeft, y: boxTop } = getUnitBoxOrigin(unitNode);
   unitNode.ly = boxTop + unitNode.boundingBox.height;
   unitNode.lx = boxLeft;
   unitNode.rx = boxLeft + unitNode.boundingBox.width;


### PR DESCRIPTION
## Summary

- lay out units by subtree so unrelated connector branches no longer overlap
- account for variable unit widths and preserve parent-relative placement
- scale and center chart content within the configured page size
- keep the debug page boundary in page coordinates

## Verification

- 1,606 tests passed, 5 skipped
- production build passed
- visually verified page fitting with debug mode enabled

Closes #625