### PR TITLE
Add rendered control-measure labels to KMZ exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Added control-measure styling and labels, including identity colours, line width, echelon, text amplifiers, and free-form text where supported. Defaults can be configured before drawing, with live previews.
 - Added a smooth-resolution setting for supported control measures, available from a slider beside the smoothing toggle.
 - Added GeoJSON import, export, clipboard, undo/redo, and scenario persistence support for control measures.
-- Added styled KML/KMZ export for rendered control measures, including generated labels and text amplifiers.
+- Added styled KML/KMZ export for rendered control measures, including generated labels and text amplifiers. KMZ exports can keep labels native or embed them as images to preserve orientation, scaling, anchors, and typography.
 - Added layer selection to partial scenario import and export, including control-measure layers and safe ID remapping when importing into an existing scenario.
 - Added feature and control-measure duplication actions to the details panel and draw toolbar. Control-measure details now also show the doctrinal description for the selected measure.
 
@@ -114,7 +114,7 @@ All notable changes to this project will be documented in this file.
 - Added geometry statistics to scenario feature details.
 - Clicking KML/KMZ features now opens a read-only details view with attached properties, including richer HTML description rendering.
 - Added view constraints support (max extent, min/max zoom) to map settings. Constraints are saved as part of the scenario.
-- Added experimental MapLibre mode with globe support. Functionality from the main map view will be gradually ported over. 
+- Added experimental MapLibre mode with globe support. Functionality from the main map view will be gradually ported over.
 - Added a standalone symbol browser page at `/symbol-browser`.
 - Added symbol export with copy and download as PNG and SVG, with configurable size and display options.
 - Added "Copy as GeoJSON" to the feature layer menu, individual feature menu, and feature details panel. Circles are exported as polygons.
@@ -146,7 +146,7 @@ All notable changes to this project will be documented in this file.
 - Fixed overlapping unit/feature selection on the map so the topmost item takes priority.
 - Fixed blank map clicks so they clear selected scenario features.
 - Fixed shift-click selection on the map so it only extends the current selection type instead of switching between units and scenario features.
-- Fixed KMZ/KML feature clicks in the OpenLayers editor so imported reference features no longer crash the map renderer. 
+- Fixed KMZ/KML feature clicks in the OpenLayers editor so imported reference features no longer crash the map renderer.
 - Fixed transform tool updates so existing features update their geometry kind when a transformation changes the geometry type.
 - Fixed the MapLibre scale control so it responds to dynamic measurement unit changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Added control-measure styling and labels, including identity colours, line width, echelon, text amplifiers, and free-form text where supported. Defaults can be configured before drawing, with live previews.
 - Added a smooth-resolution setting for supported control measures, available from a slider beside the smoothing toggle.
 - Added GeoJSON import, export, clipboard, undo/redo, and scenario persistence support for control measures.
+- Added styled KML/KMZ export for rendered control measures, including generated labels and text amplifiers.
 - Added layer selection to partial scenario import and export, including control-measure layers and safe ID remapping when importing into an existing scenario.
 - Added feature and control-measure duplication actions to the details panel and draw toolbar. Control-measure details now also show the doctrinal description for the selected measure.
 

--- a/src/components/ExportScenarioModal.vue
+++ b/src/components/ExportScenarioModal.vue
@@ -104,6 +104,7 @@ const form = useLocalStorage(
     outlineWidth: 8,
     renderAmplifiers: false,
     renderCustomIconLabels: false,
+    controlMeasureLabelMode: "native",
     timeMode: "current",
     exportEventId: "",
     exportEventIds: [],
@@ -153,8 +154,8 @@ async function onExport() {
     const andMore = kmzWarnings.length > 2 ? ` (+${kmzWarnings.length - 2} more)` : "";
     send({
       type: "warning",
-      title: "Some custom icons used fallback",
-      message: `${kmzWarnings.length} icon(s) could not be embedded. ${warningExamples}${andMore}`,
+      title: "Export used compatibility fallbacks",
+      message: `${warningExamples}${andMore}`,
       duration: 10000,
     });
   }

--- a/src/components/ExportSettingsKmlKmz.vue
+++ b/src/components/ExportSettingsKmlKmz.vue
@@ -50,6 +50,13 @@ const labelScale = computed({
   },
 });
 
+const controlMeasureLabelMode = computed({
+  get: () => (isKmz.value ? form.value.controlMeasureLabelMode : "native"),
+  set: (value: "native" | "rendered") => {
+    form.value.controlMeasureLabelMode = value;
+  },
+});
+
 const events = computed(() => {
   return store.state.events
     .map((e) => store.state.eventMap[e])
@@ -120,6 +127,28 @@ function toggleAllEvents() {
             >Side and groups (nested)</InputRadio
           >
         </MRadioGroup>
+      </InputGroupTemplate>
+      <InputGroupTemplate
+        v-if="form.includeFeatures"
+        class="col-span-full"
+        label="Control-measure labels"
+      >
+        <MRadioGroup class="mt-4 sm:flex sm:gap-6">
+          <InputRadio v-model="controlMeasureLabelMode" value="native">
+            Native — searchable, always upright
+          </InputRadio>
+          <InputRadio
+            v-model="controlMeasureLabelMode"
+            value="rendered"
+            :disabled="!isKmz"
+          >
+            Rendered — preserve appearance and orientation (KMZ)
+          </InputRadio>
+        </MRadioGroup>
+        <template #description>
+          Rendered labels are embedded as images. Plain KML uses native labels because it
+          cannot package image assets.
+        </template>
       </InputGroupTemplate>
     </div>
 

--- a/src/extlib/tokml/index.test.ts
+++ b/src/extlib/tokml/index.test.ts
@@ -44,4 +44,33 @@ describe("foldersToKML", () => {
       '<hotSpot x="0.5" y="0.75" xunits="fraction" yunits="fraction">',
     );
   });
+
+  it("serializes line, polygon, and label styles for rendered graphics", () => {
+    const root: Root = { type: "root", children: [] };
+    const kml = foldersToKML(root, [
+      {
+        id: "control-measure",
+        lineColor: "ff332211",
+        lineWidth: 4,
+        polyColor: "80332211",
+        polyFill: true,
+        polyOutline: true,
+      },
+      {
+        id: "control-measure-label",
+        labelColor: "ff332211",
+        labelScale: 1.5,
+        hideIcon: true,
+      },
+    ]);
+
+    expect(kml).toContain('<Style id="control-measure">');
+    expect(kml).toContain("<LineStyle><color>ff332211</color><width>4</width>");
+    expect(kml).toContain(
+      "<PolyStyle><color>80332211</color><fill>1</fill><outline>1</outline>",
+    );
+    expect(kml).toContain('<Style id="control-measure-label">');
+    expect(kml).toContain("<IconStyle><scale>0</scale>");
+    expect(kml).toContain("<LabelStyle><color>ff332211</color><scale>1.5</scale>");
+  });
 });

--- a/src/extlib/tokml/index.test.ts
+++ b/src/extlib/tokml/index.test.ts
@@ -61,6 +61,7 @@ describe("foldersToKML", () => {
         labelColor: "ff332211",
         labelScale: 1.5,
         hideIcon: true,
+        iconHeading: 135,
       },
     ]);
 
@@ -71,6 +72,7 @@ describe("foldersToKML", () => {
     );
     expect(kml).toContain('<Style id="control-measure-label">');
     expect(kml).toContain("<IconStyle><scale>0</scale>");
+    expect(kml).toContain("<heading>135</heading>");
     expect(kml).toContain("<LabelStyle><color>ff332211</color><scale>1.5</scale>");
   });
 });

--- a/src/extlib/tokml/index.ts
+++ b/src/extlib/tokml/index.ts
@@ -54,6 +54,7 @@ export type StyleSettings = {
   iconScale?: number;
   iconHref?: string;
   hideIcon?: boolean;
+  iconHeading?: number;
   labelScale?: number;
   labelColor?: string;
   lineColor?: string;
@@ -72,6 +73,7 @@ function convertStyle({
   iconScale = 1,
   iconHref,
   hideIcon = false,
+  iconHeading,
   labelScale = 1,
   labelColor,
   lineColor,
@@ -87,7 +89,12 @@ function convertStyle({
   const styleId = id ?? `sidc${sidc}`;
   const href = iconHref ?? (sidc ? `icons/${sidc}.png` : undefined);
   const hasOffset = xOffset !== undefined && yOffset !== undefined;
-  const includeIconStyle = hideIcon || href !== undefined || iconScale !== 1 || hasOffset;
+  const includeIconStyle =
+    hideIcon ||
+    href !== undefined ||
+    iconScale !== 1 ||
+    iconHeading !== undefined ||
+    hasOffset;
   return [
     BR,
     x("Style", { id: styleId }, [
@@ -96,6 +103,9 @@ function convertStyle({
             href ? x("Icon", [x("href", [u("text", href)])]) : undefined,
             hideIcon ? x("scale", [u("text", "0")]) : undefined,
             iconScale !== 1 ? x("scale", [u("text", `${iconScale}`)]) : undefined,
+            iconHeading !== undefined
+              ? x("heading", [u("text", `${iconHeading}`)])
+              : undefined,
             hasOffset
               ? x("hotSpot", {
                   x: `${xOffset}`,

--- a/src/extlib/tokml/index.ts
+++ b/src/extlib/tokml/index.ts
@@ -47,43 +47,88 @@ export function foldersToKML(
   );
 }
 
-type StyleSettings = {
-  sidc: string;
+export type StyleSettings = {
+  /** Explicit style id for non-unit features. Unit styles retain the sidc shorthand. */
+  id?: string;
+  sidc?: string;
   iconScale?: number;
+  iconHref?: string;
+  hideIcon?: boolean;
   labelScale?: number;
+  labelColor?: string;
+  lineColor?: string;
+  lineWidth?: number;
+  polyColor?: string;
+  polyFill?: boolean;
+  polyOutline?: boolean;
   xOffset?: number;
   yOffset?: number;
   xUnits?: "insetPixels" | "pixels" | "fraction";
   yUnits?: "insetPixels" | "pixels" | "fraction";
 };
 function convertStyle({
+  id,
   sidc,
   iconScale = 1,
+  iconHref,
+  hideIcon = false,
   labelScale = 1,
+  labelColor,
+  lineColor,
+  lineWidth,
+  polyColor,
+  polyFill,
+  polyOutline,
   xOffset,
   yOffset,
   xUnits = "insetPixels",
   yUnits = "insetPixels",
 }: StyleSettings) {
+  const styleId = id ?? `sidc${sidc}`;
+  const href = iconHref ?? (sidc ? `icons/${sidc}.png` : undefined);
   const hasOffset = xOffset !== undefined && yOffset !== undefined;
+  const includeIconStyle = hideIcon || href !== undefined || iconScale !== 1 || hasOffset;
   return [
     BR,
-    x("Style", { id: `sidc${sidc}` }, [
-      x("IconStyle", [
-        x("Icon", [x("href", [u("text", `icons/${sidc}.png`)])]),
-        iconScale !== 1 ? x("scale", [u("text", `${iconScale}`)]) : undefined,
-        hasOffset
-          ? x("hotSpot", {
-              x: `${xOffset}`,
-              y: `${yOffset}`,
-              xunits: xUnits,
-              yunits: yUnits,
-            })
-          : undefined,
-      ]),
-      x("LabelStyle", [
-        labelScale !== 1 ? x("scale", [u("text", `${labelScale}`)]) : undefined,
-      ]), // Add this line for small labels
+    x("Style", { id: styleId }, [
+      includeIconStyle
+        ? x("IconStyle", [
+            href ? x("Icon", [x("href", [u("text", href)])]) : undefined,
+            hideIcon ? x("scale", [u("text", "0")]) : undefined,
+            iconScale !== 1 ? x("scale", [u("text", `${iconScale}`)]) : undefined,
+            hasOffset
+              ? x("hotSpot", {
+                  x: `${xOffset}`,
+                  y: `${yOffset}`,
+                  xunits: xUnits,
+                  yunits: yUnits,
+                })
+              : undefined,
+          ])
+        : undefined,
+      labelColor !== undefined || labelScale !== 1
+        ? x("LabelStyle", [
+            labelColor ? x("color", [u("text", labelColor)]) : undefined,
+            labelScale !== 1 ? x("scale", [u("text", `${labelScale}`)]) : undefined,
+          ])
+        : undefined,
+      lineColor !== undefined || lineWidth !== undefined
+        ? x("LineStyle", [
+            lineColor ? x("color", [u("text", lineColor)]) : undefined,
+            lineWidth !== undefined ? x("width", [u("text", `${lineWidth}`)]) : undefined,
+          ])
+        : undefined,
+      polyColor !== undefined || polyFill !== undefined || polyOutline !== undefined
+        ? x("PolyStyle", [
+            polyColor ? x("color", [u("text", polyColor)]) : undefined,
+            polyFill !== undefined
+              ? x("fill", [u("text", polyFill ? "1" : "0")])
+              : undefined,
+            polyOutline !== undefined
+              ? x("outline", [u("text", polyOutline ? "1" : "0")])
+              : undefined,
+          ])
+        : undefined,
     ]),
   ];
 }

--- a/src/importexport/export/controlMeasureGeoJson.test.ts
+++ b/src/importexport/export/controlMeasureGeoJson.test.ts
@@ -266,4 +266,25 @@ describe("convertScenarioFeaturesToGeoJson", () => {
     expect(collection.features.every((f) => f.properties?.cmId === "cm1")).toBe(true);
     expect(collection.features.every((f) => f.id === undefined)).toBe(true);
   });
+
+  it("can convert one layer's items without flattening every scenario layer", () => {
+    const scenario = {
+      geo: {
+        layerItemsLayers: {
+          value: [{ items: [geometryItem] }, { items: [phaseLine()] }],
+        },
+      },
+      unitActions: {},
+    } as unknown as TScenario;
+    const { convertScenarioFeaturesToGeoJson } = useGeoJsonConverter(scenario);
+
+    const collection = convertScenarioFeaturesToGeoJson({}, [
+      { ...phaseLine(), _pid: "layer-2" },
+    ]);
+
+    expect(collection.features).not.toContainEqual(
+      expect.objectContaining({ geometry: geometryItem.geometry }),
+    );
+    expect(collection.features.every((f) => f.properties?.cmId === "cm1")).toBe(true);
+  });
 });

--- a/src/importexport/export/controlMeasureKml/index.test.ts
+++ b/src/importexport/export/controlMeasureKml/index.test.ts
@@ -54,4 +54,35 @@ describe("controlMeasuresToKml", () => {
     ]);
     expect(result.warnings).toEqual([expect.stringContaining("dash patterns")]);
   });
+
+  it("creates image-backed styles with original rotation and anchor in rendered mode", () => {
+    const result = controlMeasuresToKml(
+      [
+        {
+          id: "text-1",
+          kind: "tacticalGraphic",
+          graphicKind: "text",
+          controlPoints: [[10, 59]],
+          style: { color: "#123456" },
+          options: { text: "ALPHA", rotation: 0, sizePixels: 20, textAlign: "right" },
+        },
+      ],
+      { labelMode: "rendered" },
+    );
+
+    expect(result.labelImages).toEqual([
+      expect.objectContaining({ text: "ALPHA", fontSize: 20 }),
+    ]);
+    expect(result.styles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          iconHref: result.labelImages[0]?.path,
+          iconHeading: 0,
+          labelScale: 0,
+        }),
+      ]),
+    );
+    const label = result.features.find((feature) => feature.properties?.labelText);
+    expect(label?.properties?.name).toBeUndefined();
+  });
 });

--- a/src/importexport/export/controlMeasureKml/index.test.ts
+++ b/src/importexport/export/controlMeasureKml/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { cssColorToKml, controlMeasuresToKml } from "./index";
+import type { TacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
+
+function phaseLine(
+  patch: Partial<TacticalGraphicLayerItem> = {},
+): TacticalGraphicLayerItem {
+  return {
+    id: "phase-1",
+    kind: "tacticalGraphic",
+    graphicKind: "phase-line",
+    controlPoints: [
+      [10, 59],
+      [11, 60],
+    ],
+    style: { color: "rgba(17, 34, 51, 0.5)", strokeWidth: 4 },
+    textAmplifiers: { T: "PL RED" },
+    ...patch,
+  };
+}
+
+describe("controlMeasuresToKml", () => {
+  it("converts CSS colors to KML aabbggrr colors", () => {
+    expect(cssColorToKml("#123456")).toBe("ff563412");
+    expect(cssColorToKml("#12345680")).toBe("80563412");
+    expect(cssColorToKml("rgba(17, 34, 51, 0.5)")).toBe("80332211");
+  });
+
+  it("exports the complete rendered geometry with shared KML styles and labels", () => {
+    const result = controlMeasuresToKml([phaseLine()]);
+
+    expect(result.features.length).toBeGreaterThan(1);
+    expect(
+      result.features.every((feature) => feature.properties?.cmId === "phase-1"),
+    ).toBe(true);
+    expect(result.features.every((feature) => feature.properties?.styleUrl)).toBe(true);
+
+    const lineStyle = result.styles.find((style) => style.lineColor);
+    expect(lineStyle).toMatchObject({ lineColor: "80332211", lineWidth: 4 });
+
+    const label = result.features.find(
+      (feature) => feature.geometry.type === "Point" && feature.properties?.name,
+    );
+    expect(label?.properties?.name).toContain("PL RED");
+    const labelStyle = result.styles.find(
+      (style) => `#${style.id}` === label?.properties?.styleUrl,
+    );
+    expect(labelStyle).toMatchObject({ labelColor: "80332211", hideIcon: true });
+  });
+
+  it("reports KML's solid fallback for planned dash styling", () => {
+    const result = controlMeasuresToKml([
+      phaseLine({ status: "planned", style: { color: "#ff0000" } }),
+    ]);
+    expect(result.warnings).toEqual([expect.stringContaining("dash patterns")]);
+  });
+});

--- a/src/importexport/export/controlMeasureKml/index.ts
+++ b/src/importexport/export/controlMeasureKml/index.ts
@@ -1,0 +1,180 @@
+/**
+ * Temporary KML compatibility layer for @orbat-mapper/control-measures.
+ *
+ * Keep this module dependency-light and behind the KML export seam: the control
+ * measures package is expected to grow its own KML renderer, at which point this
+ * folder and the two calls from kmlExport.ts can be removed together.
+ */
+import {
+  renderControlMeasure,
+  type ControlMeasureStyle,
+  type FeaturePartProps,
+} from "@orbat-mapper/control-measures";
+import type { Feature, GeoJsonProperties, Geometry } from "geojson";
+import {
+  toControlMeasure,
+  toTacticalGraphicGeoJsonProperties,
+} from "@/geo/controlMeasures";
+import { isSupportedTacticalGraphic } from "@/scenariostore/tacticalGraphics";
+import type { TacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
+import type { StyleSettings } from "@/extlib/tokml";
+
+export type ControlMeasureKmlExport = {
+  features: Feature<Geometry, GeoJsonProperties>[];
+  styles: StyleSettings[];
+  warnings: string[];
+};
+
+type Rgba = { red: number; green: number; blue: number; alpha: number };
+
+function byte(value: number): string {
+  return Math.round(Math.max(0, Math.min(255, value)))
+    .toString(16)
+    .padStart(2, "0");
+}
+
+function parseCssColor(value: string | undefined): Rgba | undefined {
+  if (!value) return undefined;
+  const color = value.trim();
+  const hex = /^#([\da-f]{3,8})$/i.exec(color)?.[1];
+  if (hex) {
+    const expanded =
+      hex.length === 3 || hex.length === 4
+        ? [...hex].map((character) => character + character).join("")
+        : hex;
+    if (expanded.length === 6 || expanded.length === 8) {
+      return {
+        red: Number.parseInt(expanded.slice(0, 2), 16),
+        green: Number.parseInt(expanded.slice(2, 4), 16),
+        blue: Number.parseInt(expanded.slice(4, 6), 16),
+        alpha: expanded.length === 8 ? Number.parseInt(expanded.slice(6, 8), 16) : 255,
+      };
+    }
+  }
+
+  const rgb =
+    /^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+)\s*)?\)$/i.exec(
+      color,
+    );
+  if (!rgb) return undefined;
+  return {
+    red: Number(rgb[1]),
+    green: Number(rgb[2]),
+    blue: Number(rgb[3]),
+    alpha: rgb[4] === undefined ? 255 : Number(rgb[4]) * 255,
+  };
+}
+
+/** KML colors are encoded as aabbggrr, rather than CSS's rrggbbaa. */
+export function cssColorToKml(value: string | undefined): string | undefined {
+  const color = parseCssColor(value);
+  if (!color) return undefined;
+  return `${byte(color.alpha)}${byte(color.blue)}${byte(color.green)}${byte(color.red)}`;
+}
+
+function styleKey(style: StyleSettings): string {
+  return JSON.stringify(style, Object.keys(style).sort());
+}
+
+function kmlStyleForPart(
+  id: string,
+  geometry: Geometry,
+  properties: FeaturePartProps,
+): StyleSettings {
+  const style: ControlMeasureStyle = properties.style ?? {};
+  const isLabel = geometry.type === "Point" && typeof properties.text === "string";
+  return {
+    id,
+    ...(isLabel
+      ? {
+          labelColor: cssColorToKml(style.strokeColor),
+          labelScale:
+            properties.textSizePixels !== undefined
+              ? Math.max(0.1, properties.textSizePixels / 16)
+              : 1,
+          hideIcon: true,
+        }
+      : {
+          lineColor: cssColorToKml(style.strokeColor),
+          // MapLibre tactical-draw's adapter default is 2px. KML's default is 1,
+          // so leaving this absent would make otherwise unstyled measures too thin.
+          lineWidth: style.strokeWidth ?? 2,
+          polyColor: cssColorToKml(style.fillColor),
+          polyFill: style.fillColor !== undefined,
+          polyOutline: style.strokeColor !== undefined,
+        }),
+  };
+}
+
+/**
+ * Render stored control measures into styled KML-ready placemarks.
+ *
+ * KML has no portable line-dash or polygon-pattern primitive. The complete
+ * rendered geometry is retained and those two paint hints degrade to the same
+ * colors/widths as a solid KML feature; callers receive one aggregate warning.
+ */
+export function controlMeasuresToKml(
+  items: readonly TacticalGraphicLayerItem[],
+): ControlMeasureKmlExport {
+  const features: Feature<Geometry, GeoJsonProperties>[] = [];
+  const styles: StyleSettings[] = [];
+  const styleIds = new Map<string, string>();
+  let hasDash = false;
+  let hasPattern = false;
+
+  for (const item of items) {
+    if (!isSupportedTacticalGraphic(item)) continue;
+    const rendered = renderControlMeasure(toControlMeasure(item), {
+      validationMode: "silent",
+    });
+    const itemProperties = toTacticalGraphicGeoJsonProperties(item);
+
+    for (const feature of rendered.features) {
+      const candidate = kmlStyleForPart("", feature.geometry, feature.properties);
+      const key = styleKey({ ...candidate, id: "" });
+      let id = styleIds.get(key);
+      if (!id) {
+        id = `cm-${styleIds.size}`;
+        styleIds.set(key, id);
+        styles.push({ ...candidate, id });
+      }
+
+      const partStyle = feature.properties.style;
+      hasDash ||= Boolean(partStyle?.strokeDash?.length);
+      hasPattern ||= Boolean(partStyle?.fillPattern && partStyle.fillPattern !== "solid");
+      const isLabel =
+        feature.geometry.type === "Point" && typeof feature.properties.text === "string";
+
+      features.push({
+        type: "Feature",
+        id: feature.id,
+        geometry: feature.geometry,
+        properties: {
+          ...itemProperties,
+          cmId: item.id,
+          part: feature.properties.part,
+          index: feature.properties.index,
+          styleUrl: `#${id}`,
+          ...(isLabel ? { name: feature.properties.text } : {}),
+          ...(feature.properties.rotation !== undefined
+            ? { labelRotation: feature.properties.rotation }
+            : {}),
+          ...(feature.properties.textAnchor !== undefined
+            ? { labelAnchor: feature.properties.textAnchor }
+            : {}),
+        },
+      });
+    }
+  }
+
+  const warnings: string[] = [];
+  if (hasDash || hasPattern) {
+    const unsupported = [hasDash && "dash patterns", hasPattern && "fill patterns"]
+      .filter(Boolean)
+      .join(" and ");
+    warnings.push(
+      `KML does not define portable ${unsupported}; affected control-measure parts use their resolved color and width as a solid fallback.`,
+    );
+  }
+  return { features, styles, warnings };
+}

--- a/src/importexport/export/controlMeasureKml/index.ts
+++ b/src/importexport/export/controlMeasureKml/index.ts
@@ -18,10 +18,24 @@ import {
 import { isSupportedTacticalGraphic } from "@/scenariostore/tacticalGraphics";
 import type { TacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
 import type { StyleSettings } from "@/extlib/tokml";
+import type { KmlControlMeasureLabelMode } from "@/types/importExport";
+
+export type ControlMeasureLabelImage = {
+  path: string;
+  text: string;
+  fontSize: number;
+  textStyle?: FeaturePartProps["textStyle"];
+  textJustify?: FeaturePartProps["textJustify"];
+  color: string;
+  textBackground: boolean;
+  textHalo: boolean;
+  textHaloColor: string;
+};
 
 export type ControlMeasureKmlExport = {
   features: Feature<Geometry, GeoJsonProperties>[];
   styles: StyleSettings[];
+  labelImages: ControlMeasureLabelImage[];
   warnings: string[];
 };
 
@@ -76,7 +90,7 @@ function styleKey(style: StyleSettings): string {
   return JSON.stringify(style, Object.keys(style).sort());
 }
 
-function kmlStyleForPart(
+function nativeKmlStyleForPart(
   id: string,
   geometry: Geometry,
   properties: FeaturePartProps,
@@ -106,6 +120,47 @@ function kmlStyleForPart(
   };
 }
 
+function headingFromRotation(rotation: number | undefined): number {
+  if (rotation === undefined) return 0;
+  const heading = 180 - (rotation * 180) / Math.PI;
+  return ((heading % 360) + 360) % 360;
+}
+
+function labelImageKey(image: Omit<ControlMeasureLabelImage, "path">): string {
+  return JSON.stringify(image, Object.keys(image).sort());
+}
+
+function renderedLabelImage(
+  properties: FeaturePartProps,
+): Omit<ControlMeasureLabelImage, "path"> {
+  const style = properties.style ?? {};
+  return {
+    text: properties.text ?? "",
+    fontSize: properties.textSizePixels ?? 14,
+    ...(properties.textStyle ? { textStyle: properties.textStyle } : {}),
+    ...(properties.textJustify ? { textJustify: properties.textJustify } : {}),
+    color: style.strokeColor ?? "#000000",
+    textBackground: properties.textBackground === true,
+    textHalo: properties.textHalo === true,
+    textHaloColor: properties.textHaloColor ?? "#ffffff",
+  };
+}
+
+function renderedLabelStyle(path: string, properties: FeaturePartProps): StyleSettings {
+  const anchorX =
+    properties.textAnchor === "start" ? 0 : properties.textAnchor === "end" ? 1 : 0.5;
+  return {
+    id: "",
+    iconHref: path,
+    iconHeading: headingFromRotation(properties.rotation),
+    xOffset: anchorX,
+    yOffset: 0.5,
+    xUnits: "fraction",
+    yUnits: "fraction",
+    labelScale: 0,
+  };
+}
+
 /**
  * Render stored control measures into styled KML-ready placemarks.
  *
@@ -115,12 +170,16 @@ function kmlStyleForPart(
  */
 export function controlMeasuresToKml(
   items: readonly TacticalGraphicLayerItem[],
+  options: { labelMode?: KmlControlMeasureLabelMode } = {},
 ): ControlMeasureKmlExport {
   const features: Feature<Geometry, GeoJsonProperties>[] = [];
   const styles: StyleSettings[] = [];
+  const labelImages: ControlMeasureLabelImage[] = [];
   const styleIds = new Map<string, string>();
+  const labelImagePaths = new Map<string, string>();
   let hasDash = false;
   let hasPattern = false;
+  let hasGroundSizedLabel = false;
 
   for (const item of items) {
     if (!isSupportedTacticalGraphic(item)) continue;
@@ -130,7 +189,23 @@ export function controlMeasuresToKml(
     const itemProperties = toTacticalGraphicGeoJsonProperties(item);
 
     for (const feature of rendered.features) {
-      const candidate = kmlStyleForPart("", feature.geometry, feature.properties);
+      const isLabel =
+        feature.geometry.type === "Point" && typeof feature.properties.text === "string";
+      let candidate: StyleSettings;
+      if (isLabel && options.labelMode === "rendered") {
+        const image = renderedLabelImage(feature.properties);
+        const imageKey = labelImageKey(image);
+        let path = labelImagePaths.get(imageKey);
+        if (!path) {
+          path = `icons/control-measure-labels/label-${labelImages.length}.png`;
+          labelImagePaths.set(imageKey, path);
+          labelImages.push({ path, ...image });
+        }
+        candidate = renderedLabelStyle(path, feature.properties);
+        hasGroundSizedLabel ||= feature.properties.textSizeMeters !== undefined;
+      } else {
+        candidate = nativeKmlStyleForPart("", feature.geometry, feature.properties);
+      }
       const key = styleKey({ ...candidate, id: "" });
       let id = styleIds.get(key);
       if (!id) {
@@ -142,20 +217,27 @@ export function controlMeasuresToKml(
       const partStyle = feature.properties.style;
       hasDash ||= Boolean(partStyle?.strokeDash?.length);
       hasPattern ||= Boolean(partStyle?.fillPattern && partStyle.fillPattern !== "solid");
-      const isLabel =
-        feature.geometry.type === "Point" && typeof feature.properties.text === "string";
+      const exportedItemProperties = { ...itemProperties };
+      if (isLabel && options.labelMode === "rendered") {
+        delete exportedItemProperties.name;
+      }
 
       features.push({
         type: "Feature",
         id: feature.id,
         geometry: feature.geometry,
         properties: {
-          ...itemProperties,
+          ...exportedItemProperties,
           cmId: item.id,
           part: feature.properties.part,
           index: feature.properties.index,
           styleUrl: `#${id}`,
-          ...(isLabel ? { name: feature.properties.text } : {}),
+          ...(isLabel && options.labelMode !== "rendered"
+            ? { name: feature.properties.text }
+            : {}),
+          ...(isLabel && options.labelMode === "rendered"
+            ? { labelText: feature.properties.text }
+            : {}),
           ...(feature.properties.rotation !== undefined
             ? { labelRotation: feature.properties.rotation }
             : {}),
@@ -176,5 +258,71 @@ export function controlMeasuresToKml(
       `KML does not define portable ${unsupported}; affected control-measure parts use their resolved color and width as a solid fallback.`,
     );
   }
-  return { features, styles, warnings };
+  if (hasGroundSizedLabel) {
+    warnings.push(
+      "KML point icons cannot retain meter-based label sizing across zoom levels; affected rendered labels use the 14px engine fallback.",
+    );
+  }
+  return { features, styles, labelImages, warnings };
+}
+
+function fontForLabel(image: ControlMeasureLabelImage): string {
+  const fontStyle = image.textStyle === "italic" ? "italic" : "normal";
+  const fontWeight = image.textStyle === "light" ? "300" : "400";
+  return `${fontStyle} ${fontWeight} ${image.fontSize}px sans-serif`;
+}
+
+/** Rasterize one rendered-label resource for packaging inside a KMZ archive. */
+export async function renderControlMeasureLabelBlob(
+  image: ControlMeasureLabelImage,
+): Promise<Blob> {
+  const text = image.textStyle === "caps" ? image.text.toUpperCase() : image.text;
+  const lines = text.split("\n");
+  const measureCanvas = document.createElement("canvas");
+  const measureContext = measureCanvas.getContext("2d");
+  if (!measureContext) throw new Error("Failed to create label measurement context");
+  measureContext.font = fontForLabel(image);
+  const lineHeight = Math.ceil(image.fontSize * 1.2);
+  const widestLine = Math.max(
+    1,
+    ...lines.map((line) => Math.ceil(measureContext.measureText(line).width)),
+  );
+  const effectWidth = image.textBackground
+    ? Math.max(3, image.fontSize * 0.22)
+    : image.textHalo
+      ? Math.max(2, image.fontSize / 4)
+      : 0;
+  const padding = Math.ceil(effectWidth + 2);
+  const canvas = document.createElement("canvas");
+  canvas.width = widestLine + padding * 2;
+  canvas.height = lineHeight * Math.max(1, lines.length) + padding * 2;
+  const context = canvas.getContext("2d");
+  if (!context) throw new Error("Failed to create label canvas context");
+
+  context.font = fontForLabel(image);
+  context.textBaseline = "top";
+  context.textAlign = image.textJustify ?? "center";
+  context.fillStyle = image.color;
+  const textX =
+    context.textAlign === "left"
+      ? padding
+      : context.textAlign === "right"
+        ? canvas.width - padding
+        : canvas.width / 2;
+  if (image.textBackground || image.textHalo) {
+    context.strokeStyle = image.textBackground ? "#ffffff" : image.textHaloColor;
+    context.lineWidth = effectWidth;
+    context.lineJoin = "round";
+  }
+  lines.forEach((line, index) => {
+    const y = padding + index * lineHeight;
+    if (image.textBackground || image.textHalo) context.strokeText(line, textX, y);
+    context.fillText(line, textX, y);
+  });
+
+  const blob = await new Promise<Blob | null>((resolve) =>
+    canvas.toBlob(resolve, "image/png"),
+  );
+  if (!blob) throw new Error("Failed to encode rendered control-measure label");
+  return blob;
 }

--- a/src/importexport/export/geojsonConverter.ts
+++ b/src/importexport/export/geojsonConverter.ts
@@ -42,9 +42,14 @@ export function useGeoJsonConverter(scenario: TScenario) {
     return featureCollection(features) as OrbatMapperGeoJsonCollection;
   }
 
-  function convertScenarioFeaturesToGeoJson(options: Partial<GeoJsonSettings> = {}) {
+  function convertScenarioFeaturesToGeoJson(
+    options: Partial<GeoJsonSettings> = {},
+    sourceItems?: readonly NScenarioLayerItem[],
+  ) {
     const includeIdInProperties = options.includeIdInProperties ?? false;
-    const layerItems = geo.layerItemsLayers.value.map((layer) => layer.items).flat(1);
+    const layerItems = sourceItems
+      ? [...sourceItems]
+      : geo.layerItemsLayers.value.map((layer) => layer.items).flat(1);
 
     const geometryFeatures: Feature<Geometry, GeoJsonProperties>[] = layerItems
       .filter((layerItem): layerItem is NScenarioLayerItem & GeometryLayerItem =>

--- a/src/importexport/export/kmlExport.test.ts
+++ b/src/importexport/export/kmlExport.test.ts
@@ -192,6 +192,7 @@ function createKmzOptions(overrides: Record<string, unknown> = {}) {
     outlineWidth: 8,
     renderAmplifiers: false,
     renderCustomIconLabels: false,
+    controlMeasureLabelMode: "native" as const,
     timeMode: "current" as const,
     exportEventIds: [],
     useRadioFolder: false,
@@ -456,7 +457,15 @@ describe("downloadAsKMZ custom symbols", () => {
     } as any;
     const { generateKml } = useKmlExport(scenario);
 
-    await generateKml(createKmzOptions({ includeUnits: false, includeFeatures: true }));
+    // Standalone KML cannot package rendered label images, so even a persisted
+    // rendered preference must fall back to portable native KML labels.
+    await generateKml(
+      createKmzOptions({
+        includeUnits: false,
+        includeFeatures: true,
+        controlMeasureLabelMode: "rendered",
+      }),
+    );
 
     const [root, styles] = foldersToKMLMock.mock.calls[0] as any[];
     expect(styles).toEqual(
@@ -475,9 +484,62 @@ describe("downloadAsKMZ custom symbols", () => {
     const exportedFeatures = layerFolder.children as any[];
     expect(exportedFeatures.some((feature) => feature.properties.name)).toBe(true);
     expect(exportedFeatures.every((feature) => feature.properties.styleUrl)).toBe(true);
+    expect(styles.some((style: any) => style.iconHref)).toBe(false);
     expect(scenarioFeaturesFolder.children[1].meta).toMatchObject({
       id: "layer-empty",
       name: "Empty reference layer",
     });
+  });
+
+  it("packages rendered control-measure labels as rotated KMZ images", async () => {
+    const scenario = createMilScenario();
+    scenario.geo.layerItemsLayers = {
+      value: [
+        {
+          id: "layer-control-measures",
+          name: "Control measures",
+          items: [
+            {
+              id: "cm-text",
+              kind: "tacticalGraphic",
+              graphicKind: "text",
+              controlPoints: [[10, 59]],
+              style: { color: "#123456" },
+              options: { text: "ALPHA", rotation: 90, sizePixels: 20 },
+            },
+          ],
+        },
+      ],
+    } as any;
+    const { downloadAsKMZ } = useKmlExport(scenario);
+
+    await downloadAsKMZ(
+      createKmzOptions({
+        includeUnits: false,
+        includeFeatures: true,
+        controlMeasureLabelMode: "rendered",
+      }),
+    );
+
+    const zipData = zipSyncMock.mock.calls[0][0] as Record<string, Uint8Array>;
+    expect(
+      Object.keys(zipData).some((path) =>
+        path.startsWith("icons/control-measure-labels/"),
+      ),
+    ).toBe(true);
+    const [root, styles] = foldersToKMLMock.mock.calls[0] as any[];
+    expect(styles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          iconHref: expect.stringContaining("control-measure-labels"),
+          iconHeading: expect.any(Number),
+          labelScale: 0,
+        }),
+      ]),
+    );
+    const labelFeature = root.children[0].children[0].children.find(
+      (feature: any) => feature.properties.labelText,
+    );
+    expect(labelFeature.properties.name).toBeUndefined();
   });
 });

--- a/src/importexport/export/kmlExport.test.ts
+++ b/src/importexport/export/kmlExport.test.ts
@@ -425,4 +425,59 @@ describe("downloadAsKMZ custom symbols", () => {
     const zipData = zipSyncMock.mock.calls[0][0] as Record<string, Uint8Array>;
     expect(Object.keys(zipData).some((k) => k.startsWith("icons/"))).toBe(true);
   });
+
+  it("replaces unstyled GeoJSON control measures with styled rendered KML parts", async () => {
+    const scenario = createMilScenario();
+    scenario.geo.layerItemsLayers = {
+      value: [
+        {
+          id: "layer-control-measures",
+          name: "Control measures",
+          items: [
+            {
+              id: "cm-phase",
+              kind: "tacticalGraphic",
+              graphicKind: "phase-line",
+              controlPoints: [
+                [10, 59],
+                [11, 60],
+              ],
+              style: { color: "#123456", strokeWidth: 4 },
+              textAmplifiers: { T: "RED" },
+            },
+          ],
+        },
+        {
+          id: "layer-empty",
+          name: "Empty reference layer",
+          items: [],
+        },
+      ],
+    } as any;
+    const { generateKml } = useKmlExport(scenario);
+
+    await generateKml(createKmzOptions({ includeUnits: false, includeFeatures: true }));
+
+    const [root, styles] = foldersToKMLMock.mock.calls[0] as any[];
+    expect(styles).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ lineColor: "ff563412", lineWidth: 4 }),
+        expect.objectContaining({ labelColor: "ff563412", hideIcon: true }),
+      ]),
+    );
+    const scenarioFeaturesFolder = root.children[0];
+    expect(scenarioFeaturesFolder.children).toHaveLength(2);
+    const layerFolder = scenarioFeaturesFolder.children[0];
+    expect(layerFolder.meta).toMatchObject({
+      id: "layer-control-measures",
+      name: "Control measures",
+    });
+    const exportedFeatures = layerFolder.children as any[];
+    expect(exportedFeatures.some((feature) => feature.properties.name)).toBe(true);
+    expect(exportedFeatures.every((feature) => feature.properties.styleUrl)).toBe(true);
+    expect(scenarioFeaturesFolder.children[1].meta).toMatchObject({
+      id: "layer-empty",
+      name: "Empty reference layer",
+    });
+  });
 });

--- a/src/importexport/export/kmlExport.ts
+++ b/src/importexport/export/kmlExport.ts
@@ -12,7 +12,11 @@ import type { CustomSymbol, UnitSymbolOptions } from "@/types/scenarioModels.ts"
 import { getCustomSymbolId, getFullUnitSidc } from "@/symbology/helpers.ts";
 import { CUSTOM_SYMBOL_PREFIX } from "@/config/constants.ts";
 import { useMapSettingsStore } from "@/stores/mapSettingsStore.ts";
-import { controlMeasuresToKml } from "@/importexport/export/controlMeasureKml";
+import {
+  controlMeasuresToKml,
+  renderControlMeasureLabelBlob,
+  type ControlMeasureLabelImage,
+} from "@/importexport/export/controlMeasureKml";
 import { isNTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
 import type { StyleSettings } from "@/extlib/tokml";
 
@@ -52,10 +56,14 @@ export function useKmlExport(scenario: TScenario) {
   const mapSettings = useMapSettingsStore();
   const { selectedUnitIds } = useSelectedItems();
 
-  function createKMLString(opts: KmlKmzExportSettings) {
+  function createKMLString(
+    opts: KmlKmzExportSettings,
+    options: { packageRenderedLabels?: boolean } = {},
+  ) {
     const root: Root = { type: "root", children: [] };
     const symbolDataCache = new Map<string, RenderSymbolSettings>();
     const controlMeasureStyles: StyleSettings[] = [];
+    const controlMeasureLabelImages: ControlMeasureLabelImage[] = [];
     const warnings: string[] = [];
 
     function createUnitsFolder(units: NUnit[], name: string): Folder {
@@ -193,8 +201,14 @@ export function useKmlExport(scenario: TScenario) {
       const controlMeasureItems = scenarioLayers
         .flatMap((layer) => layer.items)
         .filter(isNTacticalGraphicLayerItem);
-      const controlMeasures = controlMeasuresToKml(controlMeasureItems);
+      const controlMeasures = controlMeasuresToKml(controlMeasureItems, {
+        labelMode:
+          options.packageRenderedLabels && opts.controlMeasureLabelMode === "rendered"
+            ? "rendered"
+            : "native",
+      });
       controlMeasureStyles.push(...controlMeasures.styles);
+      controlMeasureLabelImages.push(...controlMeasures.labelImages);
       warnings.push(...controlMeasures.warnings);
 
       const layerFolders: Folder[] = scenarioLayers.map((layer) => {
@@ -228,7 +242,13 @@ export function useKmlExport(scenario: TScenario) {
       });
     }
 
-    return { root, symbolDataCache, controlMeasureStyles, warnings };
+    return {
+      root,
+      symbolDataCache,
+      controlMeasureStyles,
+      controlMeasureLabelImages,
+      warnings,
+    };
   }
 
   async function generateKml(opts: KmlKmzExportSettings): Promise<string> {
@@ -487,8 +507,24 @@ export function useKmlExport(scenario: TScenario) {
     const { foldersToKML } = await import("@/extlib/tokml");
     const data: Record<string, Uint8Array> = {};
     const hotspotCache = new Map<string, HotspotSettings>();
-    const { root, symbolDataCache, controlMeasureStyles, warnings } =
-      createKMLString(opts);
+    const {
+      root,
+      symbolDataCache,
+      controlMeasureStyles,
+      controlMeasureLabelImages,
+      warnings,
+    } = createKMLString(opts, { packageRenderedLabels: true });
+
+    for (const labelImage of controlMeasureLabelImages) {
+      try {
+        const blob = await renderControlMeasureLabelBlob(labelImage);
+        data[labelImage.path] = await blobToUint8Array(blob);
+      } catch {
+        warnings.push(
+          `Control-measure label "${labelImage.text}" could not be rendered as an image.`,
+        );
+      }
+    }
 
     if (opts.embedIcons) {
       for (const [cacheKey, symbolData] of symbolDataCache) {

--- a/src/importexport/export/kmlExport.ts
+++ b/src/importexport/export/kmlExport.ts
@@ -12,6 +12,9 @@ import type { CustomSymbol, UnitSymbolOptions } from "@/types/scenarioModels.ts"
 import { getCustomSymbolId, getFullUnitSidc } from "@/symbology/helpers.ts";
 import { CUSTOM_SYMBOL_PREFIX } from "@/config/constants.ts";
 import { useMapSettingsStore } from "@/stores/mapSettingsStore.ts";
+import { controlMeasuresToKml } from "@/importexport/export/controlMeasureKml";
+import { isNTacticalGraphicLayerItem } from "@/types/scenarioLayerItems";
+import type { StyleSettings } from "@/extlib/tokml";
 
 type RenderSymbolSettings = {
   sidc: string;
@@ -52,6 +55,8 @@ export function useKmlExport(scenario: TScenario) {
   function createKMLString(opts: KmlKmzExportSettings) {
     const root: Root = { type: "root", children: [] };
     const symbolDataCache = new Map<string, RenderSymbolSettings>();
+    const controlMeasureStyles: StyleSettings[] = [];
+    const warnings: string[] = [];
 
     function createUnitsFolder(units: NUnit[], name: string): Folder {
       const { features } = convertUnitsToGeoJson(units, {
@@ -183,25 +188,53 @@ export function useKmlExport(scenario: TScenario) {
       }
     }
 
-    const features = opts.includeFeatures
-      ? convertScenarioFeaturesToGeoJson().features
-      : [];
-
     if (opts.includeFeatures) {
+      const scenarioLayers = geo.layerItemsLayers.value;
+      const controlMeasureItems = scenarioLayers
+        .flatMap((layer) => layer.items)
+        .filter(isNTacticalGraphicLayerItem);
+      const controlMeasures = controlMeasuresToKml(controlMeasureItems);
+      controlMeasureStyles.push(...controlMeasures.styles);
+      warnings.push(...controlMeasures.warnings);
+
+      const layerFolders: Folder[] = scenarioLayers.map((layer) => {
+        const layerControlMeasureIds = new Set(
+          layer.items.filter(isNTacticalGraphicLayerItem).map((item) => item.id),
+        );
+        // The ordinary GeoJSON path intentionally strips renderer paint and labels.
+        // Replace only its fanned-out control-measure features with the KML-specific
+        // render, leaving ordinary scenario features byte-for-byte compatible.
+        const features = convertScenarioFeaturesToGeoJson({}, layer.items)
+          .features.filter(
+            (feature) => !layerControlMeasureIds.has(String(feature.properties?.cmId)),
+          )
+          .concat(
+            controlMeasures.features.filter((feature) =>
+              layerControlMeasureIds.has(String(feature.properties?.cmId)),
+            ),
+          );
+
+        return {
+          type: "folder",
+          meta: { id: layer.id, name: layer.name },
+          children: features,
+        };
+      });
+
       root.children.push({
         type: "folder",
         meta: { name: "Scenario features" },
-        children: features,
+        children: layerFolders,
       });
     }
 
-    return { root, symbolDataCache };
+    return { root, symbolDataCache, controlMeasureStyles, warnings };
   }
 
   async function generateKml(opts: KmlKmzExportSettings): Promise<string> {
     const { foldersToKML } = await import("@/extlib/tokml");
-    const { root } = createKMLString(opts);
-    return foldersToKML(root, [], {
+    const { root, controlMeasureStyles } = createKMLString(opts);
+    return foldersToKML(root, controlMeasureStyles, {
       listStyle: opts.useRadioFolder ? "radioFolder" : undefined,
     });
   }
@@ -454,8 +487,8 @@ export function useKmlExport(scenario: TScenario) {
     const { foldersToKML } = await import("@/extlib/tokml");
     const data: Record<string, Uint8Array> = {};
     const hotspotCache = new Map<string, HotspotSettings>();
-    const warnings: string[] = [];
-    const { root, symbolDataCache } = createKMLString(opts);
+    const { root, symbolDataCache, controlMeasureStyles, warnings } =
+      createKMLString(opts);
 
     if (opts.embedIcons) {
       for (const [cacheKey, symbolData] of symbolDataCache) {
@@ -525,20 +558,25 @@ export function useKmlExport(scenario: TScenario) {
 
     const kmlString = foldersToKML(
       root,
-      [...symbolDataCache.keys()].map((cacheKey) => {
-        const symbolData = symbolDataCache.get(cacheKey);
-        const customEmbeddedLabel =
-          opts.embedIcons && opts.renderCustomIconLabels && symbolData?.kind === "custom";
-        return {
-          sidc: cacheKey,
-          labelScale: customEmbeddedLabel ? 0 : opts.labelScale,
-          iconScale: opts.iconScale,
-          xOffset: hotspotCache?.get(cacheKey)?.x,
-          yOffset: hotspotCache?.get(cacheKey)?.y,
-          xUnits: hotspotCache?.get(cacheKey)?.xUnits,
-          yUnits: hotspotCache?.get(cacheKey)?.yUnits,
-        };
-      }),
+      [
+        ...controlMeasureStyles,
+        ...[...symbolDataCache.keys()].map((cacheKey) => {
+          const symbolData = symbolDataCache.get(cacheKey);
+          const customEmbeddedLabel =
+            opts.embedIcons &&
+            opts.renderCustomIconLabels &&
+            symbolData?.kind === "custom";
+          return {
+            sidc: cacheKey,
+            labelScale: customEmbeddedLabel ? 0 : opts.labelScale,
+            iconScale: opts.iconScale,
+            xOffset: hotspotCache?.get(cacheKey)?.x,
+            yOffset: hotspotCache?.get(cacheKey)?.y,
+            xUnits: hotspotCache?.get(cacheKey)?.xUnits,
+            yUnits: hotspotCache?.get(cacheKey)?.yUnits,
+          };
+        }),
+      ],
       {
         listStyle: opts.useRadioFolder ? "radioFolder" : undefined,
       },

--- a/src/types/importExport.ts
+++ b/src/types/importExport.ts
@@ -81,6 +81,7 @@ export interface OrbatMapperExportSettings extends BaseExportSettings {
 
 export type FolderMode = "one" | "side" | "sideGroup";
 export type TimeMode = "current" | "event" | "multiple";
+export type KmlControlMeasureLabelMode = "native" | "rendered";
 
 export interface KmlKmzExportSettings {
   includeUnits: boolean;
@@ -97,6 +98,7 @@ export interface KmlKmzExportSettings {
   outlineWidth: number;
   renderAmplifiers: boolean;
   renderCustomIconLabels: boolean;
+  controlMeasureLabelMode: KmlControlMeasureLabelMode;
   timeMode: TimeMode;
   exportEventId?: EntityId;
   exportEventIds: EntityId[];

--- a/user-docs/guide/export-data.md
+++ b/user-docs/guide/export-data.md
@@ -25,6 +25,10 @@ KML (Keyhole Markup Language) is a format that uses XML. Mapping applications su
 geographic data. When you export to KML, you can easily send your scenario data to usual geospatial tools and show it
 there. For more data, see the [KML documentation](https://developers.google.com/kml/documentation).
 
+Control measures are exported as their complete rendered geometry with resolved line,
+fill, opacity, width, and label styling. KML has no portable dash-pattern or patterned-fill
+primitive, so those paint details use a solid fallback in KML/KMZ viewers.
+
 ![Google earh](images/google-earth.png)
 
 ## XLSX

--- a/user-docs/guide/export-data.md
+++ b/user-docs/guide/export-data.md
@@ -29,6 +29,12 @@ Control measures are exported as their complete rendered geometry with resolved 
 fill, opacity, width, and label styling. KML has no portable dash-pattern or patterned-fill
 primitive, so those paint details use a solid fallback in KML/KMZ viewers.
 
+KMZ export offers two control-measure label modes. **Native** keeps labels searchable and
+compact, but KML viewers draw them upright. **Rendered** embeds labels and text amplifiers
+as transparent images so their orientation, pixel size, anchor, typography, background,
+and halo are retained. Plain KML always uses native labels because it cannot package the
+required image assets.
+
 ![Google earh](images/google-earth.png)
 
 ## XLSX


### PR DESCRIPTION
## Summary
- Add native and rendered control-measure label modes for KML/KMZ export
- Embed rendered labels as rotated PNG images in KMZ files
- Preserve label typography, anchors, sizing, backgrounds, and halos
- Document compatibility fallbacks and update export warnings

## Testing
- Added unit tests for KML heading output, rendered label styles, and KMZ image packaging