### PR TITLE
Update scenario editor metadata and control measure settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "orbat-mapper",
   "description": "Order of Battle Mapper",
   "private": true,
-  "version": "1.4.2",
+  "version": "1.4.3",
   "repository": "github:orbat-mapper/orbat-mapper",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,10 @@
     "@heroicons/vue": "^2.2.0",
     "@iconify-prerendered/vue-mdi": "^0.28.1737398331",
     "@lucide/vue": "^1.31.0",
-    "@orbat-mapper/control-measures": "^0.4.0",
+    "@orbat-mapper/control-measures": "^0.5.0",
     "@orbat-mapper/convert-symbology": "^1.0.2",
-    "@orbat-mapper/tactical-draw": "^0.3.1",
-    "@orbat-mapper/tactical-draw-adapter-maplibre": "^0.2.3",
+    "@orbat-mapper/tactical-draw": "^0.3.2",
+    "@orbat-mapper/tactical-draw-adapter-maplibre": "^0.2.4",
     "@panzoom/panzoom": "^4.6.2",
     "@popperjs/core": "^2.11.8",
     "@protomaps/basemaps": "^5.7.2",
@@ -131,7 +131,7 @@
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "^4.3.3",
-    "@tsconfig/node24": "^24.0.4",
+    "@tsconfig/node24": "^24.0.5",
     "@types/d3-scale": "^4.0.9",
     "@types/d3-scale-chromatic": "^3.1.0",
     "@types/d3-selection": "^3.0.11",
@@ -165,7 +165,7 @@
     "vite-plugin-vue-devtools": "^8.2.1",
     "vitepress": "^1.6.4",
     "vitest": "^4.1.10",
-    "vue-tsc": "^3.3.9"
+    "vue-tsc": "^3.3.10"
   },
   "engines": {
     "node": "^20.19.0 || >=22.12.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,17 +42,17 @@ importers:
         specifier: ^1.31.0
         version: 1.31.0(vue@3.5.41(typescript@5.9.3))
       '@orbat-mapper/control-measures':
-        specifier: ^0.4.0
-        version: 0.4.0
+        specifier: ^0.5.0
+        version: 0.5.0
       '@orbat-mapper/convert-symbology':
         specifier: ^1.0.2
         version: 1.0.2
       '@orbat-mapper/tactical-draw':
-        specifier: ^0.3.1
-        version: 0.3.1(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))
+        specifier: ^0.3.2
+        version: 0.3.2(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))
       '@orbat-mapper/tactical-draw-adapter-maplibre':
-        specifier: ^0.2.3
-        version: 0.2.3(maplibre-gl@5.24.0)(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))
+        specifier: ^0.2.4
+        version: 0.2.4(maplibre-gl@5.24.0)(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))
       '@panzoom/panzoom':
         specifier: ^4.6.2
         version: 4.6.2
@@ -325,8 +325,8 @@ importers:
         specifier: ^4.3.3
         version: 4.3.3(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       '@tsconfig/node24':
-        specifier: ^24.0.4
-        version: 24.0.4
+        specifier: ^24.0.5
+        version: 24.0.5
       '@types/d3-scale':
         specifier: ^4.0.9
         version: 4.0.9
@@ -427,8 +427,8 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
       vue-tsc:
-        specifier: ^3.3.9
-        version: 3.3.9(typescript@5.9.3)
+        specifier: ^3.3.10
+        version: 3.3.10(typescript@5.9.3)
 
 packages:
 
@@ -1138,19 +1138,19 @@ packages:
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
 
-  '@orbat-mapper/control-measures@0.4.0':
-    resolution: {integrity: sha512-jp4OfukyAuNsxmweMX+ifl7V/UpDZbIuo0HHJY7ktrJ1XZl8TDHvj4khpReosiO9Q/y2IvVsfvIbl5LZsMNfEg==}
+  '@orbat-mapper/control-measures@0.5.0':
+    resolution: {integrity: sha512-VVcv/t9qfD7AuOSSbfza+DSV1VSx90gJFlVsUX0nX1WXkmMndWgqDypekuoYKgG64VSuZ/6tgOHUZix/WreXbQ==}
 
   '@orbat-mapper/convert-symbology@1.0.2':
     resolution: {integrity: sha512-FpnPXS16/C+ay7FVPLhTkRH2NmREKxhJ+pifqcW9NpsbORH94S14qU8Eyl2ofMP7upxQYNvw2qpTok5I3P4QKw==}
 
-  '@orbat-mapper/tactical-draw-adapter-maplibre@0.2.3':
-    resolution: {integrity: sha512-WIn3tJz68LZi630e54MmacT7qeR66j6koFV6JiDJ2Da3qKs2GMiD40guvWmc2kmxiBbCmXn31AA2y7mV8AQh5w==}
+  '@orbat-mapper/tactical-draw-adapter-maplibre@0.2.4':
+    resolution: {integrity: sha512-jkutb2224PnBKRkrrKmYfMWn+eDO+6n2KzbEtvRHXnF01GlZZaLHEPmPnb7xlj8/FrodBeHSCc3uRDITOrIg3A==}
     peerDependencies:
       maplibre-gl: '>=5.8.0 <6.0.0'
 
-  '@orbat-mapper/tactical-draw@0.3.1':
-    resolution: {integrity: sha512-8pN0i/8JkwFLnQbSOI33oXazuoo8/H+WdPICs9T/Dhk6vBevp/UB76lI6z7GXsMhDs3Q0heImuBUQPJWCdljiA==}
+  '@orbat-mapper/tactical-draw@0.3.2':
+    resolution: {integrity: sha512-8GKDjWljeZxtCMgRPUfCGTBBuYYrEB2k4HImusDg6JFMU0fC6HwllxyHMU6n/Z7GF1NcRX8AZNKzJNaIOK1BQg==}
     peerDependencies:
       vitest: '>=4.0.0'
     peerDependenciesMeta:
@@ -1648,8 +1648,8 @@ packages:
   '@tmcw/togeojson@7.1.2':
     resolution: {integrity: sha512-QKnFs9DAuqqBVj4d6c69tV1Dj2TspSBTqffivoN0YoBCVdP/JY1+WaYCJbzU49RkoU5NOSOJ3jtFHCdEUVh21A==}
 
-  '@tsconfig/node24@24.0.4':
-    resolution: {integrity: sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==}
+  '@tsconfig/node24@24.0.5':
+    resolution: {integrity: sha512-DWC54fGPuhZgg3Ighg4Y/A/bA3ZdB5hnzAuv/MkQ/X85sVsBsMQxu8t7khutdYeiNksBbFdDyeqv1HSW2Zl8aA==}
 
   '@turf/along@7.4.0':
     resolution: {integrity: sha512-uWh26sph1bJm3eO1toaoq9fbPRNxtbQlW/u0m04n7m6uFyGrUu4qE+8DTDQeF+cHGWbMQft4zshHZy0rz4Nyog==}
@@ -2300,8 +2300,8 @@ packages:
       typescript:
         optional: true
 
-  '@vue/language-core@3.3.9':
-    resolution: {integrity: sha512-in/68oAa4BCtVY6n/nkuhLIkV8DHYd2UivedJ6cMZ6UYtlq9jaoaSNUBHYCVO44z3nKg7MdE5OBoHKt5SxeBKQ==}
+  '@vue/language-core@3.3.10':
+    resolution: {integrity: sha512-CR7ByBbgPHqhxrioKPOcZBqttaozzLNwtkCzXQ+uF8gLPHnUe03srPnGpdtHD3zp+bq5iyVkZ1WNx7W564RPwg==}
 
   '@vue/reactivity@3.5.41':
     resolution: {integrity: sha512-rznsqKM0np0x18EjzF8x88MpEhdNsffbvFbckLL5+oUKz1BxAImEmO7J1ArRYSyo6aQaVoBDp7jEkT91OOxydA==}
@@ -2806,8 +2806,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  electron-to-chromium@1.5.405:
-    resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
+  electron-to-chromium@1.5.406:
+    resolution: {integrity: sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==}
 
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
@@ -3591,8 +3591,8 @@ packages:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
     engines: {node: '>=12.20.0'}
 
-  ohash@2.0.11:
-    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+  ohash@2.0.12:
+    resolution: {integrity: sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==}
 
   ol-ext@4.0.38:
     resolution: {integrity: sha512-fJmMcUYV8tfNhaHTl93eV1esBo1L8QHdOjJsBzapomgpmXiW7PGv91i6tmvXU4mL2z0gFrupuzs8BMLGi6T0QQ==}
@@ -3605,8 +3605,8 @@ packages:
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
 
-  open@11.0.0:
-    resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
+  open@11.0.1:
+    resolution: {integrity: sha512-NzwMUB6C1D0+Kd+9iMS/H4k+Ck3cTX6Ckyfr/gAGlmvSE1LUQZnEZvWBi4PYmMwH/S5SMeTXnE+9uAz8uF+pWw==}
     engines: {node: '>=20'}
 
   optionator@0.9.4:
@@ -3733,6 +3733,10 @@ packages:
 
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
+    engines: {node: '>=20'}
+
+  powershell-utils@0.2.0:
+    resolution: {integrity: sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==}
     engines: {node: '>=20'}
 
   preact@10.29.8:
@@ -4409,8 +4413,8 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
-  vue-component-type-helpers@3.3.9:
-    resolution: {integrity: sha512-3c/UfMe0SqyEfcGTyH7mfshHagJ9QTCbppCb0/uGpHZpFug7+If3GeGZN7I0YheKEExemx3xldQPoO7PQSOLQg==}
+  vue-component-type-helpers@3.3.10:
+    resolution: {integrity: sha512-t7IQivQ3oD4D01b7s7a9AWzHAcr3DGBIa/1jZREsFQJcFgSL92gqUkqNiHTYgzTt7QDuJa0I9wCeDwEtZICoBQ==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -4452,8 +4456,8 @@ packages:
       vite:
         optional: true
 
-  vue-tsc@3.3.9:
-    resolution: {integrity: sha512-TS3Y1ux/IRoE8OCP2PpACAeOseuIs0UvWrcr7u+w3PmfY+SlCfEf8zjrBgnQksHUgLpthi5vHlffcQTQTdPBZA==}
+  vue-tsc@3.3.10:
+    resolution: {integrity: sha512-YaDVxcW+CGtaOt3pZahMG5jYPx0hsUTxyEoPOTSMebcGUXP9lIBabQ14vfKMORb2CqqK5CxsNo/d1d+4IQwiKg==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -4534,8 +4538,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  wsl-utils@0.3.1:
-    resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
+  wsl-utils@1.0.0:
+    resolution: {integrity: sha512-Hl0ZOAs672vg+06kfujwRhoS6/jehvULrlFkuF2dRu6pHgA8U06h3xqNIqNNU1LTXPcedxByAR4GS6pwQK0mgA==}
     engines: {node: '>=20'}
 
   xast-util-to-xml@4.0.0:
@@ -5341,21 +5345,21 @@ snapshots:
 
   '@one-ini/wasm@0.1.1': {}
 
-  '@orbat-mapper/control-measures@0.4.0': {}
+  '@orbat-mapper/control-measures@0.5.0': {}
 
   '@orbat-mapper/convert-symbology@1.0.2': {}
 
-  '@orbat-mapper/tactical-draw-adapter-maplibre@0.2.3(maplibre-gl@5.24.0)(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))':
+  '@orbat-mapper/tactical-draw-adapter-maplibre@0.2.4(maplibre-gl@5.24.0)(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))':
     dependencies:
-      '@orbat-mapper/control-measures': 0.4.0
-      '@orbat-mapper/tactical-draw': 0.3.1(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))
+      '@orbat-mapper/control-measures': 0.5.0
+      '@orbat-mapper/tactical-draw': 0.3.2(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))
       maplibre-gl: 5.24.0
     transitivePeerDependencies:
       - vitest
 
-  '@orbat-mapper/tactical-draw@0.3.1(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))':
+  '@orbat-mapper/tactical-draw@0.3.2(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))':
     dependencies:
-      '@orbat-mapper/control-measures': 0.4.0
+      '@orbat-mapper/control-measures': 0.5.0
     optionalDependencies:
       vitest: 4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0))
 
@@ -5700,7 +5704,7 @@ snapshots:
 
   '@tmcw/togeojson@7.1.2': {}
 
-  '@tsconfig/node24@24.0.4': {}
+  '@tsconfig/node24@24.0.5': {}
 
   '@turf/along@7.4.0':
     dependencies:
@@ -7220,7 +7224,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/language-core@3.3.9':
+  '@vue/language-core@3.3.10':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.41
@@ -7259,7 +7263,7 @@ snapshots:
       '@vue/compiler-dom': 3.5.41
       js-beautify: 1.15.4
       vue: 3.5.41(typescript@5.9.3)
-      vue-component-type-helpers: 3.3.9
+      vue-component-type-helpers: 3.3.10
     optionalDependencies:
       '@vue/server-renderer': 3.5.41
 
@@ -7447,7 +7451,7 @@ snapshots:
     dependencies:
       baseline-browser-mapping: 2.11.14
       caniuse-lite: 1.0.30001809
-      electron-to-chromium: 1.5.405
+      electron-to-chromium: 1.5.406
       node-releases: 2.0.53
       update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
@@ -7644,7 +7648,7 @@ snapshots:
       minimatch: 9.0.9
       semver: 7.8.5
 
-  electron-to-chromium@1.5.405: {}
+  electron-to-chromium@1.5.406: {}
 
   emoji-regex-xs@1.0.0: {}
 
@@ -8412,7 +8416,7 @@ snapshots:
 
   obug@2.1.4: {}
 
-  ohash@2.0.11: {}
+  ohash@2.0.12: {}
 
   ol-ext@4.0.38(ol@10.10.0):
     dependencies:
@@ -8433,14 +8437,14 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
-  open@11.0.0:
+  open@11.0.1:
     dependencies:
       default-browser: 5.5.0
       define-lazy-prop: 3.0.0
       is-in-ssh: 1.0.0
       is-inside-container: 1.0.0
-      powershell-utils: 0.1.0
-      wsl-utils: 0.3.1
+      powershell-utils: 0.2.0
+      wsl-utils: 1.0.0
 
   optionator@0.9.4:
     dependencies:
@@ -8584,6 +8588,8 @@ snapshots:
 
   powershell-utils@0.1.0: {}
 
+  powershell-utils@0.2.0: {}
+
   preact@10.29.8: {}
 
   prelude-ls@1.2.1: {}
@@ -8668,7 +8674,7 @@ snapshots:
       '@vueuse/shared': 14.4.0(vue@3.5.41(typescript@5.9.3))
       aria-hidden: 1.2.6
       defu: 6.1.7
-      ohash: 2.0.11
+      ohash: 2.0.12
       vue: 3.5.41(typescript@5.9.3)
     transitivePeerDependencies:
       - '@vue/composition-api'
@@ -9023,8 +9029,8 @@ snapshots:
       ansis: 4.3.1
       error-stack-parser-es: 1.0.5
       obug: 2.1.4
-      ohash: 2.0.11
-      open: 11.0.0
+      ohash: 2.0.12
+      open: 11.0.1
       perfect-debounce: 2.1.0
       sirv: 3.0.2
       unplugin-utils: 0.3.2
@@ -9171,7 +9177,7 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-component-type-helpers@3.3.9: {}
+  vue-component-type-helpers@3.3.10: {}
 
   vue-demi@0.14.10(vue@3.5.41(typescript@5.9.3)):
     dependencies:
@@ -9229,10 +9235,10 @@ snapshots:
       - unloader
       - webpack
 
-  vue-tsc@3.3.9(typescript@5.9.3):
+  vue-tsc@3.3.10(typescript@5.9.3):
     dependencies:
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 3.3.9
+      '@vue/language-core': 3.3.10
       typescript: 5.9.3
 
   vue@3.5.41(typescript@5.9.3):
@@ -9295,7 +9301,7 @@ snapshots:
 
   ws@8.21.3: {}
 
-  wsl-utils@0.3.1:
+  wsl-utils@1.0.0:
     dependencies:
       is-wsl: 3.1.1
       powershell-utils: 0.1.0

--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.test.ts
@@ -73,6 +73,41 @@ describe("ControlMeasureAmplifiers", () => {
     expect(wrapper.emitted("update-options")).toEqual([[{ echelon: "brigade" }]]);
   });
 
+  it("shows and commits enum doctrinal fields from metadata", async () => {
+    const wrapper = mount(ControlMeasureAmplifiers, {
+      props: {
+        graphicKind: "minefield",
+        options: { mineType: "unspecified" },
+      },
+      global: { stubs: { ControlMeasurePreview: PreviewStub } },
+    });
+
+    expect(wrapper.text()).toContain("Mine type");
+    expect(wrapper.text()).toContain("Modifier 1 (symbol set 25 values 13–18).");
+    expect(
+      wrapper.get("#cm-doctrinal-mineType").element.closest("[data-slot='field']"),
+    ).not.toBeNull();
+    await wrapper.get("#cm-doctrinal-mineType").setValue("antitank");
+
+    expect(wrapper.emitted("update-options")).toEqual([[{ mineType: "antitank" }]]);
+  });
+
+  it("shows and commits text doctrinal fields from metadata", async () => {
+    const wrapper = mount(ControlMeasureAmplifiers, {
+      props: {
+        graphicKind: "light-line",
+        options: { phaseLineName: "ALPHA" },
+      },
+      global: { stubs: { ControlMeasurePreview: PreviewStub } },
+    });
+    const input = wrapper.get("#cm-doctrinal-phaseLineName");
+
+    expect((input.element as HTMLInputElement).value).toBe("ALPHA");
+    await input.setValue("BRAVO");
+
+    expect(wrapper.emitted("update-options")).toEqual([[{ phaseLineName: "BRAVO" }]]);
+  });
+
   it("keeps strong-point preview geometry representative while reflecting its echelon", () => {
     const wrapper = mount(ControlMeasureAmplifiers, {
       props: {
@@ -145,6 +180,8 @@ describe("ControlMeasureAmplifiers", () => {
       global: { stubs: { ControlMeasurePreview: PreviewStub } },
     });
 
-    expect(wrapper.text()).toContain("This control measure has no text amplifiers.");
+    expect(wrapper.text()).toContain(
+      "This control measure has no doctrinal amplifier fields.",
+    );
   });
 });

--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
@@ -3,8 +3,8 @@ import { computed, ref, watch } from "vue";
 import {
   CONTROL_MEASURE_METADATA,
   getDefaultOptions,
-  resolveParameterSemanticRole,
 } from "@orbat-mapper/control-measures";
+import { doctrinalControlMeasureParams } from "@/modules/scenarioeditor/controlMeasureStyleOptions";
 import type {
   ControlMeasureId,
   TextAmplifierDescriptor,
@@ -33,10 +33,13 @@ const emit = defineEmits<{
 const descriptors = computed<readonly TextAmplifierDescriptor[]>(
   () => CONTROL_MEASURE_METADATA[props.graphicKind]?.textAmplifiers ?? [],
 );
-const hasDoctrinalParameters = computed(() =>
-  (CONTROL_MEASURE_METADATA[props.graphicKind]?.params ?? []).some(
-    (parameter) => resolveParameterSemanticRole(parameter) === "doctrinal",
-  ),
+// The same filter the child renders from, so the section and the "nothing here"
+// message can never disagree.
+const hasDoctrinalParameters = computed(
+  () =>
+    doctrinalControlMeasureParams(props.graphicKind, props.options, {
+      includeText: true,
+    }).length > 0,
 );
 const previewAmplifiers = computed<TextAmplifiers>(() =>
   Object.fromEntries(

--- a/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
+++ b/src/modules/scenarioeditor/ControlMeasureAmplifiers.vue
@@ -3,6 +3,7 @@ import { computed, ref, watch } from "vue";
 import {
   CONTROL_MEASURE_METADATA,
   getDefaultOptions,
+  resolveParameterSemanticRole,
 } from "@orbat-mapper/control-measures";
 import type {
   ControlMeasureId,
@@ -15,7 +16,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
 import ControlMeasurePreview from "@/modules/scenarioeditor/ControlMeasurePreview.vue";
-import ControlMeasureEchelonSelect from "@/modules/scenarioeditor/ControlMeasureEchelonSelect.vue";
+import ControlMeasureDoctrinalParameters from "@/modules/scenarioeditor/ControlMeasureDoctrinalParameters.vue";
 import type { TacticalGraphicOptions } from "@/types/scenarioLayerItems";
 
 const props = defineProps<{
@@ -31,6 +32,11 @@ const emit = defineEmits<{
 
 const descriptors = computed<readonly TextAmplifierDescriptor[]>(
   () => CONTROL_MEASURE_METADATA[props.graphicKind]?.textAmplifiers ?? [],
+);
+const hasDoctrinalParameters = computed(() =>
+  (CONTROL_MEASURE_METADATA[props.graphicKind]?.params ?? []).some(
+    (parameter) => resolveParameterSemanticRole(parameter) === "doctrinal",
+  ),
 );
 const previewAmplifiers = computed<TextAmplifiers>(() =>
   Object.fromEntries(
@@ -119,9 +125,12 @@ function commitGenericText() {
       </div>
     </div>
 
-    <ControlMeasureEchelonSelect
+    <ControlMeasureDoctrinalParameters
+      v-if="hasDoctrinalParameters"
       :graphic-kind="graphicKind"
       :options="options"
+      include-text
+      field-layout
       @update="emit('update-options', $event)"
     />
 
@@ -171,8 +180,11 @@ function commitGenericText() {
         />
       </div>
     </div>
-    <p v-else-if="!isGenericText" class="text-muted-foreground text-sm">
-      This control measure has no text amplifiers.
+    <p
+      v-else-if="!isGenericText && !hasDoctrinalParameters"
+      class="text-muted-foreground text-sm"
+    >
+      This control measure has no doctrinal amplifier fields.
     </p>
   </div>
 </template>

--- a/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.test.ts
@@ -6,6 +6,7 @@ import { createPinia, setActivePinia } from "pinia";
 import ControlMeasureDefaultsPopover from "@/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue";
 import ControlMeasureStyleSettings from "@/modules/scenarioeditor/ControlMeasureStyleSettings.vue";
 import SymbolCodeSelect from "@/components/SymbolCodeSelect.vue";
+import { NativeSelect } from "@/components/ui/native-select";
 import { activeScenarioKey, scenarioDrawKey } from "@/components/injects";
 import { useSelectedItems } from "@/stores/selectedStore";
 import { useControlMeasureToolStore } from "@/stores/controlMeasureToolStore";
@@ -28,7 +29,7 @@ vi.mock("@/modules/scenarioeditor/ControlMeasureColorPicker.vue", () => ({
 
 vi.mock("@/components/ui/slider", () => ({
   Slider: defineComponent({
-    name: "Slider",
+    name: "SliderStub",
     props: ["modelValue", "min", "max", "step", "disabled"],
     emits: ["update:modelValue"],
     template: "<div />",
@@ -146,6 +147,21 @@ describe("ControlMeasureDefaultsPopover", () => {
     expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
       options: { echelon: "brigade" },
     });
+  });
+
+  it("derives non-text doctrinal parameters from the control-measure metadata", async () => {
+    const { wrapper } = mountPopover([]);
+    const store = useControlMeasureToolStore();
+    store.lastKind = "minefield";
+    await nextTick();
+
+    expect(wrapper.text()).toContain("Mine type");
+    const select = wrapper.findComponent(NativeSelect);
+    expect(select.exists()).toBe(true);
+
+    await wrapper.get("#cm-doctrinal-mineType").setValue("antitank");
+    await nextTick();
+    expect(store.defaults.options).toEqual({ mineType: "antitank" });
   });
 
   it("preserves unrelated styling when changing a multi-selection", async () => {

--- a/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDefaultsPopover.vue
@@ -17,7 +17,7 @@ import PanelDataGrid from "@/components/PanelDataGrid.vue";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useControlMeasureToolStore } from "@/stores/controlMeasureToolStore";
 import ControlMeasureStyleSettings from "@/modules/scenarioeditor/ControlMeasureStyleSettings.vue";
-import ControlMeasureEchelonSelect from "@/modules/scenarioeditor/ControlMeasureEchelonSelect.vue";
+import ControlMeasureDoctrinalParameters from "@/modules/scenarioeditor/ControlMeasureDoctrinalParameters.vue";
 import type { ControlMeasureStyleUpdate } from "@/modules/scenarioeditor/controlMeasureStyleOptions";
 import { activeScenarioKey, scenarioDrawKey } from "@/components/injects";
 import { useSelectedItems } from "@/stores/selectedStore";
@@ -193,10 +193,9 @@ function updateSettings(data: ControlMeasureStyleUpdate) {
           :options="editedOptions"
           @update="updateSettings"
         />
-        <ControlMeasureEchelonSelect
+        <ControlMeasureDoctrinalParameters
           :graphic-kind="editedKind"
           :options="editedOptions"
-          inline
           @update="updateSettings({ options: $event })"
         />
       </PanelDataGrid>

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -47,6 +47,13 @@ const ControlMeasureAmplifiersStub = defineComponent({
   template: "<div data-test='amplifier-settings' />",
 });
 
+const ControlMeasureExtendedStyleSettingsStub = defineComponent({
+  name: "ControlMeasureExtendedStyleSettings",
+  props: ["graphicKind", "options"],
+  emits: ["update"],
+  template: "<div data-test='extended-style-settings' />",
+});
+
 const ControlMeasureEchelonSelectStub = defineComponent({
   name: "ControlMeasureEchelonSelect",
   props: {
@@ -69,6 +76,7 @@ const baseStubs = {
   ScrollTabs: ScrollTabsStub,
   TabsContent: { template: "<section><slot /></section>" },
   ControlMeasureStyleSettings: ControlMeasureStyleSettingsStub,
+  ControlMeasureExtendedStyleSettings: ControlMeasureExtendedStyleSettingsStub,
   ControlMeasureAmplifiers: ControlMeasureAmplifiersStub,
   ControlMeasureEchelonSelect: ControlMeasureEchelonSelectStub,
   ScenarioLayerItemState: true,
@@ -153,7 +161,7 @@ describe("ControlMeasureDetails tabs", () => {
     useSelectedItems().clear();
   });
 
-  it("shows Style, Amplifiers, Details and State, with Debug gated by debug mode", async () => {
+  it("shows styling, amplifier, details and state tabs, with Debug gated by debug mode", async () => {
     const uiStore = useUiStore();
     const tabStore = useTabStore();
     const { wrapper } = mountDetails();
@@ -161,22 +169,24 @@ describe("ControlMeasureDetails tabs", () => {
 
     expect(tabs.props("items")).toEqual([
       { label: "Style", value: "0" },
-      { label: "Amplifiers", value: "1" },
-      { label: "Details", value: "2" },
-      { label: "State", value: "3" },
+      { label: "Extended styling", value: "1" },
+      { label: "Amplifiers", value: "2" },
+      { label: "Details", value: "3" },
+      { label: "State", value: "4" },
     ]);
 
     uiStore.debugMode = true;
     await nextTick();
     expect(tabs.props("items")).toEqual([
       { label: "Style", value: "0" },
-      { label: "Amplifiers", value: "1" },
-      { label: "Details", value: "2" },
-      { label: "State", value: "3" },
-      { label: "Debug", value: "4" },
+      { label: "Extended styling", value: "1" },
+      { label: "Amplifiers", value: "2" },
+      { label: "Details", value: "3" },
+      { label: "State", value: "4" },
+      { label: "Debug", value: "5" },
     ]);
 
-    tabStore.controlMeasureDetailsTab = 4;
+    tabStore.controlMeasureDetailsTab = 5;
     uiStore.debugMode = false;
     await nextTick();
     expect(tabStore.controlMeasureDetailsTab).toBe(0);
@@ -184,7 +194,7 @@ describe("ControlMeasureDetails tabs", () => {
 
   it("falls back from a remembered Debug tab when mounting outside debug mode", () => {
     const tabStore = useTabStore();
-    tabStore.controlMeasureDetailsTab = 4;
+    tabStore.controlMeasureDetailsTab = 5;
 
     mountDetails();
 
@@ -236,7 +246,7 @@ describe("ControlMeasureDetails tabs", () => {
   it("uses independent tab state for the palette and edit-data actions", async () => {
     const tabStore = useTabStore();
     tabStore.featureDetailsTab = 2;
-    tabStore.controlMeasureDetailsTab = 2;
+    tabStore.controlMeasureDetailsTab = 3;
     const { wrapper } = mountDetails();
 
     await wrapper.find("button[title='Change control measure style']").trigger("click");
@@ -244,7 +254,7 @@ describe("ControlMeasureDetails tabs", () => {
     expect(tabStore.featureDetailsTab).toBe(2);
 
     await wrapper.find("button[title='Edit data']").trigger("click");
-    expect(tabStore.controlMeasureDetailsTab).toBe(2);
+    expect(tabStore.controlMeasureDetailsTab).toBe(3);
   });
 
   it("writes text amplifiers through the settle-first control-measure path", async () => {
@@ -277,6 +287,22 @@ describe("ControlMeasureDetails tabs", () => {
 
     expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
       options: { text: "BRAVO", textAlign: "center" },
+    });
+  });
+
+  it("writes extended styling options through the settle-first path", async () => {
+    const { wrapper, updateControlMeasure } = mountDetails({
+      graphicKind: "classic-arrow",
+      options: { arrowheadStyle: "triangle" },
+    });
+    const settings = wrapper.findComponent(ControlMeasureExtendedStyleSettingsStub);
+
+    expect(settings.props("graphicKind")).toBe("classic-arrow");
+    expect(settings.props("options")).toEqual({ arrowheadStyle: "triangle" });
+    await settings.vm.$emit("update", { arrowheadStyle: "barbed" });
+
+    expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
+      options: { arrowheadStyle: "barbed" },
     });
   });
 

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -47,13 +47,6 @@ const ControlMeasureAmplifiersStub = defineComponent({
   template: "<div data-test='amplifier-settings' />",
 });
 
-const ControlMeasureExtendedStyleSettingsStub = defineComponent({
-  name: "ControlMeasureExtendedStyleSettings",
-  props: ["graphicKind", "options"],
-  emits: ["update"],
-  template: "<div data-test='extended-style-settings' />",
-});
-
 const ControlMeasureEchelonSelectStub = defineComponent({
   name: "ControlMeasureEchelonSelect",
   props: {
@@ -76,7 +69,6 @@ const baseStubs = {
   ScrollTabs: ScrollTabsStub,
   TabsContent: { template: "<section><slot /></section>" },
   ControlMeasureStyleSettings: ControlMeasureStyleSettingsStub,
-  ControlMeasureExtendedStyleSettings: ControlMeasureExtendedStyleSettingsStub,
   ControlMeasureAmplifiers: ControlMeasureAmplifiersStub,
   ControlMeasureEchelonSelect: ControlMeasureEchelonSelectStub,
   ScenarioLayerItemState: true,
@@ -169,7 +161,6 @@ describe("ControlMeasureDetails tabs", () => {
 
     expect(tabs.props("items")).toEqual([
       { label: "Style", value: "0" },
-      { label: "Extended styling", value: "1" },
       { label: "Amplifiers", value: "2" },
       { label: "Details", value: "3" },
       { label: "State", value: "4" },
@@ -179,7 +170,6 @@ describe("ControlMeasureDetails tabs", () => {
     await nextTick();
     expect(tabs.props("items")).toEqual([
       { label: "Style", value: "0" },
-      { label: "Extended styling", value: "1" },
       { label: "Amplifiers", value: "2" },
       { label: "Details", value: "3" },
       { label: "State", value: "4" },
@@ -287,22 +277,6 @@ describe("ControlMeasureDetails tabs", () => {
 
     expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
       options: { text: "BRAVO", textAlign: "center" },
-    });
-  });
-
-  it("writes extended styling options through the settle-first path", async () => {
-    const { wrapper, updateControlMeasure } = mountDetails({
-      graphicKind: "classic-arrow",
-      options: { arrowheadStyle: "triangle" },
-    });
-    const settings = wrapper.findComponent(ControlMeasureExtendedStyleSettingsStub);
-
-    expect(settings.props("graphicKind")).toBe("classic-arrow");
-    expect(settings.props("options")).toEqual({ arrowheadStyle: "triangle" });
-    await settings.vm.$emit("update", { arrowheadStyle: "barbed" });
-
-    expect(updateControlMeasure).toHaveBeenCalledWith("cm-1", {
-      options: { arrowheadStyle: "barbed" },
     });
   });
 

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -199,6 +199,18 @@ describe("ControlMeasureDetails tabs", () => {
     );
   });
 
+  it("shows the catalog identity and geometry metadata in the Details tab", () => {
+    const { wrapper } = mountDetails();
+    const text = wrapper.text().replace(/\s+/g, "");
+
+    expect(text).toContain("EntityManeuverLines");
+    expect(text).toContain("TypePhaseLine");
+    expect(text).toContain("GeometryLine");
+    expect(text).toContain("Requiredpoints2+");
+    expect(text).toContain("Symbolcode140300");
+    expect(text).toContain("Currentpoints2");
+  });
+
   // Duplication goes through the armed-tool owner, which owns settling the open
   // shape session. The behaviour itself is covered by useScenarioDraw.test.ts.
   it("duplicates the selected control measure from the details toolbar", async () => {

--- a/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.test.ts
@@ -199,16 +199,17 @@ describe("ControlMeasureDetails tabs", () => {
     );
   });
 
-  it("shows the catalog identity and geometry metadata in the Details tab", () => {
+  it("shows only the requested catalog metadata in the Details tab", () => {
     const { wrapper } = mountDetails();
     const text = wrapper.text().replace(/\s+/g, "");
 
+    expect(text).toContain("KindPhaseline");
     expect(text).toContain("EntityManeuverLines");
     expect(text).toContain("TypePhaseLine");
-    expect(text).toContain("GeometryLine");
-    expect(text).toContain("Requiredpoints2+");
-    expect(text).toContain("Symbolcode140300");
-    expect(text).toContain("Currentpoints2");
+    expect(text).not.toContain("Geometry");
+    expect(text).not.toContain("Requiredpoints");
+    expect(text).not.toContain("Symbolcode");
+    expect(text).not.toContain("Currentpoints");
   });
 
   // Duplication goes through the armed-tool owner, which owns settling the open

--- a/src/modules/scenarioeditor/ControlMeasureDetails.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.vue
@@ -54,7 +54,6 @@ import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue"
 import PanelTitle from "@/modules/scenarioeditor/PanelTitle.vue";
 import PanelDataGrid from "@/components/PanelDataGrid.vue";
 import ControlMeasureStyleSettings from "@/modules/scenarioeditor/ControlMeasureStyleSettings.vue";
-import ControlMeasureExtendedStyleSettings from "@/modules/scenarioeditor/ControlMeasureExtendedStyleSettings.vue";
 import ControlMeasureEchelonSelect from "@/modules/scenarioeditor/ControlMeasureEchelonSelect.vue";
 import ControlMeasureAmplifiers from "@/modules/scenarioeditor/ControlMeasureAmplifiers.vue";
 import EditableLabel from "@/components/EditableLabel.vue";
@@ -82,7 +81,6 @@ const { controlMeasureDetailsTab: selectedTab } = storeToRefs(useTabStore());
 const tabList = computed(() => {
   const tabs = [
     { label: "Style", value: "0" },
-    { label: "Extended styling", value: "1" },
     { label: "Amplifiers", value: "2" },
     { label: "Details", value: "3" },
     { label: "State", value: "4" },
@@ -387,17 +385,6 @@ function doDelete() {
               @update="doControlMeasureOptionsUpdate"
             />
           </PanelDataGrid>
-        </TabsContent>
-        <TabsContent value="1" class="mx-4">
-          <ControlMeasureExtendedStyleSettings
-            v-if="supported"
-            :graphic-kind="item.graphicKind"
-            :options="resolvedOptions"
-            @update="doControlMeasureOptionsUpdate"
-          />
-          <p v-else class="text-muted-foreground pt-4 text-sm">
-            Extended styling is unavailable for this unsupported control measure.
-          </p>
         </TabsContent>
         <TabsContent value="2" class="mx-4">
           <ControlMeasureAmplifiers

--- a/src/modules/scenarioeditor/ControlMeasureDetails.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.vue
@@ -54,6 +54,7 @@ import DetailsPanelHeader from "@/modules/scenarioeditor/DetailsPanelHeader.vue"
 import PanelTitle from "@/modules/scenarioeditor/PanelTitle.vue";
 import PanelDataGrid from "@/components/PanelDataGrid.vue";
 import ControlMeasureStyleSettings from "@/modules/scenarioeditor/ControlMeasureStyleSettings.vue";
+import ControlMeasureExtendedStyleSettings from "@/modules/scenarioeditor/ControlMeasureExtendedStyleSettings.vue";
 import ControlMeasureEchelonSelect from "@/modules/scenarioeditor/ControlMeasureEchelonSelect.vue";
 import ControlMeasureAmplifiers from "@/modules/scenarioeditor/ControlMeasureAmplifiers.vue";
 import EditableLabel from "@/components/EditableLabel.vue";
@@ -81,11 +82,12 @@ const { controlMeasureDetailsTab: selectedTab } = storeToRefs(useTabStore());
 const tabList = computed(() => {
   const tabs = [
     { label: "Style", value: "0" },
-    { label: "Amplifiers", value: "1" },
-    { label: "Details", value: "2" },
-    { label: "State", value: "3" },
+    { label: "Extended styling", value: "1" },
+    { label: "Amplifiers", value: "2" },
+    { label: "Details", value: "3" },
+    { label: "State", value: "4" },
   ];
-  if (uiStore.debugMode) tabs.push({ label: "Debug", value: "4" });
+  if (uiStore.debugMode) tabs.push({ label: "Debug", value: "5" });
   return tabs;
 });
 
@@ -99,7 +101,7 @@ const selectedTabString = computed({
 watch(
   () => uiStore.debugMode,
   (debugMode) => {
-    if (!debugMode && selectedTab.value === 4) selectedTab.value = 0;
+    if (!debugMode && selectedTab.value === 5) selectedTab.value = 0;
   },
   { immediate: true },
 );
@@ -163,7 +165,7 @@ watch(
 const isEditMode = ref(false);
 function toggleEditMode() {
   isEditMode.value = !isEditMode.value;
-  selectedTab.value = 2;
+  selectedTab.value = 3;
 }
 
 function showStylePanel() {
@@ -387,6 +389,17 @@ function doDelete() {
           </PanelDataGrid>
         </TabsContent>
         <TabsContent value="1" class="mx-4">
+          <ControlMeasureExtendedStyleSettings
+            v-if="supported"
+            :graphic-kind="item.graphicKind"
+            :options="resolvedOptions"
+            @update="doControlMeasureOptionsUpdate"
+          />
+          <p v-else class="text-muted-foreground pt-4 text-sm">
+            Extended styling is unavailable for this unsupported control measure.
+          </p>
+        </TabsContent>
+        <TabsContent value="2" class="mx-4">
           <ControlMeasureAmplifiers
             v-if="supported"
             :graphic-kind="item.graphicKind as ControlMeasureId"
@@ -399,7 +412,7 @@ function doDelete() {
             Amplifiers are unavailable for this unsupported control measure.
           </p>
         </TabsContent>
-        <TabsContent value="2" class="mx-4">
+        <TabsContent value="3" class="mx-4">
           <PanelDataGrid class="mt-4">
             <div class="text-muted-foreground">Kind</div>
             <div class="truncate">{{ kindName }}</div>
@@ -430,12 +443,12 @@ function doDelete() {
             <div v-html="hDescription"></div>
           </div>
         </TabsContent>
-        <TabsContent value="3" class="mx-4">
+        <TabsContent value="4" class="mx-4">
           <ScenarioLayerItemState :item="item" heading="Control measure state" />
         </TabsContent>
         <TabsContent
           v-if="uiStore.debugMode"
-          value="4"
+          value="5"
           class="prose prose-sm dark:prose-invert mx-4 max-w-none"
         >
           <pre>{{ item }}</pre>

--- a/src/modules/scenarioeditor/ControlMeasureDetails.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.vue
@@ -40,7 +40,6 @@ import { useTabStore } from "@/stores/tabStore";
 import { renderMarkdown } from "@/composables/formatting";
 import { getGeometryIcon } from "@/modules/scenarioeditor/featureLayerUtils";
 import {
-  resolveControlMeasureControlPoints,
   resolveControlMeasureOptions,
   resolveControlMeasureStyle,
 } from "@/geo/controlMeasures";
@@ -145,30 +144,8 @@ const kindMetadata = computed(() => {
   return CONTROL_MEASURE_METADATA[kind as ControlMeasureId];
 });
 
-const coordinateRequirement = computed(() => {
-  const metadata = kindMetadata.value;
-  if (!metadata) return "";
-  const { minCoordinates: min, maxCoordinates: max } = metadata;
-  if (min === undefined && max === undefined) return "Unspecified";
-  if (min !== undefined && max !== undefined && min === max) return String(min);
-  if (min !== undefined && max !== undefined) return `${min}–${max}`;
-  if (min !== undefined) return `${min}+`;
-  return `Up to ${max}`;
-});
-
-const geometryLabel = computed(() => {
-  const geometry = kindMetadata.value?.geometry;
-  return geometry ? geometry.charAt(0).toUpperCase() + geometry.slice(1) : "";
-});
-
-// The **projected** points, like `strokeColor` above and like the map: a recorded
-// shape patch replaces `controlPoints` at the current time, so the top-level array
-// would disagree with what is drawn.
-const controlPointCount = computed(() =>
-  item.value ? resolveControlMeasureControlPoints(item.value).length : 0,
-);
-// Projected too, for the same reason as `strokeColor` and `controlPointCount`: a
-// recorded options patch is what the map is drawing with at the current time.
+// Projected like `strokeColor` above: a recorded options patch is what the map is
+// drawing with at the current time.
 const resolvedOptions = computed(() =>
   item.value ? resolveControlMeasureOptions(item.value) : undefined,
 );
@@ -430,21 +407,8 @@ function doDelete() {
               <div class="text-muted-foreground">Entity</div>
               <div>{{ kindMetadata.entity }}</div>
               <div class="text-muted-foreground">Type</div>
-              <div>
-                {{ kindMetadata.entityType }}
-                <span v-if="kindMetadata.entitySubtype">
-                  / {{ kindMetadata.entitySubtype }}
-                </span>
-              </div>
-              <div class="text-muted-foreground">Geometry</div>
-              <div>{{ geometryLabel }}</div>
-              <div class="text-muted-foreground">Required points</div>
-              <div>{{ coordinateRequirement }}</div>
-              <div class="text-muted-foreground">Symbol code</div>
-              <div class="font-mono text-xs">{{ kindMetadata.value }}</div>
+              <div>{{ kindMetadata.entityType }}</div>
             </template>
-            <div class="text-muted-foreground">Current points</div>
-            <div>{{ controlPointCount }}</div>
           </PanelDataGrid>
 
           <p

--- a/src/modules/scenarioeditor/ControlMeasureDetails.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDetails.vue
@@ -139,6 +139,28 @@ const kindDescription = computed(() => {
   return CONTROL_MEASURE_METADATA[kind as ControlMeasureId]?.description ?? "";
 });
 
+const kindMetadata = computed(() => {
+  const kind = item.value?.graphicKind;
+  if (!kind || !supported.value) return undefined;
+  return CONTROL_MEASURE_METADATA[kind as ControlMeasureId];
+});
+
+const coordinateRequirement = computed(() => {
+  const metadata = kindMetadata.value;
+  if (!metadata) return "";
+  const { minCoordinates: min, maxCoordinates: max } = metadata;
+  if (min === undefined && max === undefined) return "Unspecified";
+  if (min !== undefined && max !== undefined && min === max) return String(min);
+  if (min !== undefined && max !== undefined) return `${min}–${max}`;
+  if (min !== undefined) return `${min}+`;
+  return `Up to ${max}`;
+});
+
+const geometryLabel = computed(() => {
+  const geometry = kindMetadata.value?.geometry;
+  return geometry ? geometry.charAt(0).toUpperCase() + geometry.slice(1) : "";
+});
+
 // The **projected** points, like `strokeColor` above and like the map: a recorded
 // shape patch replaces `controlPoints` at the current time, so the top-level array
 // would disagree with what is drawn.
@@ -404,7 +426,24 @@ function doDelete() {
           <PanelDataGrid class="mt-4">
             <div class="text-muted-foreground">Kind</div>
             <div class="truncate">{{ kindName }}</div>
-            <div class="text-muted-foreground">Points</div>
+            <template v-if="kindMetadata">
+              <div class="text-muted-foreground">Entity</div>
+              <div>{{ kindMetadata.entity }}</div>
+              <div class="text-muted-foreground">Type</div>
+              <div>
+                {{ kindMetadata.entityType }}
+                <span v-if="kindMetadata.entitySubtype">
+                  / {{ kindMetadata.entitySubtype }}
+                </span>
+              </div>
+              <div class="text-muted-foreground">Geometry</div>
+              <div>{{ geometryLabel }}</div>
+              <div class="text-muted-foreground">Required points</div>
+              <div>{{ coordinateRequirement }}</div>
+              <div class="text-muted-foreground">Symbol code</div>
+              <div class="font-mono text-xs">{{ kindMetadata.value }}</div>
+            </template>
+            <div class="text-muted-foreground">Current points</div>
             <div>{{ controlPointCount }}</div>
           </PanelDataGrid>
 

--- a/src/modules/scenarioeditor/ControlMeasureDoctrinalParameters.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDoctrinalParameters.vue
@@ -98,7 +98,7 @@ function updateText(parameter: Extract<ParamDescriptor, { type: "text" }>, event
         class="w-full"
         wrapper-class="w-full"
         :title="parameter.description"
-        :model-value="valueFor(parameter)"
+        :model-value="valueFor(parameter) as string | number | undefined"
         @update:model-value="updateOption(parameter.key, $event)"
       >
         <NativeSelectOption

--- a/src/modules/scenarioeditor/ControlMeasureDoctrinalParameters.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDoctrinalParameters.vue
@@ -1,10 +1,9 @@
 <script setup lang="ts">
 import { computed, toRaw } from "vue";
 import {
-  CONTROL_MEASURE_METADATA,
-  getDefaultOptions,
-  resolveParameterSemanticRole,
-} from "@orbat-mapper/control-measures";
+  doctrinalControlMeasureParams,
+  effectiveControlMeasureOptions,
+} from "@/modules/scenarioeditor/controlMeasureStyleOptions";
 import type {
   ControlMeasureId,
   ControlMeasureKind,
@@ -30,28 +29,20 @@ const emit = defineEmits<{
   (e: "update", value: TacticalGraphicOptions): void;
 }>();
 
-const effectiveOptions = computed<Record<string, unknown>>(() => ({
-  ...(props.graphicKind
-    ? (getDefaultOptions(props.graphicKind as ControlMeasureId) as Record<
-        string,
-        unknown
-      >)
-    : undefined),
-  ...(props.options as Record<string, unknown> | undefined),
-}));
+const effectiveOptions = computed(() =>
+  effectiveControlMeasureOptions(props.graphicKind, props.options),
+);
 
 /**
  * The compact toolbar omits text parameters; the amplifier panel opts into them.
  * Both surfaces follow the registry so a newly added doctrinal field does not require
  * another kind-specific component.
  */
-const parameters = computed(() => {
-  if (!props.graphicKind) return [];
-  return (CONTROL_MEASURE_METADATA[props.graphicKind as ControlMeasureId]?.params ?? [])
-    .filter((parameter) => props.includeText || parameter.type !== "text")
-    .filter((parameter) => resolveParameterSemanticRole(parameter) === "doctrinal")
-    .filter((parameter) => parameter.visibleWhen?.(effectiveOptions.value) ?? true);
-});
+const parameters = computed(() =>
+  doctrinalControlMeasureParams(props.graphicKind, props.options, {
+    includeText: props.includeText,
+  }),
+);
 
 function valueFor(parameter: ParamDescriptor): string | number | boolean | undefined {
   return effectiveOptions.value[parameter.key] as string | number | boolean | undefined;

--- a/src/modules/scenarioeditor/ControlMeasureDoctrinalParameters.vue
+++ b/src/modules/scenarioeditor/ControlMeasureDoctrinalParameters.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { computed, toRaw } from "vue";
+import {
+  CONTROL_MEASURE_METADATA,
+  getDefaultOptions,
+  resolveParameterSemanticRole,
+} from "@orbat-mapper/control-measures";
+import type {
+  ControlMeasureId,
+  ControlMeasureKind,
+  ParamDescriptor,
+} from "@orbat-mapper/control-measures";
+import { Input } from "@/components/ui/input";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import ControlMeasureColorPicker from "@/modules/scenarioeditor/ControlMeasureColorPicker.vue";
+import ControlMeasureEchelonSelect from "@/modules/scenarioeditor/ControlMeasureEchelonSelect.vue";
+import type { TacticalGraphicOptions } from "@/types/scenarioLayerItems";
+
+const props = defineProps<{
+  graphicKind?: ControlMeasureKind;
+  options?: TacticalGraphicOptions;
+  includeText?: boolean;
+  fieldLayout?: boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "update", value: TacticalGraphicOptions): void;
+}>();
+
+const effectiveOptions = computed<Record<string, unknown>>(() => ({
+  ...(props.graphicKind
+    ? (getDefaultOptions(props.graphicKind as ControlMeasureId) as Record<
+        string,
+        unknown
+      >)
+    : undefined),
+  ...(props.options as Record<string, unknown> | undefined),
+}));
+
+/**
+ * The compact toolbar omits text parameters; the amplifier panel opts into them.
+ * Both surfaces follow the registry so a newly added doctrinal field does not require
+ * another kind-specific component.
+ */
+const parameters = computed(() => {
+  if (!props.graphicKind) return [];
+  return (CONTROL_MEASURE_METADATA[props.graphicKind as ControlMeasureId]?.params ?? [])
+    .filter((parameter) => props.includeText || parameter.type !== "text")
+    .filter((parameter) => resolveParameterSemanticRole(parameter) === "doctrinal")
+    .filter((parameter) => parameter.visibleWhen?.(effectiveOptions.value) ?? true);
+});
+
+function valueFor(parameter: ParamDescriptor): string | number | boolean | undefined {
+  return effectiveOptions.value[parameter.key] as string | number | boolean | undefined;
+}
+
+function updateOption(key: string, value: unknown) {
+  emit("update", {
+    ...toRaw(props.options),
+    [key]: value,
+  } as TacticalGraphicOptions);
+}
+
+function updateNumber(
+  parameter: Extract<ParamDescriptor, { type: "number" }>,
+  event: Event,
+) {
+  const value = (event.target as HTMLInputElement).valueAsNumber;
+  if (Number.isFinite(value)) updateOption(parameter.key, value);
+}
+
+function updateText(parameter: Extract<ParamDescriptor, { type: "text" }>, event: Event) {
+  updateOption(parameter.key, (event.target as HTMLInputElement).value);
+}
+</script>
+
+<template>
+  <template v-for="parameter in parameters" :key="parameter.key">
+    <ControlMeasureEchelonSelect
+      v-if="parameter.key === 'echelon' && parameter.type === 'enum'"
+      :graphic-kind="graphicKind as ControlMeasureId"
+      :options="options"
+      :inline="!fieldLayout"
+      @update="$emit('update', $event)"
+    />
+
+    <Field v-else :class="fieldLayout ? undefined : 'contents'">
+      <FieldLabel
+        :for="`cm-doctrinal-${parameter.key}`"
+        :class="fieldLayout ? undefined : 'self-center'"
+      >
+        {{ parameter.label }}
+        <template v-if="parameter.type === 'number' && parameter.unit">
+          ({{ parameter.unit }})
+        </template>
+      </FieldLabel>
+      <FieldDescription v-if="fieldLayout && parameter.description">
+        {{ parameter.description }}
+      </FieldDescription>
+
+      <NativeSelect
+        v-if="parameter.type === 'enum'"
+        :id="`cm-doctrinal-${parameter.key}`"
+        class="w-full"
+        wrapper-class="w-full"
+        :title="parameter.description"
+        :model-value="valueFor(parameter)"
+        @update:model-value="updateOption(parameter.key, $event)"
+      >
+        <NativeSelectOption
+          v-for="option in parameter.options"
+          :key="String(option.value)"
+          :value="option.value"
+        >
+          {{ option.label }}
+        </NativeSelectOption>
+      </NativeSelect>
+
+      <Switch
+        v-else-if="parameter.type === 'boolean'"
+        :id="`cm-doctrinal-${parameter.key}`"
+        :title="parameter.description"
+        :model-value="Boolean(valueFor(parameter))"
+        @update:model-value="updateOption(parameter.key, $event)"
+      />
+
+      <Input
+        v-else-if="parameter.type === 'number'"
+        :id="`cm-doctrinal-${parameter.key}`"
+        type="number"
+        :title="parameter.description"
+        :model-value="valueFor(parameter) as number"
+        :min="parameter.min"
+        :max="parameter.max"
+        :step="parameter.step"
+        @change="updateNumber(parameter, $event)"
+      />
+
+      <ControlMeasureColorPicker
+        v-else-if="parameter.type === 'color'"
+        :model-value="String(valueFor(parameter) ?? '')"
+        @update:model-value="updateOption(parameter.key, $event)"
+      />
+
+      <Textarea
+        v-else-if="parameter.type === 'text' && parameter.multiline"
+        :id="`cm-doctrinal-${parameter.key}`"
+        :title="parameter.description"
+        :model-value="String(valueFor(parameter) ?? '')"
+        :placeholder="parameter.placeholder"
+        :maxlength="parameter.maxLength"
+        @change="updateText(parameter, $event)"
+      />
+      <Input
+        v-else-if="parameter.type === 'text'"
+        :id="`cm-doctrinal-${parameter.key}`"
+        type="text"
+        :title="parameter.description"
+        :model-value="String(valueFor(parameter) ?? '')"
+        :placeholder="parameter.placeholder"
+        :maxlength="parameter.maxLength"
+        @change="updateText(parameter, $event)"
+      />
+    </Field>
+  </template>
+</template>

--- a/src/modules/scenarioeditor/ControlMeasureExtendedStyleSettings.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureExtendedStyleSettings.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { mount } from "@vue/test-utils";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { defineComponent } from "vue";
+import ControlMeasureExtendedStyleSettings from "@/modules/scenarioeditor/ControlMeasureExtendedStyleSettings.vue";
+
+const ControlMeasureColorPickerStub = defineComponent({
+  name: "ControlMeasureColorPicker",
+  props: ["modelValue"],
+  emits: ["update:modelValue"],
+  template: "<button data-test='color-picker' />",
+});
+
+beforeAll(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterAll(() => vi.unstubAllGlobals());
+
+function mountSettings(
+  graphicKind: InstanceType<
+    typeof ControlMeasureExtendedStyleSettings
+  >["$props"]["graphicKind"],
+  options: Record<string, unknown> = {},
+) {
+  return mount(ControlMeasureExtendedStyleSettings, {
+    props: { graphicKind, options },
+    global: { stubs: { ControlMeasureColorPicker: ControlMeasureColorPickerStub } },
+  });
+}
+
+describe("ControlMeasureExtendedStyleSettings", () => {
+  it("keeps metadata order and separates advanced appearance parameters", async () => {
+    const wrapper = mountSettings("classic-arrow");
+    const advanced = wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Advanced"));
+
+    expect(wrapper.text()).toContain("Arrowhead style");
+    expect(advanced).toBeDefined();
+    expect(wrapper.text()).not.toContain("Arrowhead length");
+    await advanced!.trigger("click");
+    const expandedText = wrapper.text();
+    expect(expandedText).toContain("Arrowhead length");
+    expect(expandedText).toContain("Arrowhead width");
+    expect(expandedText.indexOf("Arrowhead style")).toBeLessThan(
+      expandedText.indexOf("Advanced"),
+    );
+    expect(expandedText.indexOf("Arrowhead length")).toBeLessThan(
+      expandedText.indexOf("Arrowhead width"),
+    );
+    expect(expandedText).not.toContain("Smooth");
+    expect(expandedText).not.toContain("Smooth resolution");
+  });
+
+  it("does not duplicate doctrinal, amplifier, or transform-box parameters", () => {
+    const textSettings = mountSettings("text");
+    const text = textSettings.text();
+
+    expect(text).toContain("Alignment");
+    expect(text).toContain("Style");
+    expect(text).toContain("Max size");
+    expect(text).not.toContain("The text to render");
+    expect(text).not.toContain("Rotation");
+    expect(text).not.toMatch(/\bSize \(px\)/);
+
+    const minefield = mountSettings("minefield");
+    expect(minefield.text()).toContain(
+      "This control measure has no extended styling settings.",
+    );
+    expect(minefield.text()).not.toContain("Mine type");
+    expect(minefield.text()).not.toContain("Rotation");
+  });
+
+  it("shows only the active half of a screen/ground size pair", async () => {
+    const wrapper = mountSettings("boundary", { echelonSizePixels: 20 });
+    const text = () => wrapper.text().replace(/\s+/g, " ");
+
+    expect(text()).toContain("Echelon size");
+    expect(text()).toContain("20 px");
+    expect(text()).not.toContain("900 m");
+    expect(wrapper.text()).not.toContain("EchelonField B");
+
+    await wrapper.setProps({ options: { echelonSize: 900 } });
+    expect(text()).toContain("Echelon size");
+    expect(text()).toContain("900 m");
+    expect(text()).not.toContain("20 px");
+  });
+
+  it("preserves existing options and restores the enum value type", async () => {
+    const wrapper = mountSettings("block-arrow", {
+      arrowheadStyle: "triangle",
+      custom: "kept",
+    });
+    const barbed = wrapper.findAll("button").find((button) => button.text() === "Barbed");
+
+    expect(barbed).toBeDefined();
+    await barbed!.trigger("click");
+
+    expect(wrapper.emitted("update")?.at(-1)).toEqual([
+      { arrowheadStyle: "barbed", custom: "kept" },
+    ]);
+  });
+
+  it("reevaluates metadata visibility from the live options", async () => {
+    const wrapper = mountSettings("boundary", { labelRepetitions: 1 });
+    const advanced = wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Advanced"));
+    await advanced!.trigger("click");
+
+    expect(wrapper.text()).toContain("Label position");
+    expect(wrapper.text()).not.toContain("Label spacing");
+
+    await wrapper.setProps({ options: { labelRepetitions: 3 } });
+    expect(wrapper.text()).not.toContain("Label position");
+    expect(wrapper.text()).toContain("Label spacing");
+  });
+
+  it("uses capturesLabelSize to add the shared label-size control", async () => {
+    const wrapper = mountSettings("phase-line");
+    const labelSize = wrapper
+      .findAllComponents({ name: "Slider" })
+      .find((slider) => slider.attributes("id")?.includes("labelSizePixels"));
+
+    expect(wrapper.text()).toContain("Label size");
+    expect(wrapper.text()).toContain("14 px");
+    expect(labelSize).toBeDefined();
+    await labelSize!.vm.$emit("value-commit", [20]);
+    expect(wrapper.emitted("update")?.at(-1)).toEqual([{ labelSizePixels: 20 }]);
+
+    await wrapper.setProps({ options: { labelSize: 500 } });
+    expect(wrapper.text()).toContain("500 m");
+  });
+});

--- a/src/modules/scenarioeditor/ControlMeasureExtendedStyleSettings.vue
+++ b/src/modules/scenarioeditor/ControlMeasureExtendedStyleSettings.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import { computed, toRaw, useId } from "vue";
 import {
-  CONTROL_MEASURE_METADATA,
   applyBoxTransformOptions,
   foldsBoxTransformOptions,
-  getDefaultOptions,
   resolveParameterPresentationTier,
   resolveParameterSemanticRole,
 } from "@orbat-mapper/control-measures";
+import {
+  CONTROL_MEASURE_STYLE_OWNED_OPTION_KEYS,
+  effectiveControlMeasureOptions,
+  getLabelSizeParam,
+  metadataFor,
+} from "@/modules/scenarioeditor/controlMeasureStyleOptions";
 import { DEFAULT_LABEL_SIZE_PIXELS } from "@orbat-mapper/tactical-draw";
 import { ChevronRight } from "@lucide/vue";
 import {
@@ -44,51 +48,20 @@ function fieldId(key: string): string {
   return `${instanceId}-cm-extended-${key}`;
 }
 
-const metadata = computed(
-  () => CONTROL_MEASURE_METADATA[props.graphicKind as ControlMeasureId],
+const metadata = computed(() => metadataFor(props.graphicKind));
+
+/** Shared label sizing is declared by the per-kind `capturesLabelSize` flag. */
+const labelSizeParameter = computed<ParamDescriptor | undefined>(() =>
+  getLabelSizeParam(props.graphicKind, props.options),
 );
+
 const effectiveOptions = computed<Record<string, unknown>>(() => ({
-  ...(getDefaultOptions(props.graphicKind as ControlMeasureId) as Record<
-    string,
-    unknown
-  >),
-  ...(props.options as Record<string, unknown> | undefined),
-  ...(metadata.value?.capturesLabelSize &&
-  props.options?.labelSizePixels === undefined &&
-  props.options?.labelSize === undefined
+  ...effectiveControlMeasureOptions(props.graphicKind, props.options),
+  ...(labelSizeParameter.value?.key === "labelSizePixels" &&
+  props.options?.labelSizePixels === undefined
     ? { labelSizePixels: DEFAULT_LABEL_SIZE_PIXELS }
     : undefined),
 }));
-
-/** Shared label sizing is declared by the per-kind `capturesLabelSize` flag. */
-const labelSizeParameter = computed<ParamDescriptor | undefined>(() => {
-  if (!metadata.value?.capturesLabelSize) return undefined;
-  if (
-    props.options?.labelSizePixels === undefined &&
-    props.options?.labelSize !== undefined
-  ) {
-    return {
-      key: "labelSize",
-      label: "Label size",
-      description: "Label text height in meters.",
-      type: "number",
-      min: 50,
-      max: 20_000,
-      step: 50,
-      unit: "m",
-    };
-  }
-  return {
-    key: "labelSizePixels",
-    label: "Label size",
-    description: "Label text height in screen pixels.",
-    type: "number",
-    min: 8,
-    max: 48,
-    step: 1,
-    unit: "px",
-  };
-});
 
 /**
  * A screen/ground size pair is represented by two adjacent number descriptors with
@@ -117,8 +90,8 @@ function inactiveSizePairKeys(parameters: readonly ParamDescriptor[]): Set<strin
  * another kind gains the capability in a future package release.
  */
 function isTransformBoxParameter(parameter: ParamDescriptor): boolean {
+  if (parameter.type !== "number") return false;
   const kind = props.graphicKind as ControlMeasureId;
-  if (!foldsBoxTransformOptions(kind) || parameter.type !== "number") return false;
 
   const probeOptions = { ...effectiveOptions.value };
   if (parameter.key.endsWith("Pixels")) {
@@ -147,27 +120,35 @@ function isTransformBoxParameter(parameter: ParamDescriptor): boolean {
 const appearanceParameters = computed(() => {
   const parameters = metadata.value?.params ?? [];
   const inactiveSizeKeys = inactiveSizePairKeys(parameters);
-  const visible = parameters
-    .filter((parameter) => resolveParameterSemanticRole(parameter) === "appearance")
-    // Smoothing, including its advanced resolution, already lives in Style.
-    .filter((parameter) => !["smooth", "smoothResolution"].includes(parameter.key))
-    .filter((parameter) => !inactiveSizeKeys.has(parameter.key))
-    .filter((parameter) => !isTransformBoxParameter(parameter))
-    .filter((parameter) => parameter.visibleWhen?.(effectiveOptions.value) ?? true);
+  // Whether the transform box folds any option at all is a static per-kind fact, so
+  // the expensive per-parameter probe is skipped entirely for kinds without it.
+  const foldsTransform = foldsBoxTransformOptions(props.graphicKind as ControlMeasureId);
+  const visible = parameters.filter(
+    (parameter) =>
+      resolveParameterSemanticRole(parameter) === "appearance" &&
+      // Smoothing, including its advanced resolution, already lives in Style.
+      !CONTROL_MEASURE_STYLE_OWNED_OPTION_KEYS.includes(parameter.key) &&
+      !inactiveSizeKeys.has(parameter.key) &&
+      (parameter.visibleWhen?.(effectiveOptions.value) ?? true) &&
+      !(foldsTransform && isTransformBoxParameter(parameter)),
+  );
   if (labelSizeParameter.value) visible.push(labelSizeParameter.value);
   return visible;
 });
 
-const standardParameters = computed(() =>
-  appearanceParameters.value.filter(
-    (parameter) => resolveParameterPresentationTier(parameter) !== "advanced",
-  ),
-);
-const advancedParameters = computed(() =>
-  appearanceParameters.value.filter(
-    (parameter) => resolveParameterPresentationTier(parameter) === "advanced",
-  ),
-);
+const parameterTiers = computed(() => {
+  const standard: ParamDescriptor[] = [];
+  const advanced: ParamDescriptor[] = [];
+  for (const parameter of appearanceParameters.value) {
+    (resolveParameterPresentationTier(parameter) === "advanced"
+      ? advanced
+      : standard
+    ).push(parameter);
+  }
+  return { standard, advanced };
+});
+const standardParameters = computed(() => parameterTiers.value.standard);
+const advancedParameters = computed(() => parameterTiers.value.advanced);
 
 function valueFor(parameter: ParamDescriptor): string | number | boolean | undefined {
   return effectiveOptions.value[parameter.key] as string | number | boolean | undefined;

--- a/src/modules/scenarioeditor/ControlMeasureExtendedStyleSettings.vue
+++ b/src/modules/scenarioeditor/ControlMeasureExtendedStyleSettings.vue
@@ -1,0 +1,236 @@
+<script setup lang="ts">
+import { computed, toRaw, useId } from "vue";
+import {
+  CONTROL_MEASURE_METADATA,
+  applyBoxTransformOptions,
+  foldsBoxTransformOptions,
+  getDefaultOptions,
+  resolveParameterPresentationTier,
+  resolveParameterSemanticRole,
+} from "@orbat-mapper/control-measures";
+import { DEFAULT_LABEL_SIZE_PIXELS } from "@orbat-mapper/tactical-draw";
+import { ChevronRight } from "@lucide/vue";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
+import type {
+  ControlMeasureId,
+  ControlMeasureKind,
+  ParamDescriptor,
+} from "@orbat-mapper/control-measures";
+import {
+  FieldDescription,
+  FieldGroup,
+  FieldLegend,
+  FieldSet,
+} from "@/components/ui/field";
+import { Separator } from "@/components/ui/separator";
+import ControlMeasureParameterField from "@/modules/scenarioeditor/ControlMeasureParameterField.vue";
+import type { TacticalGraphicOptions } from "@/types/scenarioLayerItems";
+
+const props = defineProps<{
+  graphicKind: ControlMeasureKind;
+  options?: TacticalGraphicOptions;
+}>();
+
+const emit = defineEmits<{
+  (e: "update", value: TacticalGraphicOptions): void;
+}>();
+
+const instanceId = useId();
+function fieldId(key: string): string {
+  return `${instanceId}-cm-extended-${key}`;
+}
+
+const metadata = computed(
+  () => CONTROL_MEASURE_METADATA[props.graphicKind as ControlMeasureId],
+);
+const effectiveOptions = computed<Record<string, unknown>>(() => ({
+  ...(getDefaultOptions(props.graphicKind as ControlMeasureId) as Record<
+    string,
+    unknown
+  >),
+  ...(props.options as Record<string, unknown> | undefined),
+  ...(metadata.value?.capturesLabelSize &&
+  props.options?.labelSizePixels === undefined &&
+  props.options?.labelSize === undefined
+    ? { labelSizePixels: DEFAULT_LABEL_SIZE_PIXELS }
+    : undefined),
+}));
+
+/** Shared label sizing is declared by the per-kind `capturesLabelSize` flag. */
+const labelSizeParameter = computed<ParamDescriptor | undefined>(() => {
+  if (!metadata.value?.capturesLabelSize) return undefined;
+  if (
+    props.options?.labelSizePixels === undefined &&
+    props.options?.labelSize !== undefined
+  ) {
+    return {
+      key: "labelSize",
+      label: "Label size",
+      description: "Label text height in meters.",
+      type: "number",
+      min: 50,
+      max: 20_000,
+      step: 50,
+      unit: "m",
+    };
+  }
+  return {
+    key: "labelSizePixels",
+    label: "Label size",
+    description: "Label text height in screen pixels.",
+    type: "number",
+    min: 8,
+    max: 48,
+    step: 1,
+    unit: "px",
+  };
+});
+
+/**
+ * A screen/ground size pair is represented by two adjacent number descriptors with
+ * the same stem (`radiusPixels` / `radius`). Only one is live: the authored pixel
+ * key selects screen sizing, otherwise the ground-sized half is used. This mirrors
+ * the package adapter contract and avoids presenting two identically labelled knobs.
+ */
+function inactiveSizePairKeys(parameters: readonly ParamDescriptor[]): Set<string> {
+  const keys = new Set(parameters.map(({ key }) => key));
+  const inactive = new Set<string>();
+  for (const parameter of parameters) {
+    if (!parameter.key.endsWith("Pixels")) continue;
+    const groundKey = parameter.key.slice(0, -"Pixels".length);
+    if (!keys.has(groundKey)) continue;
+    inactive.add(
+      props.options?.[parameter.key] === undefined ? parameter.key : groundKey,
+    );
+  }
+  return inactive;
+}
+
+/**
+ * Some static graphics persist box rotation/scale in their option bag. Probe the
+ * package's pure transform hook with a representative value so those parameters stay
+ * on the transform box instead of being duplicated here. The probe also adapts when
+ * another kind gains the capability in a future package release.
+ */
+function isTransformBoxParameter(parameter: ParamDescriptor): boolean {
+  const kind = props.graphicKind as ControlMeasureId;
+  if (!foldsBoxTransformOptions(kind) || parameter.type !== "number") return false;
+
+  const probeOptions = { ...effectiveOptions.value };
+  if (parameter.key.endsWith("Pixels")) {
+    delete probeOptions[parameter.key.slice(0, -"Pixels".length)];
+  } else {
+    delete probeOptions[`${parameter.key}Pixels`];
+  }
+  // Static point graphics use `sizeMeters` / `sizePixels` rather than the usual
+  // shared-stem pair. Make the descriptor under test the live size denomination.
+  if (parameter.key.startsWith("size")) {
+    for (const key of Object.keys(probeOptions)) {
+      if (key.startsWith("size") && key !== parameter.key) delete probeOptions[key];
+    }
+  }
+  if (probeOptions[parameter.key] === undefined) {
+    probeOptions[parameter.key] = parameter.min ?? parameter.step ?? 1;
+  }
+
+  const patch = applyBoxTransformOptions(kind, probeOptions, {
+    scale: 1.1,
+    rotationRadians: 0.1,
+  });
+  return Object.prototype.hasOwnProperty.call(patch ?? {}, parameter.key);
+}
+
+const appearanceParameters = computed(() => {
+  const parameters = metadata.value?.params ?? [];
+  const inactiveSizeKeys = inactiveSizePairKeys(parameters);
+  const visible = parameters
+    .filter((parameter) => resolveParameterSemanticRole(parameter) === "appearance")
+    // Smoothing, including its advanced resolution, already lives in Style.
+    .filter((parameter) => !["smooth", "smoothResolution"].includes(parameter.key))
+    .filter((parameter) => !inactiveSizeKeys.has(parameter.key))
+    .filter((parameter) => !isTransformBoxParameter(parameter))
+    .filter((parameter) => parameter.visibleWhen?.(effectiveOptions.value) ?? true);
+  if (labelSizeParameter.value) visible.push(labelSizeParameter.value);
+  return visible;
+});
+
+const standardParameters = computed(() =>
+  appearanceParameters.value.filter(
+    (parameter) => resolveParameterPresentationTier(parameter) !== "advanced",
+  ),
+);
+const advancedParameters = computed(() =>
+  appearanceParameters.value.filter(
+    (parameter) => resolveParameterPresentationTier(parameter) === "advanced",
+  ),
+);
+
+function valueFor(parameter: ParamDescriptor): string | number | boolean | undefined {
+  return effectiveOptions.value[parameter.key] as string | number | boolean | undefined;
+}
+
+function updateOption(key: string, value: unknown) {
+  emit("update", {
+    ...toRaw(props.options),
+    [key]: value,
+  } as TacticalGraphicOptions);
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-5 pt-4">
+    <FieldGroup v-if="standardParameters.length">
+      <ControlMeasureParameterField
+        v-for="parameter in standardParameters"
+        :id="fieldId(parameter.key)"
+        :key="parameter.key"
+        :parameter="parameter"
+        :model-value="valueFor(parameter)"
+        @update:model-value="updateOption(parameter.key, $event)"
+      />
+    </FieldGroup>
+
+    <Collapsible v-if="advancedParameters.length">
+      <Separator v-if="standardParameters.length" />
+      <CollapsibleTrigger class="group mt-4 flex w-full items-center gap-2 text-left">
+        <ChevronRight
+          :size="16"
+          class="text-muted-foreground transition-transform group-data-[state=open]:rotate-90"
+        />
+        <span class="font-medium">Advanced</span>
+        <span class="text-muted-foreground text-xs tabular-nums">
+          {{ advancedParameters.length }}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent class="pt-4">
+        <FieldSet class="gap-4">
+          <FieldLegend class="sr-only" variant="label">Advanced settings</FieldLegend>
+          <FieldDescription>
+            Fine-tune how this control measure is constructed and labelled.
+          </FieldDescription>
+          <FieldGroup>
+            <ControlMeasureParameterField
+              v-for="parameter in advancedParameters"
+              :id="fieldId(parameter.key)"
+              :key="parameter.key"
+              :parameter="parameter"
+              :model-value="valueFor(parameter)"
+              @update:model-value="updateOption(parameter.key, $event)"
+            />
+          </FieldGroup>
+        </FieldSet>
+      </CollapsibleContent>
+    </Collapsible>
+
+    <p
+      v-if="!standardParameters.length && !advancedParameters.length"
+      class="text-muted-foreground text-sm"
+    >
+      This control measure has no extended styling settings.
+    </p>
+  </div>
+</template>

--- a/src/modules/scenarioeditor/ControlMeasureParameterField.vue
+++ b/src/modules/scenarioeditor/ControlMeasureParameterField.vue
@@ -1,0 +1,175 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import type { ParamDescriptor } from "@orbat-mapper/control-measures";
+import { Field, FieldDescription, FieldLabel } from "@/components/ui/field";
+import { Input } from "@/components/ui/input";
+import { NativeSelect, NativeSelectOption } from "@/components/ui/native-select";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import ControlMeasureColorPicker from "@/modules/scenarioeditor/ControlMeasureColorPicker.vue";
+
+const props = defineProps<{
+  id: string;
+  parameter: ParamDescriptor;
+  modelValue?: string | number | boolean;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:modelValue", value: string | number | boolean): void;
+}>();
+
+const boundedNumber = computed(
+  () =>
+    props.parameter.type === "number" &&
+    props.parameter.min !== undefined &&
+    props.parameter.max !== undefined,
+);
+const numberDraft = ref(0);
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (typeof value === "number") numberDraft.value = value;
+  },
+  { immediate: true },
+);
+
+function previewNumber(value: number[] | undefined) {
+  if (value?.[0] !== undefined) numberDraft.value = value[0];
+}
+
+function commitNumber(value: number[] | undefined) {
+  if (value?.[0] !== undefined) emit("update:modelValue", value[0]);
+}
+
+function updateNumber(event: Event) {
+  const value = (event.target as HTMLInputElement).valueAsNumber;
+  if (Number.isFinite(value)) emit("update:modelValue", value);
+}
+
+function updateText(event: Event) {
+  emit("update:modelValue", (event.target as HTMLInputElement).value);
+}
+
+function enumValue(parameter: Extract<ParamDescriptor, { type: "enum" }>): string {
+  const option = parameter.options.find(({ value }) => value === props.modelValue);
+  return String(option?.value ?? parameter.options[0]?.value ?? "");
+}
+
+function updateEnum(
+  parameter: Extract<ParamDescriptor, { type: "enum" }>,
+  rawValue: unknown,
+) {
+  const option = parameter.options.find(
+    ({ value }) => String(value) === String(rawValue),
+  );
+  if (option) emit("update:modelValue", option.value);
+}
+</script>
+
+<template>
+  <Field>
+    <div class="flex items-center justify-between gap-2">
+      <FieldLabel :for="id">{{ parameter.label }}</FieldLabel>
+      <span
+        v-if="parameter.type === 'number' && boundedNumber"
+        class="text-muted-foreground text-xs tabular-nums"
+      >
+        {{ numberDraft }}{{ parameter.unit ? ` ${parameter.unit}` : "" }}
+      </span>
+    </div>
+    <FieldDescription v-if="parameter.description">
+      {{ parameter.description }}
+    </FieldDescription>
+
+    <ToggleGroup
+      v-if="parameter.type === 'enum' && parameter.options.length <= 7"
+      :id="id"
+      type="single"
+      variant="outline"
+      :model-value="enumValue(parameter)"
+      :aria-label="parameter.label"
+      class="flex w-full flex-wrap"
+      @update:model-value="updateEnum(parameter, $event)"
+    >
+      <ToggleGroupItem
+        v-for="option in parameter.options"
+        :key="String(option.value)"
+        :value="String(option.value)"
+        class="h-auto min-h-9 flex-1 py-1 text-xs whitespace-normal"
+      >
+        {{ option.label }}
+      </ToggleGroupItem>
+    </ToggleGroup>
+
+    <NativeSelect
+      v-else-if="parameter.type === 'enum'"
+      :id="id"
+      class="w-full"
+      wrapper-class="w-full"
+      :model-value="enumValue(parameter)"
+      @update:model-value="updateEnum(parameter, $event)"
+    >
+      <NativeSelectOption
+        v-for="option in parameter.options"
+        :key="String(option.value)"
+        :value="String(option.value)"
+      >
+        {{ option.label }}
+      </NativeSelectOption>
+    </NativeSelect>
+
+    <Switch
+      v-else-if="parameter.type === 'boolean'"
+      :id="id"
+      :model-value="Boolean(modelValue)"
+      @update:model-value="$emit('update:modelValue', Boolean($event))"
+    />
+
+    <Slider
+      v-else-if="parameter.type === 'number' && boundedNumber"
+      :id="id"
+      :model-value="[numberDraft]"
+      :min="parameter.min"
+      :max="parameter.max"
+      :step="parameter.step ?? 1"
+      @update:model-value="previewNumber"
+      @value-commit="commitNumber"
+    />
+
+    <Input
+      v-else-if="parameter.type === 'number'"
+      :id="id"
+      type="number"
+      :model-value="modelValue as number"
+      :min="parameter.min"
+      :max="parameter.max"
+      :step="parameter.step"
+      @change="updateNumber"
+    />
+
+    <ControlMeasureColorPicker
+      v-else-if="parameter.type === 'color'"
+      :model-value="String(modelValue ?? '')"
+      @update:model-value="$emit('update:modelValue', $event)"
+    />
+
+    <Textarea
+      v-else-if="parameter.type === 'text' && parameter.multiline"
+      :id="id"
+      :model-value="String(modelValue ?? '')"
+      :placeholder="parameter.placeholder"
+      :maxlength="parameter.maxLength"
+      @change="updateText"
+    />
+    <Input
+      v-else-if="parameter.type === 'text'"
+      :id="id"
+      :model-value="String(modelValue ?? '')"
+      :placeholder="parameter.placeholder"
+      :maxlength="parameter.maxLength"
+      @change="updateText"
+    />
+  </Field>
+</template>

--- a/src/modules/scenarioeditor/ControlMeasureStyleSettings.test.ts
+++ b/src/modules/scenarioeditor/ControlMeasureStyleSettings.test.ts
@@ -24,7 +24,7 @@ vi.mock("@/components/ui/popover", () => ({
 
 vi.mock("@/components/ui/slider", () => ({
   Slider: defineComponent({
-    name: "Slider",
+    name: "SliderStub",
     props: ["modelValue", "min", "max", "step", "disabled"],
     emits: ["update:modelValue"],
     template: "<div />",
@@ -48,7 +48,7 @@ describe("the UI-only styling gate", () => {
     const wrapper = mountSettings({ graphicKind: "phase-line" });
     const nativeSelectWrappers = wrapper.findAll("[data-slot='native-select-wrapper']");
 
-    expect(nativeSelectWrappers).toHaveLength(3);
+    expect(nativeSelectWrappers).toHaveLength(2);
     expect(
       nativeSelectWrappers.every((selectWrapper) =>
         selectWrapper.classes().includes("w-full"),
@@ -114,8 +114,18 @@ describe("the UI-only styling gate", () => {
 describe("what it emits", () => {
   it("emits the host-owned field on its own", async () => {
     const wrapper = mountSettings({ graphicKind: "phase-line" });
-    await wrapper.findAll("select")[2]!.setValue("planned");
+    await wrapper.findAll("select")[1]!.setValue("planned");
     expect(wrapper.emitted("update")).toEqual([[{ status: "planned" }]]);
+  });
+
+  it("uses a switch to change the color mode", async () => {
+    const wrapper = mountSettings({ graphicKind: "phase-line" });
+    const colors = wrapper.get("#cm-color-mode");
+
+    expect(colors.attributes("data-state")).toBe("unchecked");
+    await colors.trigger("click");
+
+    expect(wrapper.emitted("update")).toEqual([[{ colorMode: "monochrome" }]]);
   });
 
   it("emits the whole style, merged, so nothing authored is lost", async () => {
@@ -147,7 +157,7 @@ describe("what it emits", () => {
       graphicKind: "polygon",
       measureStyle: { fillPattern: "hatch" },
     });
-    await wrapper.findAll("select")[3]!.setValue("");
+    await wrapper.findAll("select")[2]!.setValue("");
     expect(wrapper.emitted("update")).toEqual([[{ style: {} }]]);
   });
 });
@@ -225,9 +235,9 @@ describe("the smoothing toggle", () => {
 
   it("reflects an authored option over the library default", () => {
     const off = mountSettings({ graphicKind: "phase-line" });
-    expect(off.findComponent({ name: "Switch" }).props("modelValue")).toBe(false);
+    expect(smoothSwitch(off).attributes("data-state")).toBe("unchecked");
     const on = mountSettings({ graphicKind: "phase-line", options: { smooth: true } });
-    expect(on.findComponent({ name: "Switch" }).props("modelValue")).toBe(true);
+    expect(smoothSwitch(on).attributes("data-state")).toBe("checked");
   });
 
   it("emits the whole options object, merged, so nothing authored is lost", async () => {
@@ -235,7 +245,7 @@ describe("the smoothing toggle", () => {
       graphicKind: "phase-line",
       options: { smoothResolution: 24, smooth: false },
     });
-    await wrapper.findComponent({ name: "Switch" }).vm.$emit("update:modelValue", true);
+    await smoothSwitch(wrapper).trigger("click");
     expect(wrapper.emitted("update")).toEqual([
       [{ options: { smoothResolution: 24, smooth: true } }],
     ]);
@@ -246,7 +256,7 @@ describe("the smoothing toggle", () => {
       graphicKind: "phase-line",
       options: { smooth: false, smoothResolution: 8 },
     });
-    const slider = wrapper.findComponent({ name: "Slider" });
+    const slider = wrapper.findComponent({ name: "SliderStub" });
     expect(slider.props()).toMatchObject({
       modelValue: [8],
       min: 2,
@@ -261,7 +271,9 @@ describe("the smoothing toggle", () => {
       graphicKind: "phase-line",
       options: { smooth: true, includePrefix: false },
     });
-    await wrapper.findComponent({ name: "Slider" }).vm.$emit("update:modelValue", [9]);
+    await wrapper
+      .findComponent({ name: "SliderStub" })
+      .vm.$emit("update:modelValue", [9]);
     expect(wrapper.emitted("update")).toEqual([
       [{ options: { smooth: true, includePrefix: false, smoothResolution: 9 } }],
     ]);

--- a/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
+++ b/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
@@ -136,11 +136,11 @@ const identityModel = computed({
   set: (value: string) => emit("update", { standardIdentity: value as SidValue }),
 });
 
-const colorModeModel = computed({
-  get: () => props.colorMode ?? "identity",
-  set: (value: string) =>
-    emit("update", { colorMode: value as TacticalGraphicColorMode }),
-});
+function updateColorMode(monochrome: boolean) {
+  emit("update", {
+    colorMode: (monochrome ? "monochrome" : "identity") as TacticalGraphicColorMode,
+  });
+}
 
 const statusModel = computed({
   get: () => props.status ?? "present",
@@ -212,16 +212,15 @@ const fillPatternModel = computed({
     </NativeSelectOption>
   </NativeSelect>
 
-  <label for="cm-color-mode" class="self-center">Colors</label>
-  <NativeSelect
-    id="cm-color-mode"
-    class="w-full"
-    wrapper-class="w-full"
-    v-model="colorModeModel"
-  >
-    <NativeSelectOption value="identity">Identity</NativeSelectOption>
-    <NativeSelectOption value="monochrome">Monochrome</NativeSelectOption>
-  </NativeSelect>
+  <div aria-hidden="true"></div>
+  <label for="cm-color-mode" class="flex items-center gap-2">
+    <Switch
+      id="cm-color-mode"
+      :model-value="colorMode === 'monochrome'"
+      @update:model-value="updateColorMode(Boolean($event))"
+    />
+    <span>Monochrome</span>
+  </label>
 
   <label for="cm-status" class="self-center">Status</label>
   <NativeSelect

--- a/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
+++ b/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
@@ -212,7 +212,8 @@ const fillPatternModel = computed({
     </NativeSelectOption>
   </NativeSelect>
 
-  <label for="cm-color-mode" class="col-span-2 flex items-center gap-2">
+  <div></div>
+  <label for="cm-color-mode" class="flex items-center gap-2">
     <Switch
       id="cm-color-mode"
       :model-value="colorMode === 'monochrome'"

--- a/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
+++ b/src/modules/scenarioeditor/ControlMeasureStyleSettings.vue
@@ -212,8 +212,7 @@ const fillPatternModel = computed({
     </NativeSelectOption>
   </NativeSelect>
 
-  <div aria-hidden="true"></div>
-  <label for="cm-color-mode" class="flex items-center gap-2">
+  <label for="cm-color-mode" class="col-span-2 flex items-center gap-2">
     <Switch
       id="cm-color-mode"
       :model-value="colorMode === 'monochrome'"

--- a/src/modules/scenarioeditor/controlMeasureStyleOptions.test.ts
+++ b/src/modules/scenarioeditor/controlMeasureStyleOptions.test.ts
@@ -113,6 +113,21 @@ describe("newControlMeasureDefaults", () => {
     expect(result.options).not.toBe(defaults.options);
   });
 
+  it("carries non-text doctrinal options only onto kinds that declare them", () => {
+    const doctrinal = {
+      ...defaults,
+      options: { ...defaults.options, mineType: "antitank" },
+    } as const;
+
+    expect(newControlMeasureDefaults(doctrinal, "minefield").options).toEqual({
+      mineType: "antitank",
+    });
+    expect(newControlMeasureDefaults(doctrinal, "phase-line").options).toEqual({
+      smooth: true,
+      smoothResolution: 8,
+    });
+  });
+
   it("emits no style at all when nothing survives the gate", () => {
     const colourless = { standardIdentity: "3", style: { fillPattern: "dots" } } as const;
     expect(newControlMeasureDefaults(colourless, "line")).toEqual({

--- a/src/modules/scenarioeditor/controlMeasureStyleOptions.ts
+++ b/src/modules/scenarioeditor/controlMeasureStyleOptions.ts
@@ -17,6 +17,7 @@
 import {
   CONTROL_MEASURE_METADATA,
   getDefaultOptions,
+  resolveParameterSemanticRole,
 } from "@orbat-mapper/control-measures";
 import type {
   ControlMeasureId,
@@ -179,15 +180,33 @@ export function newControlMeasureDefaults(
     if (Object.keys(authored).length > 0) narrowed.style = authored;
   }
 
-  if (options && canSmoothControlMeasureKind(graphicKind)) {
+  if (options) {
     const authored = options as Record<string, unknown>;
     const narrowedOptions: Record<string, unknown> = {};
-    if (typeof authored.smooth === "boolean") narrowedOptions.smooth = authored.smooth;
     if (
-      getSmoothResolutionParam(graphicKind) &&
-      typeof authored.smoothResolution === "number"
+      canSmoothControlMeasureKind(graphicKind) &&
+      typeof authored.smooth === "boolean"
     ) {
-      narrowedOptions.smoothResolution = authored.smoothResolution;
+      narrowedOptions.smooth = authored.smooth;
+      if (
+        getSmoothResolutionParam(graphicKind) &&
+        typeof authored.smoothResolution === "number"
+      ) {
+        narrowedOptions.smoothResolution = authored.smoothResolution;
+      }
+    }
+
+    // Doctrinal generator choices are kind-specific just like smoothing, but unlike
+    // free text they belong in the compact draw palette. Derive the allow-list from
+    // semantic metadata so future modifiers flow through without a host-side list.
+    for (const parameter of metadataFor(graphicKind)?.params ?? []) {
+      if (
+        parameter.type !== "text" &&
+        resolveParameterSemanticRole(parameter) === "doctrinal" &&
+        authored[parameter.key] !== undefined
+      ) {
+        narrowedOptions[parameter.key] = authored[parameter.key];
+      }
     }
     if (Object.keys(narrowedOptions).length > 0) {
       narrowed.options = narrowedOptions as TacticalGraphicOptions;

--- a/src/modules/scenarioeditor/controlMeasureStyleOptions.ts
+++ b/src/modules/scenarioeditor/controlMeasureStyleOptions.ts
@@ -54,10 +54,56 @@ export const CONTROL_MEASURE_STROKE_WIDTH_PRESETS = [
   { label: "Heavy", value: 4 },
 ] as const;
 
-function metadataFor(kind: ControlMeasureKind | undefined) {
+/** The registry entry for a kind, with the single `ControlMeasureId` cast in one place. */
+export function metadataFor(kind: ControlMeasureKind | undefined) {
   if (kind === undefined) return undefined;
   return CONTROL_MEASURE_METADATA[kind as ControlMeasureId];
 }
+
+/**
+ * What the generator actually runs with: the library's defaults for the kind, with the
+ * item's authored options on top. Every surface that has to show "what the map is
+ * drawing" — visibility predicates, field values, smoothing state — resolves it here.
+ */
+export function effectiveControlMeasureOptions(
+  kind: ControlMeasureKind | undefined,
+  options: TacticalGraphicOptions | undefined,
+): Record<string, unknown> {
+  return {
+    ...(kind === undefined
+      ? undefined
+      : (getDefaultOptions(kind as ControlMeasureId) as Record<string, unknown>)),
+    ...(options as Record<string, unknown> | undefined),
+  };
+}
+
+/**
+ * The doctrinal generator parameters a kind offers, already narrowed by the descriptor's
+ * own `visibleWhen`. Both the amplifier panel and its empty-state check read this, so the
+ * section and its "nothing here" message can never disagree.
+ */
+export function doctrinalControlMeasureParams(
+  kind: ControlMeasureKind | undefined,
+  options: TacticalGraphicOptions | undefined,
+  { includeText = false }: { includeText?: boolean } = {},
+): readonly ParamDescriptor[] {
+  const effective = effectiveControlMeasureOptions(kind, options);
+  return (metadataFor(kind)?.params ?? []).filter(
+    (parameter) =>
+      (includeText || parameter.type !== "text") &&
+      resolveParameterSemanticRole(parameter) === "doctrinal" &&
+      (parameter.visibleWhen?.(effective) ?? true),
+  );
+}
+
+/**
+ * Option keys the Style tab already owns, so the extended-styling tab knows to leave them
+ * alone. One list rather than a hard-coded copy on each side.
+ */
+export const CONTROL_MEASURE_STYLE_OWNED_OPTION_KEYS: readonly string[] = [
+  "smooth",
+  "smoothResolution",
+];
 
 /** True for exactly the 7 Generic Graphics kinds — the ones the UI lets you colour. */
 export function isStyleableControlMeasureKind(
@@ -130,12 +176,54 @@ export function isControlMeasureSmoothed(
   kind: ControlMeasureKind | undefined,
   options: TacticalGraphicOptions | undefined,
 ): boolean {
-  const authored = (options as Record<string, unknown> | undefined)?.smooth;
-  if (typeof authored === "boolean") return authored;
-  if (kind === undefined) return false;
-  const defaults = getDefaultOptions(kind as ControlMeasureId) as
-    Record<string, unknown> | undefined;
-  return defaults?.smooth === true;
+  return effectiveControlMeasureOptions(kind, options).smooth === true;
+}
+
+/**
+ * The label-size knob for kinds that declare `capturesLabelSize`. The pair is a
+ * screen/ground denomination like the other size pairs: an authored ground `labelSize`
+ * (with no pixel override) keeps the metre-denominated descriptor, everything else is
+ * sized in screen pixels. Kept here beside the other metadata-derived accessors so the
+ * bounds are reachable and testable without mounting a component.
+ */
+const LABEL_SIZE_PARAMS = {
+  ground: {
+    key: "labelSize",
+    label: "Label size",
+    description: "Label text height in meters.",
+    type: "number",
+    min: 50,
+    max: 20_000,
+    step: 50,
+    unit: "m",
+  },
+  pixels: {
+    key: "labelSizePixels",
+    label: "Label size",
+    description: "Label text height in screen pixels.",
+    type: "number",
+    min: 8,
+    max: 48,
+    step: 1,
+    unit: "px",
+  },
+} as const satisfies Record<string, ParamDescriptor>;
+
+/** True when the kind sizes its label in ground metres rather than screen pixels. */
+export function usesGroundLabelSize(
+  options: TacticalGraphicOptions | undefined,
+): boolean {
+  return options?.labelSizePixels === undefined && options?.labelSize !== undefined;
+}
+
+export function getLabelSizeParam(
+  kind: ControlMeasureKind | undefined,
+  options: TacticalGraphicOptions | undefined,
+): ParamDescriptor | undefined {
+  if (!metadataFor(kind)?.capturesLabelSize) return undefined;
+  return usesGroundLabelSize(options)
+    ? LABEL_SIZE_PARAMS.ground
+    : LABEL_SIZE_PARAMS.pixels;
 }
 
 /** `"solid"` has no preview tile — it is the absence of a pattern, not one of them. */
@@ -183,11 +271,8 @@ export function newControlMeasureDefaults(
   if (options) {
     const authored = options as Record<string, unknown>;
     const narrowedOptions: Record<string, unknown> = {};
-    if (
-      canSmoothControlMeasureKind(graphicKind) &&
-      typeof authored.smooth === "boolean"
-    ) {
-      narrowedOptions.smooth = authored.smooth;
+    if (canSmoothControlMeasureKind(graphicKind)) {
+      if (typeof authored.smooth === "boolean") narrowedOptions.smooth = authored.smooth;
       if (
         getSmoothResolutionParam(graphicKind) &&
         typeof authored.smoothResolution === "number"

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,7 +4,7 @@
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-    "lib": ["ES2021", "DOM"],
+    "lib": ["ES2022", "DOM"],
     "noUncheckedIndexedAccess": false,
 
     "paths": {


### PR DESCRIPTION
## Summary

- Update scenario editor control measure metadata and style options
- Refine defaults, doctrinal parameters, amplifiers, and extended style settings
- Expand component and option coverage with updated tests
- Refresh package metadata and lockfile

## Testing

- Updated unit tests for control measure settings, defaults, amplifiers, details, and style options