### PR TITLE
Support control measures in partial scenario transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Added control-measure styling and labels, including identity colours, line width, echelon, text amplifiers, and free-form text where supported. Defaults can be configured before drawing, with live previews.
 - Added a smooth-resolution setting for supported control measures, available from a slider beside the smoothing toggle.
 - Added GeoJSON import, export, clipboard, undo/redo, and scenario persistence support for control measures.
+- Added layer selection to partial scenario import and export, including control-measure layers and safe ID remapping when importing into an existing scenario.
 - Added feature and control-measure duplication actions to the details panel and draw toolbar. Control-measure details now also show the doctrinal description for the selected measure.
 
 ### Changed

--- a/src/components/ExportSettingsOrbatMapper.test.ts
+++ b/src/components/ExportSettingsOrbatMapper.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+import { defineComponent } from "vue";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import ExportSettingsOrbatMapper from "@/components/ExportSettingsOrbatMapper.vue";
+import { activeScenarioKey } from "@/components/injects";
+import type { OrbatMapperExportSettings } from "@/types/importExport";
+
+const InputCheckboxStub = defineComponent({
+  name: "InputCheckbox",
+  props: ["label", "description", "value", "modelValue"],
+  template: "<div />",
+});
+
+function mountSettings(form: OrbatMapperExportSettings) {
+  const state = {
+    info: { name: "Source scenario" },
+    sides: [],
+    sideMap: {},
+    sideGroupMap: {},
+    layerStack: ["features", "control-measures"],
+    layerStackMap: {
+      features: { id: "features", kind: "overlay", name: "Features", items: [] },
+      "control-measures": {
+        id: "control-measures",
+        kind: "overlay",
+        name: "Control measures",
+        specialization: "controlMeasure",
+        items: [],
+      },
+    },
+  };
+
+  return mount(ExportSettingsOrbatMapper, {
+    props: { modelValue: form },
+    global: {
+      provide: {
+        [activeScenarioKey as symbol]: { store: { state } },
+      },
+      stubs: {
+        InputCheckbox: InputCheckboxStub,
+        InputGroupTemplate: { template: "<section><slot /></section>" },
+        InputGroup: true,
+      },
+    },
+  });
+}
+
+function form(layerIds?: string[]): OrbatMapperExportSettings {
+  return {
+    sideGroups: [],
+    layerIds,
+    customColors: true,
+    fileName: "scenario.json",
+  };
+}
+
+describe("ExportSettingsOrbatMapper", () => {
+  it("selects every layer for settings saved before layer selection existed", () => {
+    const settings = form();
+    const wrapper = mountSettings(settings);
+
+    expect(settings.layerIds).toEqual(["features", "control-measures"]);
+    expect(
+      wrapper
+        .findAllComponents(InputCheckboxStub)
+        .filter((checkbox) =>
+          ["features", "control-measures"].includes(checkbox.props("value")),
+        )
+        .map((checkbox) => [checkbox.props("value"), checkbox.props("description")]),
+    ).toEqual([
+      ["features", undefined],
+      ["control-measures", "Control measures"],
+    ]);
+  });
+
+  it("preserves an explicitly empty layer selection", () => {
+    const settings = form([]);
+    mountSettings(settings);
+
+    expect(settings.layerIds).toEqual([]);
+  });
+});

--- a/src/components/ExportSettingsOrbatMapper.vue
+++ b/src/components/ExportSettingsOrbatMapper.vue
@@ -14,9 +14,16 @@ const {
 } = injectStrict(activeScenarioKey);
 
 form.value.scenarioName = state.info.name;
+// Existing persisted export settings predate layer selection. Start those users with
+// every layer selected, preserving the export behavior they had before this option.
+if (form.value.layerIds === undefined) form.value.layerIds = [...state.layerStack];
 
 const sides = computed(() => {
   return state.sides.map((id) => state.sideMap[id]);
+});
+
+const layers = computed(() => {
+  return state.layerStack.map((id) => state.layerStackMap[id]).filter(Boolean);
 });
 
 function toggleSide(sideId: string) {
@@ -36,7 +43,7 @@ function toggleSide(sideId: string) {
   <fieldset class="flex flex-col gap-4">
     <InputGroupTemplate label="Select which side groups you want to export">
       <div class="divide-y">
-        <div v-for="v in sides" class="grid grid-cols-4 gap-4 py-3">
+        <div v-for="v in sides" :key="v.id" class="grid grid-cols-4 gap-4 py-3">
           <button
             type="button"
             class="flex text-sm font-medium"
@@ -54,6 +61,25 @@ function toggleSide(sideId: string) {
           />
         </div>
       </div>
+    </InputGroupTemplate>
+    <InputGroupTemplate label="Select which layers you want to export">
+      <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <InputCheckbox
+          v-for="layer in layers"
+          :key="layer.id"
+          :label="layer.name"
+          :description="
+            layer.kind === 'overlay' && layer.specialization === 'controlMeasure'
+              ? 'Control measures'
+              : undefined
+          "
+          :value="layer.id"
+          v-model="form.layerIds"
+        />
+      </div>
+      <p v-if="!layers.length" class="text-muted-foreground text-sm">
+        This scenario has no layers.
+      </p>
     </InputGroupTemplate>
     <InputGroup label="Scenario name" v-model="form.scenarioName" />
     <InputGroup label="Name of downloaded file" v-model="form.fileName" />

--- a/src/components/ImportOrbatMapperStep.vue
+++ b/src/components/ImportOrbatMapperStep.vue
@@ -50,6 +50,9 @@ import {
 import { Button } from "@/components/ui/button";
 import FieldSelect from "@/components/FieldSelect.vue";
 import ImportStepLayout from "@/components/ImportStepLayout.vue";
+import { isScenarioOverlayLayer } from "@/types/scenarioStackLayers";
+import type { ScenarioOverlayLayer } from "@/types/scenarioStackLayers";
+import { importScenarioOverlayLayers } from "@/importexport/importScenarioLayers";
 
 interface Props {
   data: Scenario;
@@ -58,7 +61,7 @@ interface Props {
 const props = defineProps<Props>();
 const emit = defineEmits(["cancel", "loaded"]);
 const activeScenario = injectStrict(activeScenarioKey);
-const { unitActions, settings, store: scnStore, time } = activeScenario;
+const { unitActions, settings, store: scnStore, time, geo } = activeScenario;
 const { loadScenario } = useBrowserScenarios();
 const { send } = useNotifications();
 const store = useImportStore();
@@ -88,6 +91,7 @@ const selectedPersonnel = ref<UnitPersonnel[]>([]);
 const selectedStatuses = ref<UnitStatus[]>([]);
 const selectedSupplyCategories = ref<NSupplyCategory[]>([]);
 const selectedCustomSymbols = ref<CustomSymbol[]>([]);
+const selectedLayers = ref<ScenarioOverlayLayer[]>([]);
 const importedState = computed(() => {
   return prepareScenario(props.data);
 });
@@ -121,8 +125,13 @@ function getCombinedSymbolOptions(
 const stats = computed(() => {
   return {
     units: Object.keys(importedState.value.unitMap).length,
+    layers: props.data.layerStack.filter(isScenarioOverlayLayer).length,
   };
 });
+
+const importedLayers = computed(() =>
+  props.data.layerStack.filter(isScenarioOverlayLayer),
+);
 
 const importedSides = computed((): SelectItem[] => {
   return importedState.value.sides
@@ -200,12 +209,6 @@ const currentCustomIcons = computed(() => {
   return Object.values(importedState.value.customSymbolMap);
 });
 
-const isSettingsImport = computed(() =>
-  ["statuses", "equipment", "personnel", "supplyCategories", "customSymbols"].includes(
-    importMode.value,
-  ),
-);
-
 const hasExistingUnits = computed(() => {
   return selectedItems.value.some((item) => item.id in targetState.unitMap);
 });
@@ -240,7 +243,12 @@ const sources = [
     value: "customSymbols",
     label: "Symbols",
   },
+  { value: "layers", label: "Layers" },
 ];
+
+const isUnitImport = computed(() =>
+  ["side", "group", "units"].includes(importMode.value),
+);
 
 watch(selectedSourceSideId, (newSide) => {
   const side = importedState.value.sideMap[newSide];
@@ -433,6 +441,23 @@ const customIconColumns: ColumnDef<CustomSymbol>[] = [
   },
 ];
 
+const layerColumns: ColumnDef<ScenarioOverlayLayer>[] = [
+  { accessorKey: "name", id: "name", header: "Name", size: 400 },
+  {
+    id: "type",
+    header: "Type",
+    accessorFn: (layer) =>
+      layer.specialization === "controlMeasure" ? "Control measures" : "Features",
+    size: 180,
+  },
+  {
+    id: "items",
+    header: "Items",
+    accessorFn: (layer) => layer.items.length,
+    size: 90,
+  },
+];
+
 // check that the item is a unit
 function isUnit(item: Unit | SideGroup): item is Unit {
   return "sidc" in item;
@@ -451,6 +476,15 @@ async function onFormSubmit() {
     doSupplyCategoryImport(selectedSupplyCategories.value);
   } else if (importMode.value === "customSymbols") {
     doCustomSymbolImport(selectedCustomSymbols.value);
+  } else if (importMode.value === "layers") {
+    scnStore.groupUpdate(() => {
+      importScenarioOverlayLayers(
+        importedState.value,
+        targetState,
+        geo,
+        selectedLayers.value.map((layer) => layer.id),
+      );
+    });
   } else if (unitImportMode.value === "state-only") {
     doStateOnlyImport(selectedUnitIds);
   } else if (importMode.value === "side" && selectedSourceSideId.value) {
@@ -704,7 +738,9 @@ function doGroupImport(importedGroupId: string) {
           }}</CardDescription>
         </CardHeader>
         <CardContent class="flex items-center justify-between gap-2 py-2">
-          <span class="text-muted-foreground text-xs">{{ stats.units }} units</span>
+          <span class="text-muted-foreground text-xs">
+            {{ stats.units }} units · {{ stats.layers }} layers
+          </span>
           <Button
             type="button"
             variant="link"
@@ -735,7 +771,7 @@ function doGroupImport(importedGroupId: string) {
       </FieldGroup>
 
       <!-- Source Selection (for unit imports) -->
-      <template v-if="!isSettingsImport">
+      <template v-if="isUnitImport">
         <!-- Import Content Options -->
         <FieldSet>
           <FieldLabel>Content to import</FieldLabel>
@@ -874,7 +910,7 @@ function doGroupImport(importedGroupId: string) {
 
     <!-- Main content: Data grids -->
     <div class="flex h-full min-h-0 flex-col p-6">
-      <template v-if="!isSettingsImport">
+      <template v-if="isUnitImport">
         <div class="mb-4 flex gap-4">
           <FieldSelect
             class="w-64"
@@ -900,6 +936,18 @@ function doGroupImport(importedGroupId: string) {
           select-all
           v-model:selected="selectedItems"
           no-indeterminate
+        />
+      </template>
+
+      <template v-else-if="importMode === 'layers'">
+        <DataGrid
+          :data="importedLayers"
+          :columns="layerColumns"
+          :row-height="40"
+          v-model:selected="selectedLayers"
+          select
+          select-all
+          class="flex-1"
         />
       </template>
 

--- a/src/importexport/export/partialScenarioControlMeasures.test.ts
+++ b/src/importexport/export/partialScenarioControlMeasures.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+import { useScenarioExport } from "@/importexport/export/scenarioExport";
+import { loadControlMeasureScenarioFixture } from "@/testdata/controlMeasureScenario";
+import type { TScenario } from "@/scenariostore";
+
+vi.mock("@/importexport/export/kmlExport", () => ({
+  useKmlExport: () => ({
+    generateKml: vi.fn(),
+    downloadAsKML: vi.fn(),
+    downloadAsKMZ: vi.fn(),
+  }),
+}));
+
+describe("partial ORBAT Mapper export", () => {
+  it("retains control-measure layers and their complete parameter bags", () => {
+    const source = loadControlMeasureScenarioFixture();
+    const activeScenario = {
+      io: { toObject: () => source },
+      store: { state: { sideMap: {} } },
+      geo: { layerItemsLayers: { value: [] }, everyVisibleUnit: { value: [] } },
+      unitActions: {},
+      helpers: {},
+    } as unknown as TScenario;
+
+    const exported = JSON.parse(
+      useScenarioExport({ activeScenario }).generateOrbatMapper({
+        sideGroups: [],
+        scenarioName: "Control measures only",
+        customColors: true,
+        fileName: "control-measures.json",
+      }),
+    );
+    const items = exported.layerStack.flatMap(
+      (layer: { kind: string; items?: unknown[] }) =>
+        layer.kind === "overlay" ? (layer.items ?? []) : [],
+    );
+    const phaseLine = items.find((item: { id?: string }) => item.id === "cm-phase-line");
+
+    expect(exported.name).toBe("Control measures only");
+    expect(exported.sides).toEqual([]);
+    expect(phaseLine).toMatchObject({
+      kind: "tacticalGraphic",
+      graphicKind: "phase-line",
+      standardIdentity: "3",
+      controlPoints: [
+        [10, 60],
+        [11, 60],
+      ],
+      textAmplifiers: { T: "BLUE" },
+    });
+    expect(phaseLine.state[0].patch.controlPoints).toEqual([
+      [10, 61],
+      [11, 61],
+    ]);
+  });
+});

--- a/src/importexport/export/partialScenarioControlMeasures.test.ts
+++ b/src/importexport/export/partialScenarioControlMeasures.test.ts
@@ -12,7 +12,7 @@ vi.mock("@/importexport/export/kmlExport", () => ({
 }));
 
 describe("partial ORBAT Mapper export", () => {
-  it("retains control-measure layers and their complete parameter bags", () => {
+  function exporter() {
     const source = loadControlMeasureScenarioFixture();
     const activeScenario = {
       io: { toObject: () => source },
@@ -21,9 +21,12 @@ describe("partial ORBAT Mapper export", () => {
       unitActions: {},
       helpers: {},
     } as unknown as TScenario;
+    return useScenarioExport({ activeScenario });
+  }
 
+  it("retains control-measure layers and their complete parameter bags", () => {
     const exported = JSON.parse(
-      useScenarioExport({ activeScenario }).generateOrbatMapper({
+      exporter().generateOrbatMapper({
         sideGroups: [],
         scenarioName: "Control measures only",
         customColors: true,
@@ -52,5 +55,38 @@ describe("partial ORBAT Mapper export", () => {
       [10, 61],
       [11, 61],
     ]);
+  });
+
+  it("exports only explicitly selected layers", () => {
+    const exported = JSON.parse(
+      exporter().generateOrbatMapper({
+        sideGroups: [],
+        layerIds: ["layer-control-measures"],
+        customColors: true,
+        fileName: "selected-layers.json",
+      }),
+    );
+
+    expect(exported.layerStack.map((layer: { id: string }) => layer.id)).toEqual([
+      "layer-control-measures",
+    ]);
+    expect(
+      exported.layerStack[0].items.some(
+        (item: { id: string }) => item.id === "cm-phase-line",
+      ),
+    ).toBe(true);
+  });
+
+  it("exports no layers when the selection is explicitly empty", () => {
+    const exported = JSON.parse(
+      exporter().generateOrbatMapper({
+        sideGroups: [],
+        layerIds: [],
+        customColors: true,
+        fileName: "no-layers.json",
+      }),
+    );
+
+    expect(exported.layerStack).toEqual([]);
   });
 });

--- a/src/importexport/export/scenarioExport.ts
+++ b/src/importexport/export/scenarioExport.ts
@@ -262,6 +262,7 @@ export function useScenarioExport(options: Partial<UseScenarioExportOptions> = {
   function generateOrbatMapper({
     scenarioName,
     sideGroups,
+    layerIds,
   }: OrbatMapperExportSettings): string {
     const scn = io.toObject();
     const sidesWithFilteredGroups = scn.sides.map((side) => ({
@@ -271,6 +272,12 @@ export function useScenarioExport(options: Partial<UseScenarioExportOptions> = {
     const newScenario = {
       ...scn,
       sides: sidesWithFilteredGroups.filter((e) => e.groups.length),
+      // Undefined is intentional backward compatibility for callers and saved form
+      // settings created before layer selection existed. An explicit [] exports none.
+      layerStack:
+        layerIds === undefined
+          ? scn.layerStack
+          : scn.layerStack.filter((layer) => layerIds.includes(layer.id)),
     };
     newScenario.id = nanoid();
     newScenario.meta = {

--- a/src/importexport/importScenarioLayers.test.ts
+++ b/src/importexport/importScenarioLayers.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest";
+import { useNewScenarioStore } from "@/scenariostore/newScenarioStore";
+import { useGeo } from "@/scenariostore/geo";
+import { importScenarioOverlayLayers } from "@/importexport/importScenarioLayers";
+import type { Scenario } from "@/types/scenarioModels";
+
+vi.mock("@/stores/settingsStore", () => ({
+  useSymbolSettingsStore: () => ({ symbologyStandard: "2525d" }),
+}));
+
+function scenario(id: string, layerStack: Scenario["layerStack"] = []): Scenario {
+  return {
+    id,
+    type: "ORBAT-mapper",
+    version: "3.0.0",
+    name: id,
+    startTime: Date.parse("2025-01-01T00:00:00Z"),
+    timeZone: "UTC",
+    sides: [],
+    events: [],
+    layerStack,
+    settings: {
+      rangeRingGroups: [],
+      statuses: [],
+      supplyClasses: [],
+      supplyUoMs: [],
+      symbolFillColors: [],
+    },
+  };
+}
+
+function controlMeasureLayer() {
+  return {
+    id: "control-measures",
+    kind: "overlay" as const,
+    name: "Control measures",
+    specialization: "controlMeasure" as const,
+    locked: true,
+    items: [
+      {
+        id: "phase-line",
+        kind: "tacticalGraphic" as const,
+        graphicKind: "phase-line" as const,
+        standardIdentity: "3" as const,
+        controlPoints: [
+          [10, 60],
+          [11, 60],
+        ] as [number, number][],
+        textAmplifiers: { T: "BLUE" },
+        state: [
+          {
+            id: "phase-line-state",
+            t: Date.parse("2025-01-01T01:00:00Z"),
+            patch: {
+              controlPoints: [
+                [10, 61],
+                [11, 61],
+              ] as [number, number][],
+            },
+          },
+        ],
+      },
+    ],
+  };
+}
+
+describe("importScenarioOverlayLayers", () => {
+  it("imports a selected control-measure layer and its authored and timed fields", () => {
+    const source = useNewScenarioStore(scenario("source", [controlMeasureLayer()])).state;
+    const targetStore = useNewScenarioStore(scenario("target"));
+
+    const result = importScenarioOverlayLayers(
+      source,
+      targetStore.state,
+      useGeo(targetStore),
+      ["control-measures"],
+    );
+
+    expect(result).toEqual({
+      importedLayerIds: ["control-measures"],
+      importedItemIds: ["phase-line"],
+    });
+    expect(targetStore.state.layerStackMap["control-measures"]).toMatchObject({
+      specialization: "controlMeasure",
+      locked: true,
+      items: ["phase-line"],
+    });
+    expect(targetStore.state.layerItemMap["phase-line"]).toMatchObject({
+      kind: "tacticalGraphic",
+      graphicKind: "phase-line",
+      standardIdentity: "3",
+      textAmplifiers: { T: "BLUE" },
+      _pid: "control-measures",
+      state: [{ id: "phase-line-state", t: Date.parse("2025-01-01T01:00:00Z") }],
+    });
+  });
+
+  it("remaps colliding layer and item ids without changing the source", () => {
+    const source = useNewScenarioStore(scenario("source", [controlMeasureLayer()])).state;
+    const targetStore = useNewScenarioStore(
+      scenario("target", [
+        {
+          ...controlMeasureLayer(),
+          name: "Existing control measures",
+        },
+      ]),
+    );
+    const ids = ["imported-layer", "imported-item"];
+
+    const result = importScenarioOverlayLayers(
+      source,
+      targetStore.state,
+      useGeo(targetStore),
+      ["control-measures"],
+      () => ids.shift()!,
+    );
+
+    expect(result).toEqual({
+      importedLayerIds: ["imported-layer"],
+      importedItemIds: ["imported-item"],
+    });
+    expect(targetStore.state.layerItemMap["imported-item"]).toMatchObject({
+      id: "imported-item",
+      _pid: "imported-layer",
+      graphicKind: "phase-line",
+    });
+    expect(source.layerStackMap["control-measures"]).toMatchObject({
+      id: "control-measures",
+      items: ["phase-line"],
+    });
+  });
+
+  it("ignores unselected layers", () => {
+    const source = useNewScenarioStore(scenario("source", [controlMeasureLayer()])).state;
+    const targetStore = useNewScenarioStore(scenario("target"));
+
+    expect(
+      importScenarioOverlayLayers(source, targetStore.state, useGeo(targetStore), []),
+    ).toEqual({ importedLayerIds: [], importedItemIds: [] });
+    expect(targetStore.state.layerStack).toEqual([]);
+  });
+
+  it("preserves legacy control measures in an unspecialized layer", () => {
+    const legacyLayer = { ...controlMeasureLayer(), specialization: undefined };
+    const source = useNewScenarioStore(scenario("source", [legacyLayer])).state;
+    const targetStore = useNewScenarioStore(scenario("target"));
+
+    const result = importScenarioOverlayLayers(
+      source,
+      targetStore.state,
+      useGeo(targetStore),
+      ["control-measures"],
+    );
+
+    expect(result.importedItemIds).toEqual(["phase-line"]);
+    expect(targetStore.state.layerItemMap["phase-line"]).toMatchObject({
+      kind: "tacticalGraphic",
+      _pid: "control-measures",
+    });
+  });
+});

--- a/src/importexport/importScenarioLayers.ts
+++ b/src/importexport/importScenarioLayers.ts
@@ -1,0 +1,101 @@
+import { nanoid } from "@/utils";
+import type { FeatureId } from "@/types/scenarioGeoModels";
+import type { ScenarioState } from "@/scenariostore/newScenarioStore";
+import type { ScenarioLayerItem } from "@/types/scenarioLayerItems";
+import type { ScenarioLayerUpdate } from "@/types/internalModels";
+import type { NScenarioOverlayLayer } from "@/types/scenarioStackLayers";
+
+interface LayerImportGeo {
+  addLayer(layer: NScenarioOverlayLayer): NScenarioOverlayLayer | undefined;
+  addFeature(
+    item: ScenarioLayerItem,
+    layerId: FeatureId,
+    options?: { allowSpecializationMismatch?: boolean },
+  ): FeatureId | undefined;
+  updateLayer(layerId: FeatureId, update: ScenarioLayerUpdate): void;
+}
+
+export interface ImportScenarioLayersResult {
+  importedLayerIds: string[];
+  importedItemIds: FeatureId[];
+}
+
+function withoutInternalFields<T extends object>(value: T): T {
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) => !key.startsWith("_")),
+  ) as T;
+}
+
+function availableId(
+  requested: string,
+  occupied: Set<string>,
+  generateId: () => string,
+): string {
+  let id = requested;
+  while (occupied.has(id)) id = generateId();
+  occupied.add(id);
+  return id;
+}
+
+/**
+ * Import selected overlay layers from a prepared scenario into another scenario.
+ *
+ * The source is prepared rather than raw file data so visibility and state timestamps
+ * already have the runtime representation expected by the target store. Layer and item
+ * ids are retained when possible and remapped on collision. Derived `_` fields are never
+ * copied; the target store recreates them for its own current time and ownership graph.
+ */
+export function importScenarioOverlayLayers(
+  source: ScenarioState,
+  target: Pick<ScenarioState, "layerStackMap" | "layerItemMap">,
+  geo: LayerImportGeo,
+  selectedLayerIds: readonly FeatureId[],
+  generateId: () => string = nanoid,
+): ImportScenarioLayersResult {
+  const selected = new Set(selectedLayerIds);
+  const occupiedLayerIds = new Set(Object.keys(target.layerStackMap));
+  const occupiedItemIds = new Set(Object.keys(target.layerItemMap));
+  const result: ImportScenarioLayersResult = {
+    importedLayerIds: [],
+    importedItemIds: [],
+  };
+
+  for (const sourceLayerId of source.layerStack) {
+    if (!selected.has(sourceLayerId)) continue;
+    const sourceLayer = source.layerStackMap[sourceLayerId];
+    if (!sourceLayer || sourceLayer.kind !== "overlay") continue;
+
+    const layerId = availableId(sourceLayer.id, occupiedLayerIds, generateId);
+    const { items, locked, ...layerFields } = withoutInternalFields(sourceLayer);
+    const addedLayer = geo.addLayer({
+      ...layerFields,
+      id: layerId,
+      kind: "overlay",
+      items: [],
+      // A locked source layer must be writable while its items are restored.
+      locked: false,
+    });
+    if (!addedLayer) continue;
+    result.importedLayerIds.push(layerId);
+
+    for (const sourceItemId of items) {
+      const sourceItem = source.layerItemMap[sourceItemId];
+      if (!sourceItem) continue;
+      const itemId = availableId(sourceItem.id, occupiedItemIds, generateId);
+      const item = {
+        ...withoutInternalFields(sourceItem),
+        id: itemId,
+      } as ScenarioLayerItem;
+      // Full-scenario loading preserves legacy/malformed mixed layers. Partial import
+      // must do the same; authoring paths retain the normal specialization guard.
+      const addedItemId = geo.addFeature(item, layerId, {
+        allowSpecializationMismatch: true,
+      });
+      if (addedItemId !== undefined) result.importedItemIds.push(addedItemId);
+    }
+
+    if (locked) geo.updateLayer(layerId, { locked: true });
+  }
+
+  return result;
+}

--- a/src/scenariostore/geo.ts
+++ b/src/scenariostore/geo.ts
@@ -176,6 +176,8 @@ export type UpdateOptions = {
   noEmit?: boolean;
   force?: boolean;
   emitOnly?: boolean;
+  /** Preserve malformed/legacy layer contents when copying already-stored data. */
+  allowSpecializationMismatch?: boolean;
 };
 
 export interface MoveLayerOptions {
@@ -711,8 +713,8 @@ export function useGeo(store: NewScenarioStore) {
     if (!destination || destination.locked) return;
     const requiresControlMeasureLayer = newFeature.kind === "tacticalGraphic";
     if (
-      requiresControlMeasureLayer !==
-      (destination.specialization === "controlMeasure")
+      !options.allowSpecializationMismatch &&
+      requiresControlMeasureLayer !== (destination.specialization === "controlMeasure")
     ) {
       return;
     }

--- a/src/types/importExport.ts
+++ b/src/types/importExport.ts
@@ -1,4 +1,5 @@
 import { type EntityId } from "@/types/base";
+import type { FeatureId } from "@/types/scenarioGeoModels";
 import type { ImportedFileInfo } from "@/importexport/fileHandling.ts";
 import type { FeatureCollection } from "geojson";
 
@@ -73,6 +74,8 @@ export interface GeoJsonSettings extends BaseExportSettings {
 
 export interface OrbatMapperExportSettings extends BaseExportSettings {
   sideGroups: EntityId[];
+  /** Undefined preserves the legacy behavior of exporting every layer. */
+  layerIds?: FeatureId[];
   scenarioName?: string;
 }
 


### PR DESCRIPTION
## Summary
- add selectable overlay-layer imports for partial ORBAT Mapper scenarios
- preserve control measures, timed state, locks, legacy mixed layers, and safely remap ID collisions
- let partial exports include only selected scenario layers while defaulting existing settings to all layers
- document the behavior in the changelog

## Verification
- pnpm type-check
- 42 targeted Vitest tests covering import, export, persistence, and settings UI
- targeted ESLint checks
- git diff --check