### PR TITLE
Improve ORBAT chart tree layout

### DIFF
--- a/src/modules/charteditor/orbatchart/orbchart.layout.test.ts
+++ b/src/modules/charteditor/orbatchart/orbchart.layout.test.ts
@@ -1,6 +1,12 @@
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { OrbatChart } from "./orbchart";
-import { UnitLevelDistances, type ChartUnit } from "./types";
+import { getUnitBoxOrigin } from "./svgRender";
+import {
+  LevelLayouts,
+  UnitLevelDistances,
+  type ChartUnit,
+  type RenderedUnitNode,
+} from "./types";
 
 const sidc = "10031000151211004600";
 const originalGetBBox = Object.getOwnPropertyDescriptor(SVGElement.prototype, "getBBox");
@@ -22,9 +28,16 @@ beforeAll(() => {
   Object.defineProperty(SVGElement.prototype, "getBBox", {
     configurable: true,
     value(this: SVGElement) {
-      const label = this.querySelector("text")?.textContent ?? "";
-      const width = Math.max(40, label.length * 8);
-      return { x: 20 - width / 2, y: 0, width, height: 40 };
+      const textElements = Array.from(this.querySelectorAll("text"));
+      const width = Math.max(
+        40,
+        ...textElements.map((text) => (text.textContent?.length ?? 0) * 8),
+      );
+      const bottom = Math.max(
+        40,
+        ...textElements.map((text) => Number(text.getAttribute("y")) + 16),
+      );
+      return { x: 20 - width / 2, y: 0, width, height: bottom };
     },
   });
 });
@@ -140,3 +153,75 @@ describe("horizontal layout bounds", () => {
     expect(childBranches[1].units[0].x).toBe(parents[1].x + 60);
   });
 });
+
+function resourceUnit(id: string): ChartUnit {
+  return {
+    ...unit(id),
+    equipment: Array.from({ length: 4 }, (_, index) => ({
+      name: `${id} extremely long equipment category description ${index + 1}`,
+      count: index + 1,
+    })),
+    personnel: Array.from({ length: 6 }, (_, index) => ({
+      name: `${id} personnel category ${index + 1}`,
+      count: index + 1,
+    })),
+  };
+}
+
+function boxesOverlap(a: RenderedUnitNode, b: RenderedUnitNode) {
+  const aOrigin = getUnitBoxOrigin(a);
+  const bOrigin = getUnitBoxOrigin(b);
+  return (
+    aOrigin.x < bOrigin.x + b.boundingBox.width &&
+    aOrigin.x + a.boundingBox.width > bOrigin.x &&
+    aOrigin.y < bOrigin.y + b.boundingBox.height &&
+    aOrigin.y + a.boundingBox.height > bOrigin.y
+  );
+}
+
+describe.each([LevelLayouts.Tree, LevelLayouts.TreeLeft, LevelLayouts.TreeRight])(
+  "resource table spacing for %s",
+  (lastLevelLayout) => {
+    it("keeps resource tables from different units from overlapping", () => {
+      const root = unit("root", [
+        unit("left-parent", [resourceUnit("left-1"), resourceUnit("left-2")]),
+        unit("right-parent", [resourceUnit("right-1"), resourceUnit("right-2")]),
+      ]);
+      const chart = new OrbatChart(root, {
+        lastLevelLayout,
+        maxLevels: 3,
+        showEquipment: true,
+        showPersonnel: true,
+        symbolGenerator: createSymbol,
+      });
+
+      const svg = chart.toSVG(document.createElement("div"), {
+        width: 600,
+        height: 600,
+      });
+
+      const lastLevelUnits = chart.renderedChart.levels[2].branches.flatMap(
+        (branch) => branch.units,
+      );
+      for (const [index, unitNode] of lastLevelUnits.entries()) {
+        for (const otherNode of lastLevelUnits.slice(index + 1)) {
+          expect(
+            boxesOverlap(unitNode, otherNode),
+            `${unitNode.unit.id} overlaps ${otherNode.unit.id}`,
+          ).toBe(false);
+        }
+      }
+
+      const trunkPath = svg.querySelector<SVGPathElement>("#o-connectors-level-2 path");
+      const trunkX = Number(trunkPath?.getAttribute("d")?.match(/^M ([-\d.e]+),/)?.[1]);
+      expect(Number.isFinite(trunkX)).toBe(true);
+      for (const unitNode of lastLevelUnits) {
+        const origin = getUnitBoxOrigin(unitNode);
+        expect(
+          trunkX <= origin.x || trunkX >= origin.x + unitNode.boundingBox.width,
+          `${unitNode.unit.id} table crosses the connector trunk`,
+        ).toBe(true);
+      }
+    });
+  },
+);

--- a/src/modules/charteditor/orbatchart/orbchart.ts
+++ b/src/modules/charteditor/orbatchart/orbchart.ts
@@ -50,6 +50,27 @@ function isLeftRightLayout(layout: LevelLayout) {
   return layout === LevelLayouts.TreeRight || layout === LevelLayouts.TreeLeft;
 }
 
+/**
+ * Position a tree unit far enough from its parent's connector trunk that the
+ * unit's complete rendered box, including resource text, clears the line.
+ */
+function getTreeUnitOffset(
+  unit: RenderedUnitNode,
+  layout: LevelLayout,
+  index: number,
+  options: Pick<OrbChartOptions, "connectorOffset" | "lineWidth" | "treeOffset">,
+) {
+  const boxLeftOffset = getUnitBoxOrigin(unit).x - unit.x;
+  const boxRightOffset = boxLeftOffset + unit.boundingBox.width;
+  const clearance = options.connectorOffset + options.lineWidth;
+  const placeRight =
+    layout === LevelLayouts.TreeRight || (layout === LevelLayouts.Tree && index % 2 > 0);
+
+  return placeRight
+    ? Math.max(options.treeOffset, clearance - boxLeftOffset)
+    : -Math.max(options.treeOffset, clearance + boxRightOffset);
+}
+
 export function isTreeLayout(layout: LevelLayout) {
   return (
     layout === LevelLayouts.TreeRight ||
@@ -346,27 +367,52 @@ class OrbatChart {
       const groupsOnLevel = renderedLevel.branches.length;
       renderedLevel.branches.forEach((unitBranch, groupIdx) => {
         const branchOptions = { ...levelOptions, ...unitBranch.options };
-        let prevY = y;
+        let rowY = y;
+        let rowBottom = Number.NEGATIVE_INFINITY;
+        let previousInRow: RenderedUnitNode | null = null;
         for (const [yIdx, unitNode] of unitBranch.units.entries()) {
           const unitOptions = { ...branchOptions, ...unitNode.options };
           let x = unitNode.parent
             ? unitNode.parent.x
             : ((groupIdx + 1) * chartWidth) / (groupsOnLevel + 1);
 
-          if (yIdx % 2) {
-            x += unitOptions.treeOffset;
-          } else {
-            x -= unitOptions.treeOffset;
-          }
-          const ny = prevY;
+          x += getTreeUnitOffset(unitNode, LevelLayouts.Tree, yIdx, unitOptions);
           unitNode.x = x;
-          unitNode.y = ny;
+          unitNode.y = rowY;
           calculateAnchorPoints(unitNode);
 
-          if (yIdx % 2) prevY = unitNode.ly + unitOptions.stackedOffset;
+          // TREE normally shares a row between its left and right unit. Wide
+          // resource tables can meet in the middle, so move the right unit below
+          // the left one only when their rendered boxes actually intersect.
+          if (
+            yIdx % 2 &&
+            previousInRow &&
+            unitNode.lx < previousInRow.rx &&
+            unitNode.rx > previousInRow.lx
+          ) {
+            const boxTopOffset = getUnitBoxOrigin(unitNode).y - unitNode.y;
+            unitNode.y = rowBottom + unitOptions.stackedOffset - boxTopOffset;
+            calculateAnchorPoints(unitNode);
+          }
 
-          putGroupAt(unitNode.groupElement, unitNode, x, ny, unitOptions.debug);
+          rowBottom = Math.max(rowBottom, unitNode.ly);
+
+          putGroupAt(
+            unitNode.groupElement,
+            unitNode,
+            unitNode.x,
+            unitNode.y,
+            unitOptions.debug,
+          );
           if (unitOptions.debug) drawDebugAnchors(wrapperGroup, unitNode);
+
+          if (yIdx % 2) {
+            rowY = rowBottom + unitOptions.stackedOffset;
+            rowBottom = Number.NEGATIVE_INFINITY;
+            previousInRow = null;
+          } else {
+            previousInRow = unitNode;
+          }
         }
         if (branchOptions.debug) drawDebugRect(unitBranch.groupElement, "yellow");
       });
@@ -383,10 +429,8 @@ class OrbatChart {
             ? unitNode.parent.x
             : ((groupIdx + 1) * chartWidth) / (groupsOnLevel + 1);
 
-          if (layout === LevelLayouts.TreeRight) {
-            x += unitOptions.treeOffset;
-          } else if (layout === LevelLayouts.TreeLeft) {
-            x -= unitOptions.treeOffset;
+          if (isLeftRightLayout(layout)) {
+            x += getTreeUnitOffset(unitNode, layout, yIdx, unitOptions);
           }
           const ny = prevY;
           unitNode.x = x;
@@ -430,14 +474,49 @@ class OrbatChart {
       });
     });
 
+    const trailingBranchesByParent = new Map<RenderedUnitNode, RenderedBranch>();
+    if (lastHorizontalLevel < lastLevelIndex) {
+      renderedChart.levels[lastLevelIndex].branches.forEach((branch) => {
+        const parent = branch.units[0]?.parent;
+        if (parent) trailingBranchesByParent.set(parent, branch);
+      });
+    }
+
+    const trailingBranchExtents = (unit: RenderedUnitNode) => {
+      const branch = trailingBranchesByParent.get(unit);
+      if (!branch) return null;
+      const level = renderedChart.levels[lastLevelIndex];
+      const levelOptions = { ...this.options, ...level.options };
+      const branchOptions = { ...levelOptions, ...branch.options };
+      let left = 0;
+      let right = 0;
+      branch.units.forEach((child, index) => {
+        const unitOptions = { ...branchOptions, ...child.options };
+        const offset = getTreeUnitOffset(
+          child,
+          this.options.lastLevelLayout,
+          index,
+          unitOptions,
+        );
+        const childBoxLeft = getUnitBoxOrigin(child).x - child.x + offset;
+        left = Math.min(left, childBoxLeft);
+        right = Math.max(right, childBoxLeft + child.boundingBox.width);
+      });
+      return { left, right };
+    };
+
     const toLayoutItem = (
       unit: RenderedUnitNode,
     ): HorizontalTreeItem<RenderedUnitNode> => {
       const boxLeft = getUnitBoxOrigin(unit).x;
+      const trailingExtents = trailingBranchExtents(unit);
       return {
         value: unit,
-        leftExtent: unit.x - boxLeft,
-        rightExtent: boxLeft + unit.boundingBox.width - unit.x,
+        leftExtent: Math.max(unit.x - boxLeft, -(trailingExtents?.left ?? 0)),
+        rightExtent: Math.max(
+          boxLeft + unit.boundingBox.width - unit.x,
+          trailingExtents?.right ?? 0,
+        ),
         children: (childrenByParent.get(unit) ?? []).map(toLayoutItem),
       };
     };


### PR DESCRIPTION
## Summary
- lay out horizontal ORBAT subtrees using complete rendered unit bounds
- include non-horizontal final-level resource-table footprints in parent spacing
- keep Tree, TreeLeft, and TreeRight tables clear of connector trunks
- move colliding Tree pairs onto separate rows
- add regression coverage for table and connector overlap

## Verification
- pnpm test:unit (1609 passed, 5 skipped)
- pnpm type-check
- git diff --check