### PR TITLE
Refine scenario import and export dialogs

### DIFF
--- a/src/components/ExportScenarioModal.vue
+++ b/src/components/ExportScenarioModal.vue
@@ -12,17 +12,26 @@ import ExportSettingsXlsx from "@/components/ExportSettingsXlsx.vue";
 import ExportSettingsCsv from "@/components/ExportSettingsCsv.vue";
 import ExportSettingsSpatialIllusions from "@/components/ExportSettingsSpatialIllusions.vue";
 import ExportSettingsGeoJson from "@/components/ExportSettingsGeoJson.vue";
-import DocLink from "@/components/DocLink.vue";
 import ExportSettingsOrbatMapper from "@/components/ExportSettingsOrbatMapper.vue";
 import ExportSettingsKmlKmz from "@/components/ExportSettingsKmlKmz.vue";
-
 import ToggleField from "@/components/ToggleField.vue";
 import { useExportStore } from "@/stores/importExportStore";
 import { Button } from "@/components/ui/button";
+import { DialogDescription, DialogTitle } from "@/components/ui/dialog";
+import {
+  Field,
+  FieldContent,
+  FieldDescription,
+  FieldLabel,
+  FieldSet,
+  FieldTitle,
+} from "@/components/ui/field";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import NewSimpleModal from "@/components/NewSimpleModal.vue";
 import { ClipboardCopyIcon, CheckIcon } from "@lucide/vue";
 import { useClipboard } from "@vueuse/core";
 import { ref } from "vue";
+import ImportStepLayout from "@/components/ImportStepLayout.vue";
 
 const open = defineModel<boolean>({ default: false });
 const emit = defineEmits(["cancel"]);
@@ -43,15 +52,23 @@ const {
   generateOrbatMapper,
 } = useScenarioExport();
 const store = useExportStore();
-const formatItems: SelectItem<ExportFormat>[] = [
-  { label: "ORBAT Mapper", value: "orbatmapper" },
-  { label: "GeoJSON", value: "geojson" },
-  { label: "KML", value: "kml" },
-  { label: "KMZ", value: "kmz" },
-  { label: "XLSX", value: "xlsx" },
-  { label: "CSV/TSV", value: "csv" },
-  { label: "MilX", value: "milx" },
-  { label: "Spatial Illusions ORBAT builder", value: "unitgenerator" },
+const formatItems: (SelectItem<ExportFormat> & { description: string })[] = [
+  {
+    label: "ORBAT Mapper",
+    value: "orbatmapper",
+    description: "Native scenario data",
+  },
+  { label: "GeoJSON", value: "geojson", description: "Geographic JSON data" },
+  { label: "KML", value: "kml", description: "Data for Google Earth" },
+  { label: "KMZ", value: "kmz", description: "Compressed KML with unit icons" },
+  { label: "XLSX", value: "xlsx", description: "Spreadsheet workbook" },
+  { label: "CSV/TSV", value: "csv", description: "Delimited tabular data" },
+  { label: "MilX", value: "milx", description: "MilX layers" },
+  {
+    label: "Spatial Illusions ORBAT builder",
+    value: "unitgenerator",
+    description: "Unit hierarchy data",
+  },
 ];
 
 interface Form extends ExportSettings {
@@ -101,12 +118,11 @@ const justCopied = ref(false);
 
 const format = computed(() => form.value.format);
 const canCopyToClipboard = computed(() => !["xlsx", "kmz"].includes(form.value.format));
-const isGeojson = computed(() => form.value.format === "geojson");
 const isKml = computed(() => form.value.format === "kml");
 const isKmz = computed(() => form.value.format === "kmz");
 const isMilx = computed(() => form.value.format === "milx");
 
-async function onExport(e: Event) {
+async function onExport() {
   const { format } = form.value;
   let kmzWarnings: string[] = [];
   NProgress.start();
@@ -180,105 +196,155 @@ function onCancel() {
 <template>
   <NewSimpleModal
     v-model="open"
-    dialog-title="Export scenario"
+    fixed-height
     @cancel="onCancel"
-    class="sm:max-w-xl md:max-w-4xl"
+    class="grid h-[90vh] grid-rows-[auto_1fr] sm:max-w-xl md:max-w-4xl lg:max-w-[95vw]"
   >
-    <p class="text-muted-foreground mt-1 text-sm">
-      Export scenario data for use with other software applications and tools
-    </p>
-    <form @submit.prevent="onExport" class="mt-4 space-y-6">
-      <SimpleSelect
-        label="Select export format"
-        :items="formatItems"
-        v-model="form.format"
-      >
-        <template #hint>
-          <DocLink href="https://docs.orbat-mapper.app/guide/export-data" />
-        </template>
-      </SimpleSelect>
-      <div class="text-muted-foreground text-sm">
-        <p v-if="isKml">
-          KML is a file format used to display data in an Earth browser such as Google
-          Earth. Use KMZ if you want to include unit icons.
-        </p>
-        <p v-else-if="isKmz">
-          KMZ is a compressed version of KML. Use this format if you want to include unit
-          icons.
-        </p>
-      </div>
-      <ExportSettingsXlsx v-if="format === 'xlsx'" :format="format" v-model="form" />
-      <ExportSettingsCsv v-else-if="format === 'csv'" :format="format" v-model="form" />
-      <ExportSettingsSpatialIllusions
-        v-else-if="format === 'unitgenerator'"
-        :format="format"
-        v-model="form"
-      />
-      <ExportSettingsOrbatMapper v-else-if="format === 'orbatmapper'" v-model="form" />
-      <ExportSettingsGeoJson
-        v-else-if="format === 'geojson'"
-        :format="format"
-        v-model="form"
-      />
-      <ExportSettingsKmlKmz
-        v-else-if="format === 'kml' || format === 'kmz'"
-        :format="format"
-        v-model="form"
-      />
-      <template v-else>
-        <!-- fallback for other formats -->
-        <fieldset class="space-y-4">
-          <InputCheckbox
-            label="Include units"
-            description="Units with a location at current scenario time"
-            v-model="form.includeUnits"
-          />
-          <InputCheckbox
-            v-if="!isMilx"
-            label="Include scenario features"
-            v-model="form.includeFeatures"
-            description=""
-          />
-          <InputCheckbox
-            v-if="isMilx"
-            :label="'Use one layer per side'"
-            v-model="form.oneFolderPerSide"
-          />
-        </fieldset>
-      </template>
+    <div class="-mx-6 flex h-full flex-col overflow-hidden px-0">
+      <DialogTitle class="sr-only">Export scenario</DialogTitle>
+      <DialogDescription class="sr-only">
+        Export scenario data for use with other software applications and tools
+      </DialogDescription>
+      <form class="min-h-0 flex-1 overflow-hidden" @submit.prevent="onExport">
+        <ImportStepLayout
+          title="Export scenario"
+          subtitle="Export scenario data for use with other software applications and tools"
+          help-url="https://docs.orbat-mapper.app/guide/export-data"
+          has-sidebar
+        >
+          <template #actions>
+            <Button variant="outline" type="button" size="sm" @click="onCancel">
+              Cancel
+            </Button>
+            <Button
+              v-if="canCopyToClipboard"
+              variant="outline"
+              type="button"
+              size="sm"
+              @click="onCopyToClipboard"
+            >
+              <component
+                :is="justCopied ? CheckIcon : ClipboardCopyIcon"
+                class="mr-1 h-4 w-4"
+              />
+              {{ justCopied ? "Copied!" : "Copy" }}
+            </Button>
+            <Button type="submit" size="sm">Export</Button>
+          </template>
 
-      <p v-if="isKmz || isKml" class="text-sm">
-        Please note that the export functionality is experimental. Scenario feature export
-        is currently limited to geometries (no styles).
-      </p>
-
-      <p v-if="isMilx" class="text-sm">
-        Please note that the MilX export is experimental. It is currently limited and has
-        several bugs.
-      </p>
-
-      <footer class="flex items-center justify-between space-x-2">
-        <ToggleField v-model="store.keepOpen">Keep dialog open on export</ToggleField>
-        <div class="flex items-center space-x-2">
-          <Button type="submit" size="sm">Export</Button>
-          <Button
-            v-if="canCopyToClipboard"
-            variant="outline"
-            type="button"
-            size="sm"
-            @click="onCopyToClipboard"
-          >
-            <component
-              :is="justCopied ? CheckIcon : ClipboardCopyIcon"
-              class="mr-1 h-4 w-4"
+          <template #sidebar>
+            <SimpleSelect
+              class="lg:hidden"
+              label="Export format"
+              :items="formatItems"
+              v-model="form.format"
             />
-            {{ justCopied ? "Copied!" : "Copy" }}
-          </Button>
-          <Button variant="outline" type="button" size="sm" @click="onCancel"
-            >Cancel</Button
-          >
-        </div>
-      </footer>
-    </form>
+
+            <FieldSet class="hidden lg:block">
+              <FieldLabel>Export Format</FieldLabel>
+              <FieldDescription
+                >Select the format for your exported data</FieldDescription
+              >
+              <RadioGroup v-model="form.format" class="mt-3 flex flex-col gap-2">
+                <FieldLabel
+                  v-for="item in formatItems"
+                  :key="item.value"
+                  :for="`export-format-${item.value}`"
+                >
+                  <Field orientation="horizontal">
+                    <FieldContent>
+                      <FieldTitle>{{ item.label }}</FieldTitle>
+                      <FieldDescription>{{ item.description }}</FieldDescription>
+                    </FieldContent>
+                    <RadioGroupItem
+                      :id="`export-format-${item.value}`"
+                      :value="item.value"
+                    />
+                  </Field>
+                </FieldLabel>
+              </RadioGroup>
+            </FieldSet>
+
+            <div class="text-muted-foreground text-sm lg:hidden">
+              <p v-if="isKml">
+                KML displays geographic data in applications such as Google Earth. Use KMZ
+                if you want to include unit icons.
+              </p>
+              <p v-else-if="isKmz">
+                KMZ is a compressed version of KML that can include unit icons.
+              </p>
+            </div>
+
+            <ToggleField v-model="store.keepOpen">
+              Keep dialog open on export
+            </ToggleField>
+          </template>
+
+          <div class="min-h-0 flex-1 overflow-y-auto p-6">
+            <div class="space-y-6">
+              <ExportSettingsXlsx
+                v-if="format === 'xlsx'"
+                :format="format"
+                v-model="form"
+              />
+              <ExportSettingsCsv
+                v-else-if="format === 'csv'"
+                :format="format"
+                v-model="form"
+              />
+              <ExportSettingsSpatialIllusions
+                v-else-if="format === 'unitgenerator'"
+                :format="format"
+                v-model="form"
+              />
+              <ExportSettingsOrbatMapper
+                v-else-if="format === 'orbatmapper'"
+                v-model="form"
+              />
+              <ExportSettingsGeoJson
+                v-else-if="format === 'geojson'"
+                :format="format"
+                v-model="form"
+              />
+              <ExportSettingsKmlKmz
+                v-else-if="format === 'kml' || format === 'kmz'"
+                :format="format"
+                v-model="form"
+              />
+              <template v-else>
+                <fieldset class="space-y-4">
+                  <InputCheckbox
+                    label="Include units"
+                    description="Units with a location at current scenario time"
+                    v-model="form.includeUnits"
+                  />
+                  <InputCheckbox
+                    v-if="!isMilx"
+                    label="Include scenario features"
+                    v-model="form.includeFeatures"
+                    description=""
+                  />
+                  <InputCheckbox
+                    v-if="isMilx"
+                    label="Use one layer per side"
+                    v-model="form.oneFolderPerSide"
+                  />
+                </fieldset>
+              </template>
+
+              <p v-if="isKmz || isKml" class="text-sm">
+                Please note that the export functionality is experimental. Scenario
+                feature export is currently limited to geometries (no styles).
+              </p>
+
+              <p v-if="isMilx" class="text-sm">
+                Please note that the MilX export is experimental. It is currently limited
+                and has several bugs.
+              </p>
+            </div>
+          </div>
+        </ImportStepLayout>
+      </form>
+    </div>
   </NewSimpleModal>
 </template>

--- a/src/components/ImportLoadStep.vue
+++ b/src/components/ImportLoadStep.vue
@@ -59,7 +59,9 @@ const formatItems: SelectItem<ImportFormat>[] = [
   { label: "XLSX", value: "xlsx" },
 ];
 
-const sourceItems = [
+type InputSource = "file" | "url" | "browser" | "string";
+
+const sourceItems: (SelectItem<InputSource> & { description: string })[] = [
   { label: "Local file", value: "file", description: "Upload from your computer" },
   { label: "URL", value: "url", description: "Load from a web address" },
   { label: "Browser", value: "browser", description: "Open a saved scenario" },
@@ -304,7 +306,14 @@ onMounted(() => {
 
     <template #sidebar>
       <!-- Input Source Selection -->
-      <FieldSet>
+      <SimpleSelect
+        class="lg:hidden"
+        label="Input source"
+        description="Select where to load your data from"
+        :items="sourceItems"
+        v-model="store.inputSource"
+      />
+      <FieldSet class="hidden lg:block">
         <FieldLabel>Input Source</FieldLabel>
         <FieldDescription>Select where to load your data from</FieldDescription>
         <RadioGroup v-model="store.inputSource" class="mt-3 flex flex-col gap-2">

--- a/src/components/ImportStepLayout.vue
+++ b/src/components/ImportStepLayout.vue
@@ -40,11 +40,11 @@ withDefaults(defineProps<Props>(), {
     <!-- Content with optional sidebar -->
     <div
       v-if="hasSidebar"
-      class="flex flex-col lg:min-h-0 lg:flex-1 lg:flex-row lg:overflow-hidden"
+      class="flex min-h-0 flex-1 flex-col overflow-hidden lg:flex-row"
     >
       <!-- Left Sidebar -->
       <aside
-        class="bg-background flex w-full flex-col border-b lg:flex-none lg:flex-col lg:overflow-hidden lg:border-r lg:border-b-0"
+        class="bg-background flex max-h-[50%] w-full flex-col border-b lg:max-h-none lg:flex-none lg:flex-col lg:overflow-hidden lg:border-r lg:border-b-0"
         :class="sidebarWidth"
       >
         <div class="flex-1 overflow-y-auto">


### PR DESCRIPTION
## Summary

- reuse the import dialog layout for scenario exports
- use descriptive cards on desktop and compact selects on smaller screens
- keep import and export sidebars and main panes independently scrollable on mobile
- add accessible title and description metadata to the export dialog

## Verification

- pnpm type-check
- pnpm test:unit (1618 passed, 5 skipped)
- pnpm exec vitest run src/importexport/export (34 passed)
- responsive browser checks at 390x844 and 1280x800