### PR TITLE
Upgrade MapLibre GL to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "idb": "^8.0.3",
     "immer": "^11.1.17",
     "klona": "^2.0.6",
-    "maplibre-gl": "^5.24.0",
+    "maplibre-gl": "^6.3.0",
     "markdown-it": "^14.3.0",
     "markdown-it-container": "^4.0.0",
     "mgrs": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,7 +52,7 @@ importers:
         version: 0.3.3(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))
       '@orbat-mapper/tactical-draw-adapter-maplibre':
         specifier: ^0.3.0
-        version: 0.3.0(maplibre-gl@5.24.0)(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))
+        version: 0.3.0(maplibre-gl@6.3.0)(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))
       '@panzoom/panzoom':
         specifier: ^4.6.2
         version: 4.6.2
@@ -234,8 +234,8 @@ importers:
         specifier: ^2.0.6
         version: 2.0.6
       maplibre-gl:
-        specifier: ^5.24.0
-        version: 5.24.0
+        specifier: ^6.3.0
+        version: 6.3.0
       markdown-it:
         specifier: ^14.3.0
         version: 14.3.0
@@ -1081,24 +1081,17 @@ packages:
   '@mapbox/tiny-sdf@2.2.0':
     resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
 
-  '@mapbox/unitbezier@0.0.1':
-    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
-
   '@mapbox/unitbezier@1.0.0':
     resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
 
-  '@mapbox/vector-tile@2.0.5':
-    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
-
-  '@mapbox/whoots-js@3.1.0':
-    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
-    engines: {node: '>=6.0.0'}
+  '@mapbox/vector-tile@3.0.0':
+    resolution: {integrity: sha512-Qf10S1uIHMk20ri/IVBnpS+esUEkVaR5Hftmz88jTInrpmWgPGJfPe3LVjjlE77trLx8tH6qjTG7uWH9hIq/0Q==}
 
   '@maplibre/geojson-vt@6.1.1':
     resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
 
-  '@maplibre/maplibre-gl-style-spec@24.10.0':
-    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
+    resolution: {integrity: sha512-QFKCXkOeSzOr8jF75jm6kySOg+dUvOehPhRi68gcOYPHb7U5JloUq0dJW0Y5/fZV8ygfT0Vp2RWodvq+fyxFWA==}
     hasBin: true
 
   '@maplibre/mlt@1.1.12':
@@ -3441,8 +3434,8 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  maplibre-gl@5.24.0:
-    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+  maplibre-gl@6.3.0:
+    resolution: {integrity: sha512-F0Is48MTzn3DvOEidPjh68E0kuSA7hdzY1YIR0ypPtFgcif3WPtzI1oZFgsv9WtHmarQnbwIXfsf+EfQYvM00A==}
     engines: {node: '>=16.14.0', npm: '>=8.1.0'}
 
   mark.js@8.11.1:
@@ -5284,23 +5277,19 @@ snapshots:
 
   '@mapbox/tiny-sdf@2.2.0': {}
 
-  '@mapbox/unitbezier@0.0.1': {}
-
   '@mapbox/unitbezier@1.0.0': {}
 
-  '@mapbox/vector-tile@2.0.5':
+  '@mapbox/vector-tile@3.0.0':
     dependencies:
       '@mapbox/point-geometry': 1.1.0
       '@types/geojson': 7946.0.16
-      pbf: 4.0.2
-
-  '@mapbox/whoots-js@3.1.0': {}
+      pbf: 5.1.2
 
   '@maplibre/geojson-vt@6.1.1':
     dependencies:
       kdbush: 4.1.0
 
-  '@maplibre/maplibre-gl-style-spec@24.10.0':
+  '@maplibre/maplibre-gl-style-spec@26.2.1':
     dependencies:
       '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/unitbezier': 1.0.0
@@ -5349,11 +5338,11 @@ snapshots:
 
   '@orbat-mapper/convert-symbology@1.0.2': {}
 
-  '@orbat-mapper/tactical-draw-adapter-maplibre@0.3.0(maplibre-gl@5.24.0)(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))':
+  '@orbat-mapper/tactical-draw-adapter-maplibre@0.3.0(maplibre-gl@6.3.0)(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))':
     dependencies:
       '@orbat-mapper/control-measures': 0.5.1
       '@orbat-mapper/tactical-draw': 0.3.3(vitest@4.1.10(@types/node@25.9.5)(jsdom@27.4.0)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(yaml@2.9.0)))
-      maplibre-gl: 5.24.0
+      maplibre-gl: 6.3.0
     transitivePeerDependencies:
       - vitest
 
@@ -8257,16 +8246,14 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  maplibre-gl@5.24.0:
+  maplibre-gl@6.3.0:
     dependencies:
-      '@mapbox/jsonlint-lines-primitives': 2.0.3
       '@mapbox/point-geometry': 1.1.0
       '@mapbox/tiny-sdf': 2.2.0
-      '@mapbox/unitbezier': 0.0.1
-      '@mapbox/vector-tile': 2.0.5
-      '@mapbox/whoots-js': 3.1.0
+      '@mapbox/unitbezier': 1.0.0
+      '@mapbox/vector-tile': 3.0.0
       '@maplibre/geojson-vt': 6.1.1
-      '@maplibre/maplibre-gl-style-spec': 24.10.0
+      '@maplibre/maplibre-gl-style-spec': 26.2.1
       '@maplibre/mlt': 1.1.12
       '@maplibre/vt-pbf': 4.3.2
       '@types/geojson': 7946.0.16
@@ -8274,7 +8261,7 @@ snapshots:
       gl-matrix: 3.4.4
       kdbush: 4.1.0
       murmurhash-js: 1.0.0
-      pbf: 4.0.2
+      pbf: 5.1.2
       potpack: 2.1.0
       quickselect: 3.0.0
       tinyqueue: 3.0.0

--- a/scripts/inlineMaplibreWorker.ts
+++ b/scripts/inlineMaplibreWorker.ts
@@ -1,0 +1,52 @@
+type GeneratedBundle = Record<
+  string,
+  { type: "chunk"; code: string } | { type: "asset"; source: string | Uint8Array }
+>;
+
+export function inlineMaplibreWorkerInBundle(bundle: GeneratedBundle): void {
+  const workers = Object.entries(bundle).filter(([fileName]) =>
+    fileName.includes("maplibre-gl-worker"),
+  );
+  if (workers.length !== 1) {
+    throw new Error(
+      `Expected one MapLibre worker chunk, found ${workers.length}: ${Object.entries(
+        bundle,
+      )
+        .map(([fileName, output]) => `${fileName} (${output.type})`)
+        .join(", ")}.`,
+    );
+  }
+
+  const [workerFileName, workerOutput] = workers[0];
+  const workerCode =
+    workerOutput.type === "chunk" ? workerOutput.code : String(workerOutput.source);
+  // Vite emits this worker as a self-contained IIFE, so it is a classic worker. MapLibre v6 uses
+  // a `.cjs` suffix to distinguish classic workers from module workers. That distinction matters
+  // for a file:// page: Chromium rejects a module worker whose top-level Blob URL inherits an
+  // opaque origin. A URL fragment preserves the Blob resource while giving MapLibre the suffix it
+  // needs to select the classic Worker constructor.
+  const blobUrlExpression =
+    `URL.createObjectURL(new Blob([${JSON.stringify(workerCode)}],{type:"text/javascript"}))` +
+    `+"#maplibre-worker.cjs"`;
+  const urlValues = [workerFileName, `./${workerFileName}`, `/${workerFileName}`];
+  let replacements = 0;
+
+  for (const output of Object.values(bundle)) {
+    if (output.type !== "chunk" || output === workerOutput) continue;
+    for (const url of urlValues) {
+      for (const quote of ['"', "'", "`"]) {
+        const literal = `${quote}${url}${quote}`;
+        if (!output.code.includes(literal)) continue;
+        output.code = output.code.replaceAll(literal, blobUrlExpression);
+        replacements++;
+      }
+    }
+  }
+
+  if (replacements !== 1) {
+    throw new Error(
+      `Expected one MapLibre worker URL reference, replaced ${replacements}.`,
+    );
+  }
+  delete bundle[workerFileName];
+}

--- a/src/composables/boxDrawEngineML.ts
+++ b/src/composables/boxDrawEngineML.ts
@@ -1,6 +1,6 @@
-import type { Map as MlMap } from "maplibre-gl";
+import type { GeoJSONSource, Map as MlMap, MapMouseEvent } from "maplibre-gl";
 import bboxPolygon from "@turf/bbox-polygon";
-import { toBbox, type Bbox, type BoxDrawEngine } from "./boxDrawEngine";
+import { toBbox, type BoxDrawEngine } from "./boxDrawEngine";
 
 const ML_BOX_SOURCE = "__boxDrawSource";
 const ML_BOX_FILL = "__boxDrawFill";
@@ -8,8 +8,8 @@ const ML_BOX_LINE = "__boxDrawLine";
 
 export function createMLBoxDrawEngine(mlMap: MlMap): BoxDrawEngine {
   let start: [number, number] | null = null;
-  let clickHandler: ((e: maplibregl.MapMouseEvent) => void) | null = null;
-  let mouseMoveHandler: ((e: maplibregl.MapMouseEvent) => void) | null = null;
+  let clickHandler: ((e: MapMouseEvent) => void) | null = null;
+  let mouseMoveHandler: ((e: MapMouseEvent) => void) | null = null;
 
   function addPreviewLayers() {
     if (!mlMap.getSource(ML_BOX_SOURCE)) {
@@ -42,7 +42,7 @@ export function createMLBoxDrawEngine(mlMap: MlMap): BoxDrawEngine {
 
   function updatePreview(current: [number, number]) {
     if (!start) return;
-    const source = mlMap.getSource(ML_BOX_SOURCE) as maplibregl.GeoJSONSource | undefined;
+    const source = mlMap.getSource(ML_BOX_SOURCE) as GeoJSONSource | undefined;
     if (!source) return;
     source.setData(bboxPolygon(toBbox(start, current)));
   }
@@ -57,7 +57,7 @@ export function createMLBoxDrawEngine(mlMap: MlMap): BoxDrawEngine {
     start(onEnd) {
       mlMap.getCanvas().style.cursor = "crosshair";
 
-      mouseMoveHandler = (e: maplibregl.MapMouseEvent) => {
+      mouseMoveHandler = (e: MapMouseEvent) => {
         mlMap.getCanvas().style.cursor = "crosshair";
         if (!start) return;
         updatePreview([e.lngLat.lng, e.lngLat.lat]);
@@ -65,7 +65,7 @@ export function createMLBoxDrawEngine(mlMap: MlMap): BoxDrawEngine {
 
       mlMap.on("mousemove", mouseMoveHandler);
 
-      clickHandler = (e: maplibregl.MapMouseEvent) => {
+      clickHandler = (e: MapMouseEvent) => {
         if (!start) {
           start = [e.lngLat.lng, e.lngLat.lat];
           addPreviewLayers();

--- a/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
+++ b/src/geo/engines/maplibre/mapLibreScenarioLayerController.test.ts
@@ -122,6 +122,7 @@ function firstLayerIndexForSource(
 
 function createMockMap() {
   const listeners = new Map<string, Set<(event?: unknown) => void>>();
+  let missingStyleImageResolver: ((id: string) => void | Promise<void>) | null = null;
   const sources = new Map<
     string,
     { setData: ReturnType<typeof vi.fn>; updateImage: ReturnType<typeof vi.fn> }
@@ -196,6 +197,11 @@ function createMockMap() {
     hasImage: vi.fn(() => false),
     loadImage: vi.fn(),
     addImage: vi.fn(),
+    setMissingStyleImageResolver: vi.fn(
+      (resolver: ((id: string) => void | Promise<void>) | null) => {
+        missingStyleImageResolver = resolver;
+      },
+    ),
     setLayoutProperty: vi.fn(),
     setPaintProperty: vi.fn(),
     getContainer: vi.fn(() => container),
@@ -222,6 +228,9 @@ function createMockMap() {
     canvas,
     emit(event: string, payload?: unknown) {
       listeners.get(event)?.forEach((handler) => handler(payload));
+    },
+    resolveMissingImage(id: string) {
+      return missingStyleImageResolver?.(id);
     },
     clearStyle() {
       sources.clear();
@@ -1891,9 +1900,6 @@ describe("createMapLibreScenarioLayerController", () => {
     cleanup();
 
     expect(mockMap.map.off).toHaveBeenCalledWith("style.load", expect.any(Function));
-    expect(mockMap.map.off).toHaveBeenCalledWith(
-      "styleimagemissing",
-      expect.any(Function),
-    );
+    expect(mockMap.map.setMissingStyleImageResolver).toHaveBeenLastCalledWith(null);
   });
 });

--- a/src/geo/kml/maplibre/index.ts
+++ b/src/geo/kml/maplibre/index.ts
@@ -433,7 +433,8 @@ export function createMapLibreKmlLayerRenderer(
     ];
     for (const [suffix, prop, value] of layerProps) {
       const mlLayerId = getMapLibreKmlLayerId(layerId, suffix);
-      if (safeGetLayer(mlLayerId)) mlMap.setPaintProperty(mlLayerId, prop, value as any);
+      if (safeGetLayer(mlLayerId))
+        mlMap.setPaintProperty(mlLayerId, prop as never, value as never);
     }
   }
 

--- a/src/modules/maplibreview/MaplibreMap.test.ts
+++ b/src/modules/maplibreview/MaplibreMap.test.ts
@@ -67,6 +67,7 @@ vi.mock("maplibre-gl", () => {
     GlobeControl: MockGlobeControl,
     NavigationControl: MockNavigationControl,
     ScaleControl: MockScaleControl,
+    setWorkerUrl: vi.fn(),
   };
 });
 

--- a/src/modules/maplibreview/MaplibreMap.vue
+++ b/src/modules/maplibreview/MaplibreMap.vue
@@ -7,9 +7,11 @@ import {
   NavigationControl,
   type MapProjectionEvent,
   ScaleControl,
+  setWorkerUrl,
   type MapMouseEvent,
 } from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
+import maplibreWorkerUrl from "@/modules/maplibreview/maplibreWorkerUrl";
 import { storeToRefs } from "pinia";
 import type { MaplibreBasemapStyle } from "@/modules/maplibreview/maplibreBasemaps";
 import type { MapProjection } from "@/stores/mapSettingsStore";
@@ -24,6 +26,8 @@ import {
   toLngLatPair,
   type ScenarioMapViewSnapshot,
 } from "@/modules/scenarioeditor/scenarioMapViewSnapshot";
+
+setWorkerUrl(maplibreWorkerUrl);
 
 defineOptions({
   inheritAttrs: false,
@@ -155,6 +159,8 @@ onMounted(async () => {
     center: props.initialView ? toLngLatPair(props.initialView.center) : [0, 0],
     zoom: props.initialView?.zoom ?? 3,
     bearing: radiansToBearingDegrees(props.initialView?.rotation ?? 0),
+    // Preserve v5 tile overscaling and queryRenderedFeatures behavior.
+    zoomLevelsToOverscale: undefined,
     canvasContextAttributes: {
       preserveDrawingBuffer: true,
     },

--- a/src/modules/maplibreview/MlMapLogic.test.ts
+++ b/src/modules/maplibreview/MlMapLogic.test.ts
@@ -89,6 +89,7 @@ function createSearchActions() {
 
 function createMockMap() {
   const listeners = new Map<string, Set<(event?: unknown) => void>>();
+  let missingStyleImageResolver: ((id: string) => void | Promise<void>) | null = null;
   const sources = new Map<string, { setData: ReturnType<typeof vi.fn> }>();
   const layers = new Map<string, unknown>();
   const canvas = document.createElement("canvas");
@@ -170,6 +171,11 @@ function createMockMap() {
     hasImage: vi.fn(() => false),
     addImage: vi.fn(),
     removeImage: vi.fn(),
+    setMissingStyleImageResolver: vi.fn(
+      (resolver: ((id: string) => void | Promise<void>) | null) => {
+        missingStyleImageResolver = resolver;
+      },
+    ),
     queryRenderedFeatures: vi.fn(() => []),
     // The interactive query scopes itself to the live style's layer ids.
     getLayersOrder: vi.fn(() => [...layers.keys()]),
@@ -197,6 +203,9 @@ function createMockMap() {
     },
     emit(event: string, payload?: unknown) {
       listeners.get(event)?.forEach((handler) => handler(payload));
+    },
+    resolveMissingImage(id: string) {
+      return missingStyleImageResolver?.(id);
     },
   };
 }
@@ -418,7 +427,7 @@ describe("MlMapLogic", () => {
     const setDataCalls = mockMap.getSource("unitSource")?.setData.mock.calls ?? [];
     const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
     const symbolKey = unitData.features[0].properties.symbolKey;
-    mockMap.emit("styleimagemissing", { id: symbolKey });
+    mockMap.resolveMissingImage(symbolKey);
 
     expect(symbolGenerator).toHaveBeenCalledWith(
       "SFGPUCI----K",
@@ -468,7 +477,7 @@ describe("MlMapLogic", () => {
     const setDataCalls = mockMap.getSource("unitSource")?.setData.mock.calls ?? [];
     const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
     expect(unitData.features[0].properties.sidc).toBe("10031000001100000000");
-    mockMap.emit("styleimagemissing", { id: unitData.features[0].properties.symbolKey });
+    mockMap.resolveMissingImage(unitData.features[0].properties.symbolKey);
 
     expect(symbolGenerator).toHaveBeenCalledWith(
       "10031000001100000000",
@@ -511,7 +520,7 @@ describe("MlMapLogic", () => {
     const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
     const symbolKey = unitData.features[0].properties.symbolKey;
     // Bake the on-screen sprite, which records the id as in-use.
-    mockMap.emit("styleimagemissing", { id: symbolKey });
+    mockMap.resolveMissingImage(symbolKey);
 
     const source = getSymbolImageSource(mockMap.map);
     expect(source).toBeDefined();
@@ -570,7 +579,7 @@ describe("MlMapLogic", () => {
     const setDataCalls = mockMap.getSource("unitSource")?.setData.mock.calls ?? [];
     const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
     const symbolKey = unitData.features[0].properties.symbolKey;
-    mockMap.emit("styleimagemissing", { id: symbolKey });
+    mockMap.resolveMissingImage(symbolKey);
 
     expect(symbolGenerator).toHaveBeenCalledWith(
       "SFGPUCI----K",
@@ -718,7 +727,7 @@ describe("MlMapLogic", () => {
     const setDataCalls = mockMap.getSource("unitSource")?.setData.mock.calls ?? [];
     const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
     const symbolKey = unitData.features[0].properties.symbolKey;
-    mockMap.emit("styleimagemissing", { id: symbolKey });
+    mockMap.resolveMissingImage(symbolKey);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(symbolGenerator).not.toHaveBeenCalled();
@@ -779,7 +788,7 @@ describe("MlMapLogic", () => {
     const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
     const symbolKey = unitData.features[0].properties.symbolKey;
     expect(symbolKey).toMatch(/^sel-/);
-    mockMap.emit("styleimagemissing", { id: symbolKey });
+    mockMap.resolveMissingImage(symbolKey);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(symbolGenerator).not.toHaveBeenCalled();
@@ -842,7 +851,7 @@ describe("MlMapLogic", () => {
     const setDataCalls = source?.setData.mock.calls ?? [];
     const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
     const symbolKey = unitData.features[0].properties.symbolKey;
-    mockMap.emit("styleimagemissing", { id: symbolKey });
+    mockMap.resolveMissingImage(symbolKey);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     const addImageCalls = mockMap.map.addImage.mock.calls;
@@ -962,7 +971,7 @@ describe("MlMapLogic", () => {
     const setDataCalls = source?.setData.mock.calls ?? [];
     const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
     const symbolKey = unitData.features[0].properties.symbolKey;
-    mockMap.emit("styleimagemissing", { id: symbolKey });
+    mockMap.resolveMissingImage(symbolKey);
 
     expect(symbolGenerator).toHaveBeenCalledWith(
       "SFGPUCI----K",
@@ -1074,7 +1083,7 @@ describe("MlMapLogic", () => {
     const setDataCalls = source?.setData.mock.calls ?? [];
     const unitData = setDataCalls[setDataCalls.length - 1]?.[0];
     const symbolKey = unitData.features[0].properties.symbolKey;
-    mockMap.emit("styleimagemissing", { id: symbolKey });
+    mockMap.resolveMissingImage(symbolKey);
 
     expect(symbolGenerator).toHaveBeenCalledWith(
       "SFGPUCI----K",

--- a/src/modules/maplibreview/MlMapLogic.vue
+++ b/src/modules/maplibreview/MlMapLogic.vue
@@ -4,7 +4,6 @@ import {
   type GeoJSONSource,
   type MapGeoJSONFeature,
   type MapMouseEvent,
-  type MapStyleImageMissingEvent,
   type MapTouchEvent,
   type Map as MlMap,
   type PointLike,
@@ -72,6 +71,7 @@ import { provideMapHoverContext, type HoverFeatureLike } from "@/geo/mapHover";
 import MapHoverFeatureTooltip from "@/components/MapHoverFeatureTooltip.vue";
 import { CUSTOM_SYMBOL_PREFIX, CUSTOM_SYMBOL_SLICE } from "@/config/constants";
 import { SID_INDEX } from "@/symbology/sidc";
+import { registerMissingStyleImageResolver } from "@/modules/maplibreview/missingStyleImageResolver";
 
 const ALWAYS_VISIBLE_UNIT_GROUP_ID = "always";
 const NATIVE_CAPTURE_OPTIONS = { capture: true };
@@ -534,21 +534,21 @@ async function buildSymbolImageData(
   return buildMilSymbolImageData(imageId, cachedSymbol, pixelRatio);
 }
 
-function styleImageMissing(e: MapStyleImageMissingEvent) {
-  if (usedImageIds.has(e.id) || mlMap.hasImage(e.id)) return;
+function resolveMissingStyleImage(id: string) {
+  if (usedImageIds.has(id) || mlMap.hasImage(id)) return;
 
-  const symbolCode = e.id.startsWith("sel-") ? e.id.slice(4) : e.id;
+  const symbolCode = id.startsWith("sel-") ? id.slice(4) : id;
   const cachedSymbol = symbolCache.get(symbolCode);
   if (cachedSymbol?.kind === "custom") {
-    createCustomSymbolImage(e.id, cachedSymbol);
+    createCustomSymbolImage(id, cachedSymbol);
     return;
   }
 
   const pixelRatio = getSpritePixelRatio();
-  const data = buildMilSymbolImageData(e.id, cachedSymbol, pixelRatio);
+  const data = buildMilSymbolImageData(id, cachedSymbol, pixelRatio);
   if (data) {
-    mlMap.addImage(e.id, data, { pixelRatio });
-    usedImageIds.add(e.id);
+    mlMap.addImage(id, data, { pixelRatio });
+    usedImageIds.add(id);
   }
 }
 
@@ -567,7 +567,10 @@ function onStyleLoad() {
 
 useMaplibreDayNightTerminator(engineRef, activeScenario);
 
-mlMap.on("styleimagemissing", styleImageMissing);
+const unregisterMissingStyleImageResolver = registerMissingStyleImageResolver(
+  mlMap,
+  resolveMissingStyleImage,
+);
 mlMap.on("style.load", onStyleLoad);
 onStyleLoad();
 
@@ -1128,7 +1131,7 @@ mlMap
 mlMap.on("mousedown", onUnitDragStart);
 mlMap.on("touchstart", onUnitDragStart);
 mlMap.on("mousemove", onMapMouseMove);
-mlMap.on("mouseleave", onMapMouseLeave);
+mlMap.on("mouseleave" as never, onMapMouseLeave);
 mlMap.on("touchmove", onMapTouchMove);
 mlMap.on("mouseup", onUnitDragEnd);
 mlMap.on("touchend", onUnitDragEnd);
@@ -1338,7 +1341,7 @@ onUnmounted(() => {
   clearSuppressNextNativeClick();
   boxSelect.cleanup();
   disposeUnitHistory();
-  mlMap.off("styleimagemissing", styleImageMissing);
+  unregisterMissingStyleImageResolver();
   mlMap.off("style.load", onStyleLoad);
   mlMap.off("click", onMapClick);
   mlMap
@@ -1350,7 +1353,7 @@ onUnmounted(() => {
   mlMap.off("mousedown", onUnitDragStart);
   mlMap.off("touchstart", onUnitDragStart);
   mlMap.off("mousemove", onMapMouseMove);
-  mlMap.off("mouseleave", onMapMouseLeave);
+  mlMap.off("mouseleave" as never, onMapMouseLeave);
   mlMap.off("touchmove", onMapTouchMove);
   mlMap.off("mouseup", onUnitDragEnd);
   mlMap.off("touchend", onUnitDragEnd);

--- a/src/modules/maplibreview/imageExport/mapLibreExport.test.ts
+++ b/src/modules/maplibreview/imageExport/mapLibreExport.test.ts
@@ -35,6 +35,8 @@ const maplibreMock = vi.hoisted(() => {
 
     addImage() {}
 
+    setMissingStyleImageResolver() {}
+
     getCanvas() {
       const canvas = document.createElement("canvas");
       canvas.toBlob = (callback: BlobCallback) => {
@@ -73,7 +75,7 @@ const maplibreMock = vi.hoisted(() => {
 });
 
 vi.mock("maplibre-gl", () => ({
-  default: { Map: maplibreMock.FakeMap },
+  Map: maplibreMock.FakeMap,
 }));
 
 vi.mock("../symbolImageRegistry", async (importOriginal) => {

--- a/src/modules/maplibreview/imageExport/mapLibreExport.ts
+++ b/src/modules/maplibreview/imageExport/mapLibreExport.ts
@@ -1,5 +1,6 @@
-import maplibregl, {
+import {
   type LngLatBoundsLike,
+  Map as MlMapConstructor,
   type Map as MlMap,
   type StyleImage,
 } from "maplibre-gl";
@@ -376,7 +377,7 @@ async function renderViaHiddenMap(
   let hiddenMap: MlMap | null = null;
   try {
     const style = cloneStyleForExport(sourceMap.getStyle());
-    hiddenMap = new maplibregl.Map({
+    hiddenMap = new MlMapConstructor({
       container,
       style,
       ...(camera.bounds
@@ -384,6 +385,8 @@ async function renderViaHiddenMap(
         : { center: camera.center, zoom: camera.zoom }),
       interactive: false,
       attributionControl: false,
+      // Match the live map's v5-compatible overscaling behavior.
+      zoomLevelsToOverscale: undefined,
       pixelRatio: outputScale,
       // MapLibre clamps the canvas to maxCanvasSize (default [4096, 4096]) and
       // silently lowers the effective pixel ratio to fit. At high output scales
@@ -405,9 +408,9 @@ async function renderViaHiddenMap(
     // markers, etc.) is copied from the source map as-is.
     const symbolSource = getSymbolImageSource(sourceMap);
     const ownedIds = symbolSource ? new Set(symbolSource.usedImageIds()) : null;
-    hiddenMap.on("styleimagemissing", (e) => {
-      if (ownedIds?.has(e.id)) return;
-      copyImageBetweenMaps(sourceMap, hiddenMap!, e.id);
+    hiddenMap.setMissingStyleImageResolver((id) => {
+      if (ownedIds?.has(id)) return;
+      copyImageBetweenMaps(sourceMap, hiddenMap!, id);
     });
 
     await new Promise<void>((resolve, reject) => {
@@ -649,25 +652,29 @@ function scaleUnitSymbolLayers(map: MlMap, scale: number) {
     map.setLayoutProperty(
       layer.id,
       "icon-size",
-      multiplyStyleValue(layout["icon-size"], scale),
+      multiplyStyleValue(layout["icon-size"], scale) as never,
     );
     map.setLayoutProperty(
       layer.id,
       "text-size",
-      multiplyStyleValue(layout["text-size"], scale),
+      multiplyStyleValue(layout["text-size"], scale) as never,
     );
-    map.setLayoutProperty(layer.id, "text-offset", scaledTextOffsetExpression(scale));
+    map.setLayoutProperty(
+      layer.id,
+      "text-offset",
+      scaledTextOffsetExpression(scale) as never,
+    );
 
     const paint = layer.paint ?? {};
     map.setPaintProperty(
       layer.id,
       "text-halo-width",
-      multiplyStyleValue(paint["text-halo-width"], scale),
+      multiplyStyleValue(paint["text-halo-width"], scale) as never,
     );
     map.setPaintProperty(
       layer.id,
       "text-halo-blur",
-      multiplyStyleValue(paint["text-halo-blur"], scale),
+      multiplyStyleValue(paint["text-halo-blur"], scale) as never,
     );
   }
 }

--- a/src/modules/maplibreview/maplibreScenarioFeatures.ts
+++ b/src/modules/maplibreview/maplibreScenarioFeatures.ts
@@ -10,14 +10,10 @@ import type {
   Point,
   Position,
 } from "geojson";
-import type {
-  GeoJSONSource,
-  Map as MlMap,
-  MapGeoJSONFeature,
-  MapStyleImageMissingEvent,
-} from "maplibre-gl";
+import type { GeoJSONSource, Map as MlMap, MapGeoJSONFeature } from "maplibre-gl";
 import { toRgbaColor } from "@/utils/cssColor";
 import { getSpritePixelRatio } from "@/modules/maplibreview/spriteConfig";
+import { registerMissingStyleImageResolver } from "@/modules/maplibreview/missingStyleImageResolver";
 import {
   drawArrowSymbol,
   getArrowGlobeIconOffset,
@@ -1140,8 +1136,9 @@ function ensureImage(
 export class MapLibreScenarioFeatureManager {
   private plans = new Map<string, ScenarioLayerRenderPlan>();
   private imageDefinitions = new Map<string, ImageDefinition>();
-  private styleImageMissingHandler = (event: MapStyleImageMissingEvent) => {
-    ensureImage(this.mlMap, event.id, this.imageDefinitions.get(event.id));
+  private unregisterMissingStyleImageResolver: () => void;
+  private resolveMissingStyleImage = (id: string) => {
+    ensureImage(this.mlMap, id, this.imageDefinitions.get(id));
   };
 
   constructor(
@@ -1153,12 +1150,15 @@ export class MapLibreScenarioFeatureManager {
       featureIds: new Set(),
     }),
   ) {
-    this.mlMap.on("styleimagemissing", this.styleImageMissingHandler);
+    this.unregisterMissingStyleImageResolver = registerMissingStyleImageResolver(
+      this.mlMap,
+      this.resolveMissingStyleImage,
+    );
   }
 
   destroy() {
     this.clear();
-    this.mlMap.off("styleimagemissing", this.styleImageMissingHandler);
+    this.unregisterMissingStyleImageResolver();
   }
 
   clear() {

--- a/src/modules/maplibreview/maplibreWorkerUrl.ts
+++ b/src/modules/maplibreview/maplibreWorkerUrl.ts
@@ -1,0 +1,3 @@
+import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&url";
+
+export default workerUrl;

--- a/src/modules/maplibreview/missingStyleImageResolver.ts
+++ b/src/modules/maplibreview/missingStyleImageResolver.ts
@@ -1,0 +1,46 @@
+import type { Map as MlMap, MissingStyleImageResolver } from "maplibre-gl";
+
+type ResolverRegistry = {
+  resolvers: Set<MissingStyleImageResolver>;
+  dispatch: MissingStyleImageResolver;
+};
+
+const registries = new WeakMap<MlMap, ResolverRegistry>();
+
+/**
+ * MapLibre exposes one missing-image resolver per map. This registry lets the
+ * unit and scenario-feature renderers contribute images without overwriting
+ * each other's resolver.
+ */
+export function registerMissingStyleImageResolver(
+  map: MlMap,
+  resolver: MissingStyleImageResolver,
+): () => void {
+  let registry = registries.get(map);
+  if (!registry) {
+    const resolvers = new Set<MissingStyleImageResolver>();
+    registry = {
+      resolvers,
+      dispatch: async (id) => {
+        for (const candidate of resolvers) {
+          await candidate(id);
+          if (map.hasImage(id)) return;
+        }
+      },
+    };
+    registries.set(map, registry);
+    map.setMissingStyleImageResolver(registry.dispatch);
+  }
+
+  registry.resolvers.add(resolver);
+  let registered = true;
+  return () => {
+    if (!registered) return;
+    registered = false;
+    registry.resolvers.delete(resolver);
+    if (registry.resolvers.size === 0) {
+      map.setMissingStyleImageResolver(null);
+      registries.delete(map);
+    }
+  };
+}

--- a/src/stores/maplibreLayersStore.test.ts
+++ b/src/stores/maplibreLayersStore.test.ts
@@ -3,8 +3,17 @@ import { createPinia, setActivePinia } from "pinia";
 import { useMaplibreLayersStore } from "@/stores/maplibreLayersStore";
 import { useMapSettingsStore } from "@/stores/mapSettingsStore";
 
+const runtimeEnvironment = vi.hoisted(() => ({ canReadHostedConfig: true }));
+
+vi.mock("@/utils/runtimeEnvironment", () => ({
+  get canReadHostedConfig() {
+    return runtimeEnvironment.canReadHostedConfig;
+  },
+}));
+
 beforeEach(() => {
   setActivePinia(createPinia());
+  runtimeEnvironment.canReadHostedConfig = true;
 });
 
 afterEach(() => {
@@ -13,9 +22,25 @@ afterEach(() => {
 });
 
 describe("a config that cannot be read", () => {
+  it("does not request a server-only config in the standalone build", async () => {
+    runtimeEnvironment.canReadHostedConfig = false;
+    const fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+    const store = useMaplibreLayersStore();
+
+    await store.initialize();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(store.layers.map((layer) => layer.sourceType)).toEqual([
+      "style",
+      "style",
+      "style",
+      "style",
+    ]);
+  });
+
   it("offers the fallback basemaps", async () => {
-    // The standalone build always lands here: a file:// page has no server to read the config
-    // from. It keeps the fallbacks, because whether they load is a property of the network.
+    // A served build also keeps working when its optional config is missing.
     const fetchSpy = vi.fn(async () => {
       throw new TypeError("Failed to fetch");
     });

--- a/src/stores/maplibreLayersStore.ts
+++ b/src/stores/maplibreLayersStore.ts
@@ -13,6 +13,7 @@ import {
 import { unregisterArchive } from "@/geo/pmtilesProtocol";
 import { useMapSettingsStore } from "@/stores/mapSettingsStore";
 import { customBasemapToLayerConfig } from "@/geo/customBasemap";
+import { canReadHostedConfig } from "@/utils/runtimeEnvironment";
 
 /**
  * The basemaps to use when `config/maplibreConfig.json` cannot be read.
@@ -66,15 +67,16 @@ export const useMaplibreLayersStore = defineStore("maplibreLayers", () => {
   }
 
   async function runInitialize() {
-    try {
-      const res = await fetch("/config/maplibreConfig.json");
-      const config = (await res.json()) as MlLayerConfigFile;
-      layers.value = config && config.length > 0 ? config : FALLBACK_LAYERS;
-    } catch (e) {
-      // A standalone file has no server to read the config from, thus it always lands here and
-      // offers the fallbacks. They load if the computer can reach them, and the user selects
-      // "No base map" or "Open PMTiles archive…" if it cannot.
-      console.warn("Could not read config/maplibreConfig.json", e);
+    if (canReadHostedConfig) {
+      try {
+        const res = await fetch("/config/maplibreConfig.json");
+        const config = (await res.json()) as MlLayerConfigFile;
+        layers.value = config && config.length > 0 ? config : FALLBACK_LAYERS;
+      } catch (e) {
+        console.warn("Could not read config/maplibreConfig.json", e);
+        layers.value = FALLBACK_LAYERS;
+      }
+    } else {
       layers.value = FALLBACK_LAYERS;
     }
     addCustomBasemaps();

--- a/src/utils/runtimeEnvironment.ts
+++ b/src/utils/runtimeEnvironment.ts
@@ -28,3 +28,12 @@ export const isGeoSearchAvailable = true;
  * browser has the API at all.
  */
 export const canPersistFileHandles = true;
+
+/**
+ * True when this build has a web server that can provide files from `public/config/`.
+ *
+ * A standalone file uses its built-in basemap defaults. Trying the hosted path first would turn
+ * `/config/maplibreConfig.json` into a file:// URL, which browsers must reject as a cross-origin
+ * fetch from an opaque origin.
+ */
+export const canReadHostedConfig = true;

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -14,6 +14,7 @@
 
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
     "types": ["node"]
   }
 }

--- a/vite.singlefile.config.test.ts
+++ b/vite.singlefile.config.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { inlineMaplibreWorkerInBundle } from "./scripts/inlineMaplibreWorker.ts";
+
+describe("inlineMaplibreWorkerInBundle", () => {
+  it("replaces the emitted worker path with a classic-worker Blob URL", () => {
+    const bundle = {
+      "index.js": {
+        type: "chunk" as const,
+        code: "const workerUrl=`./maplibre-gl-worker-abc.js`;setWorkerUrl(workerUrl);",
+      },
+      "maplibre-gl-worker-abc.js": {
+        type: "asset" as const,
+        source: 'self.postMessage("ready");',
+      },
+    };
+
+    inlineMaplibreWorkerInBundle(bundle);
+
+    expect(bundle["index.js"].code).toContain(
+      'URL.createObjectURL(new Blob(["self.postMessage(\\"ready\\");"],{type:"text/javascript"}))+"#maplibre-worker.cjs"',
+    );
+    expect(bundle).not.toHaveProperty("maplibre-gl-worker-abc.js");
+  });
+});

--- a/vite.singlefile.config.ts
+++ b/vite.singlefile.config.ts
@@ -38,6 +38,10 @@ export function createAppHistory() {
   // origin has no IndexedDB and no working file picker).
   "src/utils/runtimeEnvironment.ts": `export const isGeoSearchAvailable = false;
 export const canPersistFileHandles = false;`,
+  // MapLibre v6 requires an explicit worker URL under Vite. The hosted build emits a cacheable
+  // worker asset; the standalone build turns the same bundled worker into an in-document URL.
+  "src/modules/maplibreview/maplibreWorkerUrl.ts": `import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&inline&url";
+export default workerUrl;`,
 };
 
 function replaceStandaloneModules(): Plugin {

--- a/vite.singlefile.config.ts
+++ b/vite.singlefile.config.ts
@@ -3,7 +3,7 @@ import { extname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { defineConfig, mergeConfig, type Plugin } from "vite";
 import { viteSingleFile } from "vite-plugin-singlefile";
-import baseConfig from "./vite.config";
+import baseConfig from "./vite.config.ts";
 import { inlineMaplibreWorkerInBundle } from "./scripts/inlineMaplibreWorker.ts";
 
 const repoPath = (path: string) => fileURLToPath(new URL(path, import.meta.url));

--- a/vite.singlefile.config.ts
+++ b/vite.singlefile.config.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { defineConfig, mergeConfig, type Plugin } from "vite";
 import { viteSingleFile } from "vite-plugin-singlefile";
 import baseConfig from "./vite.config";
+import { inlineMaplibreWorkerInBundle } from "./scripts/inlineMaplibreWorker.ts";
 
 const repoPath = (path: string) => fileURLToPath(new URL(path, import.meta.url));
 
@@ -37,11 +38,8 @@ export function createAppHistory() {
   // No place search (it is a service on the internet), and no persisted file handles (an opaque
   // origin has no IndexedDB and no working file picker).
   "src/utils/runtimeEnvironment.ts": `export const isGeoSearchAvailable = false;
-export const canPersistFileHandles = false;`,
-  // MapLibre v6 requires an explicit worker URL under Vite. The hosted build emits a cacheable
-  // worker asset; the standalone build turns the same bundled worker into an in-document URL.
-  "src/modules/maplibreview/maplibreWorkerUrl.ts": `import workerUrl from "maplibre-gl/dist/maplibre-gl-worker.mjs?worker&inline&url";
-export default workerUrl;`,
+export const canPersistFileHandles = false;
+export const canReadHostedConfig = false;`,
 };
 
 function replaceStandaloneModules(): Plugin {
@@ -119,6 +117,21 @@ function inlinePublicAssets(): Plugin {
 }
 
 /**
+ * Replaces Vite's emitted MapLibre worker URL with a Blob URL backed by the
+ * bundled worker source. `?worker&inline&url` cannot be used here: Vite exports
+ * a worker constructor for that query, while MapLibre's setWorkerUrl requires
+ * an actual string URL.
+ */
+function inlineMaplibreWorker(): Plugin {
+  return {
+    name: "singlefile-inline-maplibre-worker",
+    generateBundle(_options, bundle) {
+      inlineMaplibreWorkerInBundle(bundle);
+    },
+  };
+}
+
+/**
  * Fails the build unless the output is one file that needs nothing else.
  *
  * This is the promise of Level 3, stated once and checked against the artifact, rather than
@@ -159,8 +172,8 @@ function assertSelfContained(): Plugin {
 }
 
 // Level 3 (standalone file) packaging: the normal build, inlined into one HTML file that runs from
-// file://. It bundles no tiles, fonts or scenarios. Workers are inlined at their import sites
-// (`?worker&inline`), thus both builds bundle them the same way.
+// file://. It bundles no tiles, fonts or scenarios. The MapLibre worker is emitted by Vite and
+// folded back into the HTML as a classic-worker Blob URL.
 export default mergeConfig(
   baseConfig,
   defineConfig({
@@ -168,6 +181,7 @@ export default mergeConfig(
     plugins: [
       replaceStandaloneModules(),
       inlinePublicAssets(),
+      inlineMaplibreWorker(),
       viteSingleFile(),
       assertSelfContained(),
     ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from "node:url";
 import { mergeConfig, defineConfig, configDefaults } from "vitest/config";
-import viteConfig from "./vite.config";
+import viteConfig from "./vite.config.ts";
 
 export default mergeConfig(
   viteConfig,


### PR DESCRIPTION
## Summary

- Upgrade MapLibre GL from v5.24.0 to v6.3.0
- Adapt missing-style-image handling to the v6 resolver API
- Configure the MapLibre worker URL for hosted builds
- Inline the MapLibre worker as a classic Blob worker in standalone file builds
- Avoid server-only MapLibre config requests from standalone file builds
- Make shared Vite config imports compatible with the upcoming native config loader
- Preserve existing overscaling and map export behavior
- Update MapLibre-related mocks and unit tests

## Testing

- `pnpm vitest run vite.singlefile.config.test.ts src/stores/maplibreLayersStore.test.ts` — 7 passed
- `pnpm type-check` — passed
- `pnpm build:singlefile` — passed without config-loader warnings
- Verified the artifact contains only `dist-singlefile/index.html`, no `/config/maplibreConfig.json` reference, and one classic worker marker
- Full unit suite: 1,645 passed, 5 skipped, and one unrelated failure in `ControlMeasureAmplifiers.test.ts` because the test expects values 13–18 while the UI renders 13–19