### PR TITLE
Preview scoped scenario imports with single-step undo

### DIFF
--- a/src/components/ImportOrbatMapperStep.vue
+++ b/src/components/ImportOrbatMapperStep.vue
@@ -10,35 +10,26 @@ import {
 } from "@/components/ui/field";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { computed, h, ref, watch } from "vue";
+import { klona } from "klona";
 import BaseButton from "@/components/BaseButton.vue";
-import { createNameToIdMap, injectStrict, moveItemMutable } from "@/utils";
+import { createNameToIdMap, injectStrict } from "@/utils";
 import { activeScenarioKey } from "@/components/injects";
 import type {
   CustomSymbol,
   Scenario,
-  SideGroup,
-  Unit,
   UnitEquipment,
   UnitPersonnel,
   UnitStatus,
-  UnitSymbolOptions,
 } from "@/types/scenarioModels";
-import { mapReinforcedStatus2Field } from "@/types/scenarioModels";
 import { useBrowserScenarios } from "@/composables/browserScenarios";
-import type { SelectItem } from "@/components/types";
 import { prepareScenario } from "@/scenariostore/newScenarioStore";
-import type { CellContext, ColumnDef } from "@tanstack/vue-table";
-import OrbatCellRenderer from "@/components/OrbatCellRenderer.vue";
+import type { ColumnDef } from "@tanstack/vue-table";
 import DataGrid from "@/modules/grid/DataGrid.vue";
 import ToggleField from "@/components/ToggleField.vue";
-import type { NSideGroup, NSupplyCategory, NUnit } from "@/types/internalModels";
+import type { NSupplyCategory } from "@/types/internalModels";
 import { useNotifications } from "@/composables/notifications";
-import { ChevronRightIcon } from "@heroicons/vue/20/solid";
-import { useTimeFormatStore } from "@/stores/timeFormatStore";
 import { useImportStore } from "@/stores/importExportStore";
-import { addUnitHierarchy } from "@/importexport/convertUtils";
-import dayjs from "dayjs";
-import InlineAlertWarning from "@/components/InlineAlertWarning.vue";
+import ScenarioImportContribution from "@/components/ScenarioImportContribution.vue";
 import { getSupplyClass, getUom } from "@/scenariostore/supplyManipulations";
 import {
   Card,
@@ -63,6 +54,8 @@ interface Props {
 }
 
 const props = defineProps<Props>();
+const contributionOptions = ref<HTMLElement | null>(null);
+const contributionActions = ref<HTMLElement | null>(null);
 const emit = defineEmits(["cancel", "loaded"]);
 const activeScenario = injectStrict(activeScenarioKey);
 const { unitActions, settings, store: scnStore, time, geo } = activeScenario;
@@ -83,13 +76,6 @@ const importMode = ref<
   | "supplyCategories"
   | "customSymbols"
 >("side");
-const unitImportMode = ref<"units-only" | "units-and-state" | "state-only">(
-  "units-and-state",
-);
-const stateMergeMode = ref<"replace" | "add_new">("replace");
-const sideMergeMode = ref<"replace" | "add_new">("replace");
-const groupMergeMode = ref<"replace" | "add_new">("add_new");
-const selectedItems = ref<(Unit | SideGroup)[]>([]);
 const selectedEquipment = ref<UnitEquipment[]>([]);
 const selectedPersonnel = ref<UnitPersonnel[]>([]);
 const selectedStatuses = ref<UnitStatus[]>([]);
@@ -119,34 +105,8 @@ function previewItemName(id: FeatureId, removed: boolean) {
   return item?.name ? `${item.name} (${id})` : id;
 }
 const importedState = computed(() => {
-  return prepareScenario(props.data);
+  return prepareScenario(klona(props.data));
 });
-
-const fmt = useTimeFormatStore();
-
-function getCombinedSymbolOptions(
-  unitOrSideGroup: NUnit | NSideGroup,
-  ignoreUnit = false,
-): UnitSymbolOptions {
-  if (!unitOrSideGroup) return {};
-  const state = importedState.value;
-  let _sid, _gid, reinforcedReduced;
-  if ("sidc" in unitOrSideGroup) {
-    _sid = unitOrSideGroup._sid;
-    _gid = unitOrSideGroup._gid;
-    reinforcedReduced = mapReinforcedStatus2Field(unitOrSideGroup.reinforcedStatus);
-  } else {
-    _sid = unitOrSideGroup._pid;
-    _gid = unitOrSideGroup.id;
-    ignoreUnit = true;
-  }
-  return {
-    ...(state.sideMap[_sid!]?.symbolOptions || {}),
-    ...(state.sideGroupMap[_gid!]?.symbolOptions || {}),
-    ...(ignoreUnit ? {} : unitOrSideGroup.symbolOptions || {}),
-    ...(ignoreUnit ? {} : { reinforcedReduced: reinforcedReduced ?? "" }),
-  };
-}
 
 const stats = computed(() => {
   return {
@@ -158,62 +118,6 @@ const stats = computed(() => {
 const importedLayers = computed(() =>
   props.data.layerStack.filter(isScenarioOverlayLayer),
 );
-
-const importedSides = computed((): SelectItem[] => {
-  return importedState.value.sides
-    .map((id) => importedState.value.sideMap[id])
-    .map((side) => {
-      return {
-        label: side.name,
-        value: side.id,
-      };
-    });
-});
-
-const targetSides = computed((): SelectItem[] => {
-  return targetState.sides
-    .map((id) => targetState.sideMap[id])
-    .map((side) => {
-      return {
-        label: side.name,
-        value: side.id,
-      };
-    });
-});
-
-const importedSideGroups = computed(() => {
-  const sideId = selectedSourceSideId.value;
-  if (!sideId) return [];
-  const side = importedState.value.sideMap[sideId];
-  if (!side) return [];
-  return side.groups
-    .map((id) => importedState.value.sideGroupMap[id])
-    .map((sideGroup) => {
-      return {
-        label: sideGroup.name,
-        value: sideGroup.id,
-      };
-    });
-});
-
-const selectedSourceSideId = ref(importedSides.value[0]?.value as string);
-const selectedTargetSideId = ref(targetSides.value[0]?.value as string);
-const selectedSourceSideGroupId = ref(importedSideGroups.value[0]?.value as string);
-
-const selectedSourceSide = computed(() => {
-  return props.data.sides.find((s) => s.id === selectedSourceSideId.value);
-});
-
-const currentData = computed(() => {
-  const s = props.data.sides.find((s) => s.id === selectedSourceSideId.value);
-
-  if (importMode.value === "side") {
-    return [...(s?.groups ?? []), ...(s?.subUnits ?? [])];
-  }
-
-  const sg = s?.groups.find((g) => g.id === selectedSourceSideGroupId.value);
-  return sg?.subUnits ?? [];
-});
 
 const currentEquipment = computed(() => {
   return props.data.equipment ?? [];
@@ -234,23 +138,6 @@ const currentSupplyCategories = computed(() => {
 const currentCustomIcons = computed(() => {
   return Object.values(importedState.value.customSymbolMap);
 });
-
-const hasExistingUnits = computed(() => {
-  return selectedItems.value.some((item) => item.id in targetState.unitMap);
-});
-
-const hasExistingSide = computed(() => {
-  return selectedSourceSideId.value in targetState.sideMap;
-});
-
-const hasExistingSideGroup = computed(() => {
-  return selectedSourceSideGroupId.value in targetState.sideGroupMap;
-});
-
-const wantsToImportState = computed(
-  () =>
-    unitImportMode.value === "units-and-state" || unitImportMode.value === "state-only",
-);
 
 const sources = [
   { value: "side", label: "Side" },
@@ -275,103 +162,6 @@ const sources = [
 const isUnitImport = computed(() =>
   ["side", "group", "units"].includes(importMode.value),
 );
-
-watch(selectedSourceSideId, (newSide) => {
-  const side = importedState.value.sideMap[newSide];
-  selectedSourceSideGroupId.value = side.groups[0];
-});
-
-watch(hasExistingUnits, (exists) => {
-  if (!exists && unitImportMode.value === "state-only") {
-    unitImportMode.value = "units-and-state";
-  }
-});
-
-function renderExpandCell({ getValue, row }: CellContext<Unit, string>) {
-  const symbolOptions: UnitSymbolOptions & { customSymbolMap?: Record<string, unknown> } =
-    getCombinedSymbolOptions(importedState.value.unitMap[row.original.id]);
-  symbolOptions.customSymbolMap = importedState.value.customSymbolMap ?? {};
-
-  return h(OrbatCellRenderer, {
-    value: getValue(),
-    sidc: row.original.sidc,
-    expanded: row.getIsExpanded(),
-    level: row.depth,
-    canExpand: row.getCanExpand(),
-    onToggle: row.getToggleExpandedHandler(),
-    symbolOptions,
-  });
-}
-
-const computedColumns = computed((): (ColumnDef<Unit> | false)[] => {
-  return [
-    {
-      accessorFn: (f) => f.name,
-      id: "name",
-      cell: renderExpandCell,
-      header: ({ table }) => {
-        return h(
-          "button",
-          {
-            type: "button",
-            title: "Expand/collapse all",
-            onClick: table.getToggleAllRowsExpandedHandler(),
-            class: "flex items-center gap-2",
-          },
-          [
-            h(ChevronRightIcon, {
-              class: [
-                "size-6 transform transition-transform text-muted-foreground",
-                table.getIsAllRowsExpanded() ? "rotate-90" : "",
-              ],
-            }),
-            "Name",
-          ],
-        );
-      },
-      enableGlobalFilter: false,
-      size: 350,
-      enableSorting: false,
-    },
-    {
-      accessorFn: (f) =>
-        f.state?.length
-          ? fmt.trackFormatter.format(+new Date(f.state[f.state.length - 1].t)) +
-            ` (${f.state.length})`
-          : "",
-      id: "t",
-      header: "Last state entry",
-      enableSorting: false,
-      size: 235,
-    },
-    {
-      accessorFn: (f) =>
-        f.id in targetState.unitMap || f.id in targetState.sideGroupMap ? "Yes" : "No",
-      id: "exists",
-      header: "Exists?",
-      enableSorting: false,
-      size: 90,
-    },
-
-    {
-      accessorFn: (f) => {
-        if (!f.state?.length) return "";
-        const existingUnit = targetState.unitMap[f.id];
-        if (!existingUnit) return "";
-        if (!existingUnit.state?.length) return "";
-        const lastTimestamp = existingUnit.state[existingUnit.state.length - 1].t;
-        const lastSourceTimestamp = f.state[f.state.length - 1].t;
-        const diff = +new Date(lastSourceTimestamp) - lastTimestamp;
-        if (diff === 0) return "";
-        return dayjs.duration(diff).toISOString();
-      },
-
-      id: "diff",
-      header: "Diff",
-      enableSorting: false,
-    },
-  ];
-});
 
 const equipmentColumns: ColumnDef<UnitEquipment>[] = [
   {
@@ -484,14 +274,8 @@ const layerColumns: ColumnDef<ScenarioOverlayLayer>[] = [
   },
 ];
 
-// check that the item is a unit
-function isUnit(item: Unit | SideGroup): item is Unit {
-  return "sidc" in item;
-}
-
 async function onFormSubmit() {
   let didReplaceLayers = false;
-  const selectedUnitIds = new Set(selectedItems.value.filter(isUnit).map((u) => u.id));
   console.log("import mode", importMode.value);
   if (importMode.value === "equipment") {
     doEquipmentImport(selectedEquipment.value);
@@ -517,12 +301,6 @@ async function onFormSubmit() {
       },
       { label: "batchLayer", value: "scenario-import" },
     );
-  } else if (unitImportMode.value === "state-only") {
-    doStateOnlyImport(selectedUnitIds);
-  } else if (importMode.value === "side" && selectedSourceSideId.value) {
-    doSideImport(selectedSourceSideId.value);
-  } else if (importMode.value === "group" && selectedSourceSideGroupId.value) {
-    doGroupImport(selectedSourceSideGroupId.value);
   }
   time.setCurrentTime(targetState.currentTime);
   targetState.unitStateCounter++;
@@ -623,127 +401,6 @@ function doSupplyCategoryImport(selectedSupplyCategories: NSupplyCategory[]) {
     }
   });
 }
-
-function doStateOnlyImport(selectedUnitIds: Set<string>) {
-  scnStore.groupUpdate(() => {
-    for (const importedUnitId of selectedUnitIds) {
-      const importedUnit = importedState.value.unitMap[importedUnitId];
-      if (!importedUnit || !importedUnit.state?.length) {
-        continue;
-      }
-      const existingUnit = targetState.unitMap[importedUnit.id];
-      if (!existingUnit) {
-        continue;
-      }
-      if (stateMergeMode.value === "replace" || !existingUnit.state?.length) {
-        unitActions.setUnitState(existingUnit.id, importedUnit.state);
-      } else {
-        const lastTimestamp = existingUnit.state[existingUnit.state.length - 1].t;
-        const newStates = importedUnit.state.filter((s) => s.t > lastTimestamp);
-        if (newStates.length) {
-          unitActions.setUnitState(existingUnit.id, [
-            ...existingUnit.state,
-            ...newStates,
-          ]);
-        }
-      }
-    }
-  });
-}
-
-function doSideImport(importedSideId: string) {
-  const sideAlreadyExists = hasExistingSide.value;
-
-  const importedSide = importedState.value.sideMap[importedSideId];
-  const createNewId = sideAlreadyExists && sideMergeMode.value === "add_new";
-
-  scnStore.groupUpdate(() => {
-    let deletedSideIndex = -1;
-    if (sideAlreadyExists && sideMergeMode.value === "replace") {
-      deletedSideIndex = targetState.sides.findIndex((id) => id === importedSideId);
-      unitActions.deleteSide(importedSideId);
-    }
-
-    const addedSideId = unitActions.addSide(importedSide, {
-      addDefaultGroup: false,
-      markAsNew: false,
-      newId: createNewId,
-    });
-    if (deletedSideIndex !== -1) {
-      const nextSideId = targetState.sides[deletedSideIndex + 1];
-      if (nextSideId) unitActions.moveSide(addedSideId, nextSideId, "above");
-    }
-    for (const item of currentData.value) {
-      if (isUnit(item)) {
-        addUnitHierarchy(item, addedSideId, activeScenario, {
-          newIds: createNewId,
-          includeState: unitImportMode.value === "units-and-state",
-          sourceState: importedState.value,
-        });
-        continue;
-      }
-      const groupId = item.id;
-      const importedGroup = importedState.value.sideGroupMap[groupId];
-      const addedGroupId = unitActions.addSideGroup(
-        addedSideId,
-        { ...importedGroup, _isNew: false },
-        {
-          newId: createNewId,
-        },
-      );
-      if (!item.subUnits || !addedGroupId) continue;
-      for (const unit of item.subUnits) {
-        addUnitHierarchy(unit, addedGroupId, activeScenario, {
-          newIds: createNewId,
-          includeState: unitImportMode.value === "units-and-state",
-          sourceState: importedState.value,
-        });
-      }
-    }
-  });
-}
-
-function doGroupImport(importedGroupId: string) {
-  const importedGroup = importedState.value.sideGroupMap[importedGroupId];
-  const targetSideId = selectedTargetSideId.value;
-  if (!importedGroup) return;
-  const groupAlreadyExists = importedGroupId in targetState.sideGroupMap;
-  const createNewId = groupAlreadyExists && groupMergeMode.value === "add_new";
-
-  scnStore.groupUpdate(() => {
-    let deletedGroupIndex = -1;
-    if (groupAlreadyExists && groupMergeMode.value === "replace") {
-      deletedGroupIndex = targetState.sideMap[targetSideId].groups.findIndex(
-        (id) => id === importedGroupId,
-      );
-      unitActions.deleteSideGroup(importedGroupId);
-    }
-
-    const importedGroup = importedState.value.sideGroupMap[importedGroupId];
-    const addedGroupId = unitActions.addSideGroup(
-      targetSideId,
-      { ...importedGroup, _isNew: false },
-      {
-        newId: createNewId,
-      },
-    );
-    if (!addedGroupId) return;
-    if (deletedGroupIndex !== -1) {
-      scnStore.update((s) => {
-        const groups = s.sideMap[targetSideId].groups;
-        moveItemMutable(groups, groups.length - 1, deletedGroupIndex);
-      });
-    }
-
-    for (const unit of currentData.value as Unit[]) {
-      addUnitHierarchy(unit, addedGroupId, activeScenario, {
-        newIds: createNewId,
-        includeState: unitImportMode.value === "units-and-state",
-        sourceState: importedState.value,
-      });
-    }
-  });
-}
 </script>
 <template>
   <ImportStepLayout
@@ -757,7 +414,13 @@ function doGroupImport(importedGroupId: string) {
       <BaseButton small @click="emit('cancel')" class="flex-1 sm:flex-none"
         >Cancel</BaseButton
       >
-      <BaseButton primary small @click="onFormSubmit" class="flex-1 sm:flex-none"
+      <div v-show="isUnitImport" ref="contributionActions" />
+      <BaseButton
+        v-if="!isUnitImport"
+        primary
+        small
+        @click="onFormSubmit"
+        class="flex-1 sm:flex-none"
         >Import</BaseButton
       >
     </template>
@@ -804,6 +467,7 @@ function doGroupImport(importedGroupId: string) {
         </FieldSet>
       </FieldGroup>
 
+      <div v-show="isUnitImport" ref="contributionOptions" />
       <FieldGroup v-if="importMode === 'layers' && matchingLayers.length">
         <FieldSelect
           v-for="layer in matchingLayers"
@@ -817,174 +481,18 @@ function doGroupImport(importedGroupId: string) {
           description="Matched by layer ID."
         />
       </FieldGroup>
-      <!-- Source Selection (for unit imports) -->
-      <template v-if="isUnitImport">
-        <!-- Import Content Options -->
-        <FieldSet>
-          <FieldLabel>Content to import</FieldLabel>
-          <RadioGroup v-model="unitImportMode" class="mt-2 flex flex-col gap-2">
-            <FieldLabel for="units-only">
-              <Field orientation="horizontal">
-                <RadioGroupItem id="units-only" value="units-only" />
-                <FieldContent>
-                  <FieldTitle>Units only</FieldTitle>
-                </FieldContent>
-              </Field>
-            </FieldLabel>
-            <FieldLabel for="units-and-state">
-              <Field orientation="horizontal">
-                <RadioGroupItem id="units-and-state" value="units-and-state" />
-                <FieldContent>
-                  <FieldTitle>Units with state</FieldTitle>
-                </FieldContent>
-              </Field>
-            </FieldLabel>
-            <FieldLabel v-if="hasExistingUnits" for="state-only">
-              <Field orientation="horizontal">
-                <RadioGroupItem id="state-only" value="state-only" />
-                <FieldContent>
-                  <FieldTitle>State only (update existing)</FieldTitle>
-                </FieldContent>
-              </Field>
-            </FieldLabel>
-          </RadioGroup>
-        </FieldSet>
-
-        <!-- Conflict Resolution Section -->
-        <FieldSet v-if="hasExistingSide || hasExistingSideGroup || hasExistingUnits">
-          <FieldLabel>Conflict resolution</FieldLabel>
-
-          <!-- Side conflict -->
-          <div
-            v-if="
-              hasExistingSide && importMode === 'side' && unitImportMode !== 'state-only'
-            "
-            class="space-y-2"
-          >
-            <InlineAlertWarning class="text-xs"
-              >Side "{{ selectedSourceSide?.name }}" already exists.</InlineAlertWarning
-            >
-            <RadioGroup v-model="sideMergeMode" class="flex flex-col gap-2">
-              <FieldLabel for="side-replace">
-                <Field orientation="horizontal">
-                  <RadioGroupItem id="side-replace" value="replace" />
-                  <FieldContent>
-                    <FieldTitle>Replace existing</FieldTitle>
-                  </FieldContent>
-                </Field>
-              </FieldLabel>
-              <FieldLabel for="side-add_new">
-                <Field orientation="horizontal">
-                  <RadioGroupItem id="side-add_new" value="add_new" />
-                  <FieldContent>
-                    <FieldTitle>Create new side</FieldTitle>
-                  </FieldContent>
-                </Field>
-              </FieldLabel>
-            </RadioGroup>
-          </div>
-
-          <!-- Group conflict -->
-          <div
-            v-if="
-              hasExistingSideGroup &&
-              importMode === 'group' &&
-              unitImportMode !== 'state-only'
-            "
-            class="space-y-2"
-          >
-            <InlineAlertWarning class="text-xs"
-              >Group already exists in target scenario.</InlineAlertWarning
-            >
-            <RadioGroup v-model="groupMergeMode" class="flex flex-col gap-2">
-              <FieldLabel for="group-replace">
-                <Field orientation="horizontal">
-                  <RadioGroupItem id="group-replace" value="replace" />
-                  <FieldContent>
-                    <FieldTitle>Replace existing</FieldTitle>
-                  </FieldContent>
-                </Field>
-              </FieldLabel>
-              <FieldLabel for="group-add_new">
-                <Field orientation="horizontal">
-                  <RadioGroupItem id="group-add_new" value="add_new" />
-                  <FieldContent>
-                    <FieldTitle>Create new group</FieldTitle>
-                  </FieldContent>
-                </Field>
-              </FieldLabel>
-            </RadioGroup>
-            <FieldSelect
-              v-if="groupMergeMode !== 'replace'"
-              label="Target side"
-              :items="targetSides"
-              v-model="selectedTargetSideId"
-            />
-          </div>
-
-          <!-- Unit conflicts (state import) -->
-          <div
-            v-if="
-              hasExistingUnits && wantsToImportState && unitImportMode == 'state-only'
-            "
-            class="space-y-2"
-          >
-            <InlineAlertWarning class="text-xs"
-              >Some units exist in both scenarios.</InlineAlertWarning
-            >
-            <RadioGroup v-model="stateMergeMode" class="flex flex-col gap-2">
-              <FieldLabel for="state-replace">
-                <Field orientation="horizontal">
-                  <RadioGroupItem id="state-replace" value="replace" />
-                  <FieldContent>
-                    <FieldTitle>Replace existing state</FieldTitle>
-                  </FieldContent>
-                </Field>
-              </FieldLabel>
-              <FieldLabel for="state-add_new">
-                <Field orientation="horizontal">
-                  <RadioGroupItem id="state-add_new" value="add_new" />
-                  <FieldContent>
-                    <FieldTitle>Add new state only</FieldTitle>
-                  </FieldContent>
-                </Field>
-              </FieldLabel>
-            </RadioGroup>
-          </div>
-        </FieldSet>
-      </template>
     </template>
 
     <!-- Main content: Data grids -->
     <div class="flex h-full min-h-0 flex-col p-6">
-      <template v-if="isUnitImport">
-        <div class="mb-4 flex gap-4">
-          <FieldSelect
-            class="w-64"
-            label="Side"
-            :items="importedSides"
-            v-model="selectedSourceSideId"
-          />
-          <FieldSelect
-            v-if="importMode === 'group' || importMode === 'units'"
-            class="w-64"
-            label="Group"
-            v-model="selectedSourceSideGroupId"
-            :items="importedSideGroups"
-          />
-        </div>
-        <DataGrid
-          :key="selectedSourceSideGroupId"
-          :data="currentData"
-          :columns="computedColumns"
-          :row-height="40"
-          class="flex-1"
-          :get-sub-rows="(row) => row.subUnits ?? row.groups"
-          select-all
-          v-model:selected="selectedItems"
-          no-indeterminate
-        />
-      </template>
+      <ScenarioImportContribution
+        v-if="isUnitImport"
+        :data="data"
+        :options-target="contributionOptions"
+        :actions-target="contributionActions"
+        :mode="importMode === 'side' ? 'side' : 'group'"
+        @applied="!store.keepOpen && emit('loaded')"
+      />
 
       <template v-else-if="importMode === 'layers'">
         <section

--- a/src/components/ScenarioImportContribution.test.ts
+++ b/src/components/ScenarioImportContribution.test.ts
@@ -1,0 +1,318 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import { shallowRef } from "vue";
+import { klona } from "klona";
+import ScenarioImportContribution from "./ScenarioImportContribution.vue";
+import FieldSelect from "./FieldSelect.vue";
+import DataGrid from "@/modules/grid/DataGrid.vue";
+import { FlexRender } from "@tanstack/vue-table";
+import ToggleField from "./ToggleField.vue";
+import { activeScenarioKey } from "./injects";
+import { useNewScenarioStore } from "@/scenariostore/newScenarioStore";
+import { useScenarioIO } from "@/scenariostore/io";
+import { useScenarioTime } from "@/scenariostore/time";
+import { loadControlMeasureScenarioFixture } from "@/testdata/controlMeasureScenario";
+import "@/dayjs";
+
+vi.mock("@/composables/notifications", () => ({
+  useNotifications: () => ({ send: vi.fn() }),
+}));
+vi.mock("@/stores/settingsStore", () => ({
+  useSymbolSettingsStore: () => ({ symbologyStandard: "2525d" }),
+}));
+vi.mock("@/stores/timeFormatStore", () => ({
+  useTimeFormatStore: () => ({
+    trackFormatter: { format: (t: number) => new Date(t).toISOString() },
+  }),
+}));
+function setup(withOmittedUnit = false, withUnchangedUnit = false) {
+  const data = loadControlMeasureScenarioFixture();
+  data.sides = [
+    {
+      id: "blue",
+      name: "Blue",
+      standardIdentity: "3",
+      groups: [
+        {
+          id: "own",
+          name: "Own",
+          subUnits: [{ id: "reserve", name: "Reserve", sidc: "10031000001211000000" }],
+        },
+      ],
+    },
+  ];
+  if (withUnchangedUnit)
+    data.sides[0].groups[0].subUnits.push({
+      id: "same",
+      name: "Unchanged",
+      sidc: "10031000001211000000",
+    });
+  if (withOmittedUnit)
+    data.sides[0].groups[0].subUnits.push({
+      id: "omitted",
+      name: "Other unit",
+      sidc: "10031000001211000000",
+    });
+  const store = useNewScenarioStore(klona(data));
+  if (withOmittedUnit) data.sides[0].groups[0].subUnits.pop();
+  data.sides[0].groups[0].subUnits[0].location = [10, 20];
+  const io = useScenarioIO(shallowRef(store));
+  const wrapper = mount(ScenarioImportContribution, {
+    props: { data, mode: "group" },
+    global: {
+      provide: {
+        [activeScenarioKey as symbol]: { store, io, time: useScenarioTime(store) },
+      },
+    },
+  });
+  const select = async (label: string, value: string) => {
+    wrapper
+      .findAllComponents(FieldSelect)
+      .find((c) => c.props("label") === label)!
+      .vm.$emit("update:modelValue", value);
+    await flushPromises();
+  };
+  return { wrapper, store, select, io };
+}
+describe("scenario import controls", () => {
+  it("selects the first group and previews without modifying the scenario", async () => {
+    const { wrapper, store } = setup();
+    const original = klona(store.state);
+    await flushPromises();
+    expect(
+      wrapper
+        .findAllComponents(FieldSelect)
+        .find((c) => c.props("label") === "Group")!
+        .props("modelValue"),
+    ).toBe("own");
+    expect(wrapper.getComponent(DataGrid).props("data")[0].id).toBe("reserve");
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "Update Blue / Own",
+    );
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "1 unit updated, 0 added, 0 left unchanged.",
+    );
+    expect(wrapper.text()).toContain("Location added.");
+    expect(wrapper.get("article details").attributes("open")).toBeUndefined();
+    expect(wrapper.get("article details summary").text()).toBe("Advanced details");
+    expect(store.state).toEqual(original);
+    wrapper.unmount();
+    expect(store.state).toEqual(original);
+  });
+  it("defaults on import-type changes and handles files with no groups", async () => {
+    const { wrapper } = setup();
+    await wrapper.setProps({ mode: "side" });
+    expect(
+      wrapper
+        .findAllComponents(FieldSelect)
+        .find((c) => c.props("label") === "Side")!
+        .props("modelValue"),
+    ).toBe("blue");
+    await wrapper.setProps({ mode: "group" });
+    expect(
+      wrapper
+        .findAllComponents(FieldSelect)
+        .find((c) => c.props("label") === "Group")!
+        .props("modelValue"),
+    ).toBe("own");
+    const data = klona(wrapper.props("data"));
+    data.sides[0].groups = [];
+    await wrapper.setProps({ data });
+    expect(wrapper.findComponent(DataGrid).exists()).toBe(false);
+    expect(
+      wrapper
+        .findAll("button")
+        .find((b) => b.text() === "Import")!
+        .attributes("disabled"),
+    ).toBeDefined();
+  });
+  it("distinguishes units kept by updates from replacement removals in the summary", async () => {
+    const { wrapper, select } = setup(true);
+    await select("Group", "own");
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "1 unit updated, 0 added, 1 left unchanged.",
+    );
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "1 unit is not included",
+    );
+    await select("Action", "replace");
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "Replace Blue / Own",
+    );
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain("1 removed");
+    expect(wrapper.text()).toContain("Removed unit: Other unit");
+  });
+  it("selects units in the table and keeps the review collapsed", async () => {
+    const { wrapper, select } = setup();
+    await select("Group", "own");
+    const grid = wrapper.getComponent(DataGrid);
+    expect(grid.props("select")).toBe(true);
+    expect(grid.props("data")[0].id).toBe("reserve");
+    const review = wrapper
+      .findAll("details")
+      .find((d) => d.find("summary").text() === "Review changes")!;
+    expect(review.attributes("open")).toBeUndefined();
+    grid.vm.$emit("update:selected", []);
+    await flushPromises();
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "0 units updated, 0 added, 1 left unchanged.",
+    );
+    expect(
+      wrapper
+        .findAll("button")
+        .find((b) => b.text() === "Import")!
+        .attributes("disabled"),
+    ).toBeDefined();
+    await select("Action", "replace");
+    expect(grid.props("select")).toBe(false);
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "1 unit updated",
+    );
+  });
+  it("shows live change descriptions in the table column", async () => {
+    const { wrapper, select } = setup(false, true);
+    await flushPromises();
+    const grid = wrapper.getComponent(DataGrid);
+    const column = grid.props("columns").find((c) => c && c.id === "changes");
+    if (!column) throw new Error("Changes column missing");
+    const changed = mount(FlexRender, {
+      props: { render: column.cell, props: { row: { original: grid.props("data")[0] } } },
+    });
+    const unchanged = mount(FlexRender, {
+      props: { render: column.cell, props: { row: { original: grid.props("data")[1] } } },
+    });
+    try {
+      expect(changed.text()).toBe("Location added.");
+      expect(changed.get("span").attributes("title")).toBe("Location added.");
+      expect(unchanged.text()).toBe("No changes");
+      await select("Content to import", "state-only");
+      expect(changed.text()).toBe("No changes");
+      await select("Content to import", "units-and-state");
+      await select("Action", "copy");
+      expect(changed.text()).toBe("Added as a separate copy");
+      grid.vm.$emit("update:selected", []);
+      await flushPromises();
+      expect(changed.text()).toBe("Not selected");
+    } finally {
+      changed.unmount();
+      unchanged.unmount();
+      wrapper.unmount();
+    }
+  });
+  it("filters changed entries without altering selections or reserializing the scenario", async () => {
+    const { wrapper, select, io } = setup(false, true);
+    await select("Group", "own");
+    const grid = wrapper.getComponent(DataGrid);
+    const originalData = grid.props("data");
+    const summary = wrapper.get('[aria-label="Import summary"]').text();
+    const serialize = vi.spyOn(io, "serializeToObject");
+    expect(grid.props("rowFilter")).toBeUndefined();
+    wrapper.getComponent(ToggleField).vm.$emit("update:modelValue", true);
+    await flushPromises();
+    expect(grid.props("rowFilter")!(originalData[0])).toBe(true);
+    expect(grid.props("rowFilter")!(originalData[1])).toBe(false);
+    expect(grid.props("data")).toBe(originalData);
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toBe(summary);
+    wrapper.getComponent(ToggleField).vm.$emit("update:modelValue", false);
+    await flushPromises();
+    expect(grid.props("rowFilter")).toBeUndefined();
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toBe(summary);
+    expect(serialize).not.toHaveBeenCalled();
+  });
+  it("keeps differing entries visible when they are not selected", async () => {
+    const { wrapper } = setup(false, true);
+    await flushPromises();
+    const grid = wrapper.getComponent(DataGrid);
+    await grid.get('thead input[type="checkbox"]').setValue(false);
+    await flushPromises();
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "0 units updated",
+    );
+    await wrapper.get('[role="switch"]').trigger("click");
+    await flushPromises();
+    expect(wrapper.text()).not.toContain("No matching entries.");
+    expect(grid.props("rowFilter")!(grid.props("data")[0])).toBe(true);
+    expect(grid.props("rowFilter")!(grid.props("data")[1])).toBe(false);
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "0 units updated",
+    );
+    await grid.get('thead input[type="checkbox"]').setValue(true);
+    await flushPromises();
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "1 unit updated",
+    );
+    await grid.get('thead input[type="checkbox"]').setValue(false);
+    await flushPromises();
+    expect(wrapper.text()).not.toContain("No matching entries.");
+    expect(wrapper.get('[aria-label="Import summary"]').text()).toContain(
+      "0 units updated",
+    );
+  });
+  it("keeps actual changes visible across repeated toggles and scope changes", async () => {
+    const { wrapper, select } = setup(false, true);
+    await flushPromises();
+    for (const mode of ["group", "side", "group"] as const) {
+      await wrapper.setProps({ mode });
+      for (const action of ["update", "replace", "copy"]) {
+        await select("Action", action);
+        for (let i = 0; i < 4; i++) {
+          await wrapper.get('[role="switch"]').trigger("click");
+          await flushPromises();
+          expect(wrapper.get('[aria-label="Import summary"]').text()).toMatch(
+            /1 unit updated|2 added/,
+          );
+          expect(wrapper.text()).not.toContain("No matching entries.");
+        }
+      }
+    }
+  });
+  it("uses the chosen content mode and includes copies despite their new IDs", async () => {
+    const { wrapper, select } = setup(false, true);
+    await select("Group", "own");
+    wrapper.getComponent(ToggleField).vm.$emit("update:modelValue", true);
+    await select("Content to import", "state-only");
+    const grid = wrapper.getComponent(DataGrid);
+    expect(grid.props("data").some(grid.props("rowFilter")!)).toBe(false);
+    expect(wrapper.text()).toContain("No matching entries.");
+    await select("Content to import", "units-and-state");
+    await select("Action", "copy");
+    expect(grid.props("data").every(grid.props("rowFilter")!)).toBe(true);
+  });
+  it("places options in the sidebar and import actions in the header", async () => {
+    const options = document.createElement("div"),
+      actions = document.createElement("div");
+    document.body.append(options, actions);
+    const { wrapper } = setup();
+    try {
+      await wrapper.setProps({ optionsTarget: options, actionsTarget: actions });
+      expect(options.textContent).toContain("Content to import");
+      expect(actions.textContent).toContain("Import");
+      expect(wrapper.text()).not.toContain("Content to import");
+      expect(wrapper.findAll("button").some((b) => b.text() === "Import")).toBe(false);
+    } finally {
+      wrapper.unmount();
+      options.remove();
+      actions.remove();
+    }
+  });
+  it("applies the reviewed update as a single undoable action", async () => {
+    const { wrapper, store, select } = setup();
+    const original = klona(store.state);
+    await select("Group", "own");
+    await wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Import")!
+      .trigger("click");
+    await flushPromises();
+    expect(store.state.unitMap.reserve.location).toEqual([10, 20]);
+    expect(wrapper.emitted("applied")).toHaveLength(1);
+    expect(wrapper.text()).toContain("No content changes.");
+    expect(store.undo()).toBe(true);
+    expect(store.canUndo.value).toBe(false);
+    // Reprojection increments render counters; authored and hierarchy data restore.
+    expect(store.state.unitMap).toEqual(original.unitMap);
+    expect(store.state.sideGroupMap).toEqual(original.sideGroupMap);
+    expect(store.state.layerStackMap).toEqual(original.layerStackMap);
+    expect(store.state.currentTime).toBe(original.currentTime);
+  });
+});

--- a/src/components/ScenarioImportContribution.vue
+++ b/src/components/ScenarioImportContribution.vue
@@ -1,0 +1,530 @@
+<script setup lang="ts">
+import { computed, h, ref, shallowRef, watch } from "vue";
+import { injectStrict } from "@/utils";
+import { activeScenarioKey } from "@/components/injects";
+import type {
+  Scenario,
+  Unit,
+  SideGroup,
+  UnitSymbolOptions,
+} from "@/types/scenarioModels";
+import {
+  planScenarioImport,
+  type ImportOptions,
+} from "@/importexport/scenarioImportPlan";
+import { applyScenarioImport } from "@/importexport/applyScenarioImport";
+import { useNotifications } from "@/composables/notifications";
+import FieldSelect from "@/components/FieldSelect.vue";
+import { FieldGroup } from "@/components/ui/field";
+import { Alert, AlertTitle, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import DataGrid from "@/modules/grid/DataGrid.vue";
+import ToggleField from "@/components/ToggleField.vue";
+import OrbatCellRenderer from "@/components/OrbatCellRenderer.vue";
+import type { ColumnDef } from "@tanstack/vue-table";
+import { mapReinforcedStatus2Field } from "@/types/scenarioModels";
+import { useTimeFormatStore } from "@/stores/timeFormatStore";
+import {
+  describeImportChange,
+  summarizeImportPlan,
+} from "@/importexport/scenarioImportSummary";
+import { walkSubUnits } from "@/stores/scenarioStore";
+
+const props = defineProps<{
+  data: Scenario;
+  mode: "side" | "group";
+  optionsTarget?: HTMLElement | null;
+  actionsTarget?: HTMLElement | null;
+}>();
+const emit = defineEmits<{ applied: [] }>();
+const { store, io, time } = injectStrict(activeScenarioKey);
+// Serializing the whole scenario is expensive, and doing it inside `plan` would make
+// the preview depend on every entity in the store. Refresh it only when the store does.
+const master = shallowRef<Scenario>(io.serializeToObject());
+watch(
+  () => store.revision.value,
+  () => (master.value = io.serializeToObject()),
+  { flush: "sync" },
+);
+const { send } = useNotifications();
+const fmt = useTimeFormatStore();
+const scopeId = ref("");
+const action = ref<ImportOptions["action"]>("update");
+const content = ref<ImportOptions["content"]>("units-and-state");
+const states = ref<ImportOptions["states"]>("replace");
+const selectedIds = ref<string[]>([]);
+const showChangedOnly = ref(false);
+const targetSideId = ref(store.state.sides[0]);
+const failure = ref("");
+const scopes = computed(() =>
+  props.data.sides.flatMap((s) =>
+    props.mode === "side"
+      ? [{ value: s.id, label: s.name }]
+      : s.groups.map((g) => ({ value: g.id, label: `${s.name} / ${g.name}` })),
+  ),
+);
+watch(
+  scopes,
+  (available) => {
+    if (!available.some((scope) => scope.value === scopeId.value)) {
+      scopeId.value = available[0]?.value ?? "";
+    }
+  },
+  { immediate: true },
+);
+const units = computed(() => {
+  const result: Unit[] = [];
+  const collect = (roots: Unit[]) =>
+    roots.forEach((root) => walkSubUnits(root, (unit) => result.push(unit), true));
+  for (const side of props.data.sides) {
+    if (side.id === scopeId.value) {
+      collect(side.subUnits ?? []);
+      side.groups.forEach((g) => collect(g.subUnits));
+    } else
+      side.groups
+        .filter((g) => g.id === scopeId.value)
+        .forEach((g) => collect(g.subUnits));
+  }
+  return result;
+});
+watch(
+  scopeId,
+  () => {
+    selectedIds.value = units.value.map((u) => u.id);
+  },
+  { immediate: true },
+);
+const targetSides = computed(() =>
+  store.state.sides.map((id) => ({ value: id, label: store.state.sideMap[id].name })),
+);
+const importOptions = computed(() => ({
+  scopeId: scopeId.value,
+  action: action.value,
+  content: content.value,
+  states: states.value,
+  targetSideId: targetSideId.value,
+}));
+const allUnitIds = computed(() => units.value.map((unit) => unit.id));
+// Filtering compares all incoming entries, independent of which ones will be applied.
+// Cache this comparison across checkbox changes and reuse it for the common all-selected case.
+const comparisonPlan = computed(() =>
+  planScenarioImport(master.value, props.data, {
+    ...importOptions.value,
+    selectedIds: allUnitIds.value,
+  }),
+);
+const plan = computed(() => {
+  const selected = new Set(selectedIds.value);
+  if (
+    selected.size === allUnitIds.value.length &&
+    allUnitIds.value.every((id) => selected.has(id))
+  )
+    return comparisonPlan.value;
+  return planScenarioImport(master.value, props.data, {
+    ...importOptions.value,
+    selectedIds: selectedIds.value,
+  });
+});
+const sourceSide = computed(() =>
+  props.data.sides.find(
+    (s) => s.id === scopeId.value || s.groups.some((g) => g.id === scopeId.value),
+  ),
+);
+const targetName = computed(() => {
+  const target =
+    store.state.sideMap[scopeId.value] ?? store.state.sideGroupMap[scopeId.value];
+  const group = store.state.sideGroupMap[scopeId.value];
+  const owner = group ? store.state.sideMap[group._pid]?.name : undefined;
+  const side = sourceSide.value;
+  const sourceGroup = side?.groups.find((g) => g.id === scopeId.value);
+  const sourceName = sourceGroup ? `${side!.name} / ${sourceGroup.name}` : side?.name;
+  return target
+    ? `${owner ? owner + " / " : ""}${target.name}`
+    : (sourceName ?? `New ${props.mode === "side" ? "side" : "group"}`);
+});
+const summary = computed(() =>
+  summarizeImportPlan(plan.value.changes, {
+    action: action.value,
+    content: content.value,
+  }),
+);
+const readableChanges = computed(() => {
+  const names = new Map(plan.value.changes.map((c) => [c.id, c.name]));
+  const nameForId = (id: string) =>
+    names.get(id) ??
+    store.state.unitMap[id]?.name ??
+    store.state.sideGroupMap[id]?.name ??
+    store.state.sideMap[id]?.name ??
+    id;
+  return plan.value.changes.map((change) => ({
+    ...change,
+    descriptions: describeImportChange(change, nameForId),
+  }));
+});
+const affectedChanges = computed(() =>
+  readableChanges.value.filter((c) => ["added", "changed", "removed"].includes(c.effect)),
+);
+const unchangedChanges = computed(() =>
+  readableChanges.value.filter((c) => ["unchanged", "preserved"].includes(c.effect)),
+);
+const effectLabels = {
+  added: "Added",
+  changed: "Updated",
+  removed: "Removed",
+  unchanged: "Already matches",
+  preserved: "Not included; kept unchanged",
+};
+type ImportRow = Unit | SideGroup;
+const tableData = computed<ImportRow[]>(() => {
+  const side = sourceSide.value;
+  if (!side) return [];
+  return props.mode === "side"
+    ? [...side.groups, ...(side.subUnits ?? [])]
+    : (side.groups.find((g) => g.id === scopeId.value)?.subUnits ?? []);
+});
+const changedRowFilter = computed(() => {
+  if (!showChangedOnly.value) return undefined;
+  if (action.value === "copy" && content.value !== "state-only") {
+    // Every incoming entry can be added as a copy, even while unchecked.
+    return () => true;
+  }
+  const changed = new Set(
+    comparisonPlan.value.changes
+      .filter((c) => c.effect === "added" || c.effect === "changed")
+      .map((c) => c.id),
+  );
+  return (row: ImportRow) => changed.has(row.id);
+});
+const symbolOptions = computed(() => {
+  const result = new Map<string, UnitSymbolOptions>();
+  const collect = (roots: Unit[], inherited: UnitSymbolOptions) =>
+    roots.forEach((root) =>
+      walkSubUnits(
+        root,
+        (unit) =>
+          result.set(unit.id, {
+            ...inherited,
+            ...unit.symbolOptions,
+            reinforcedReduced: mapReinforcedStatus2Field(unit.reinforcedStatus) ?? "",
+          }),
+        true,
+      ),
+    );
+  for (const side of props.data.sides) {
+    collect(side.subUnits ?? [], side.symbolOptions ?? {});
+    for (const group of side.groups)
+      collect(group.subUnits, { ...side.symbolOptions, ...group.symbolOptions });
+  }
+  return result;
+});
+const changesById = computed(
+  () => new Map(readableChanges.value.map((change) => [change.id, change])),
+);
+const selectedUnitIds = computed(() => new Set(selectedIds.value));
+function rowChanges(row: ImportRow): string {
+  const isUnit = "sidc" in row;
+  const selected = !isUnit || selectedUnitIds.value.has(row.id);
+  if (action.value === "copy" && content.value !== "state-only") {
+    return selected ? "Added as a separate copy" : "Not selected";
+  }
+  const change = changesById.value.get(row.id);
+  if (change?.effect === "unchanged") return "No changes";
+  if (change?.effect === "preserved") return isUnit ? "Not selected" : "No changes";
+  if (change) return change.descriptions.join(" ");
+  if (!selected && (action.value !== "replace" || content.value === "state-only"))
+    return "Not selected";
+  if (content.value === "state-only" && isUnit && !store.state.unitMap[row.id])
+    return "Skipped: unit does not exist";
+  return plan.value.errors.length ? "Not applied — see review" : "No changes";
+}
+const columns: ColumnDef<ImportRow>[] = [
+  {
+    id: "name",
+    accessorKey: "name",
+    header: ({ table }) =>
+      h(
+        "button",
+        {
+          type: "button",
+          title: "Expand/collapse all",
+          onClick: table.getToggleAllRowsExpandedHandler(),
+        },
+        "Name",
+      ),
+    size: 300,
+    enableSorting: false,
+    cell: ({ row, getValue }) =>
+      h(OrbatCellRenderer, {
+        value: getValue() as string,
+        sidc: "sidc" in row.original ? row.original.sidc : undefined,
+        expanded: row.getIsExpanded(),
+        level: row.depth,
+        canExpand: row.getCanExpand(),
+        onToggle: row.getToggleExpandedHandler(),
+        symbolOptions: {
+          ...symbolOptions.value.get(row.original.id),
+          customSymbolMap: Object.fromEntries(
+            (props.data.settings?.customSymbols ?? []).map((s) => [s.id, s]),
+          ),
+        },
+      }),
+  },
+  {
+    id: "changes",
+    header: "Changes",
+    size: 350,
+    enableSorting: false,
+    // Read the live plan in the cell: a cached accessor would go stale when the
+    // selection or import options change without changing the source rows.
+    cell: ({ row }) => {
+      const description = rowChanges(row.original);
+      return h(
+        "span",
+        { class: "block min-w-0 truncate", title: description },
+        description,
+      );
+    },
+  },
+  {
+    id: "exists",
+    header: "Exists?",
+    accessorFn: (row) =>
+      row.id in store.state.unitMap || row.id in store.state.sideGroupMap ? "Yes" : "No",
+    size: 90,
+  },
+  {
+    id: "history",
+    header: "Last state entry",
+    accessorFn: (row) => {
+      if (!("sidc" in row) || !row.state?.length) return "—";
+      const latest = Math.max(...row.state.map((s) => +new Date(s.t)));
+      return `${fmt.trackFormatter.format(latest)} (${row.state.length})`;
+    },
+    size: 220,
+  },
+];
+function selectRows(rows: ImportRow[]) {
+  selectedIds.value = rows
+    .filter((row): row is Unit => "sidc" in row)
+    .map((row) => row.id);
+}
+function apply() {
+  const reviewed = plan.value;
+  if (reviewed.errors.length || !reviewed.hasChanges) return;
+  failure.value = "";
+  try {
+    applyScenarioImport(store, reviewed);
+    time.setCurrentTime(store.state.currentTime);
+    send({
+      message: "Imported scenario data. Use Undo to revert the import in one step.",
+      type: "success",
+    });
+    emit("applied");
+  } catch (error) {
+    failure.value = `Import was not applied: ${error instanceof Error ? error.message : String(error)}`;
+  }
+}
+</script>
+
+<template>
+  <div class="flex h-full min-h-0 flex-col gap-4">
+    <Teleport :to="optionsTarget ?? 'body'" :disabled="!optionsTarget">
+      <FieldGroup>
+        <FieldSelect
+          v-model="action"
+          label="Action"
+          :items="[
+            { value: 'update', label: 'Update included units' },
+            { value: 'replace', label: 'Replace entire side/group' },
+            { value: 'copy', label: 'Import as a separate copy' },
+          ]"
+        />
+        <FieldSelect
+          v-model="content"
+          label="Content to import"
+          :items="[
+            { value: 'units-and-state', label: 'Units with state' },
+            { value: 'units-only', label: 'Units only (preserve existing history)' },
+            { value: 'state-only', label: 'State only (existing units)' },
+          ]"
+        />
+        <FieldSelect
+          v-if="content !== 'units-only'"
+          v-model="states"
+          label="State history"
+          :items="[
+            { value: 'replace', label: 'Replace state history' },
+            { value: 'add_new', label: 'Append states after latest existing timestamp' },
+          ]"
+        />
+        <FieldSelect
+          v-if="
+            (action === 'copy' || !store.state.sideGroupMap[scopeId]) && mode !== 'side'
+          "
+          v-model="targetSideId"
+          label="Target side for new group"
+          :items="targetSides"
+        />
+      </FieldGroup>
+    </Teleport>
+    <div class="flex flex-wrap items-end gap-4">
+      <FieldSelect
+        v-model="scopeId"
+        :label="mode === 'side' ? 'Side' : 'Group'"
+        :items="scopes"
+        class="max-w-sm"
+      />
+      <ToggleField
+        v-if="scopeId"
+        v-model="showChangedOnly"
+        title="Includes added entries and parent rows for context. Selection is unchanged."
+        >Show changed entries only</ToggleField
+      >
+    </div>
+    <p v-if="!scopeId" class="text-muted-foreground">
+      Select a side or group from the file to import.
+    </p>
+    <template v-else>
+      <DataGrid
+        :key="scopeId"
+        :data="tableData"
+        :columns="columns"
+        :row-filter="changedRowFilter"
+        :get-sub-rows="(row: ImportRow) => row.subUnits ?? []"
+        :row-height="40"
+        :select="action !== 'replace' || content === 'state-only'"
+        select-all
+        no-indeterminate
+        class="min-h-40 flex-1"
+        @update:selected="selectRows"
+      />
+      <div class="max-h-72 shrink-0 overflow-auto">
+        <section aria-label="Import summary" aria-live="polite">
+          <p>{{ summary.action }} {{ targetName }}: {{ summary.sentence }}</p>
+          <p v-if="summary.counts.preserved" class="text-muted-foreground">
+            {{ summary.counts.preserved }}
+            {{ summary.counts.preserved === 1 ? "unit is" : "units are" }} not included
+            and will be kept.
+          </p>
+          <p
+            v-if="
+              mode !== 'side' && (action === 'copy' || !store.state.sideGroupMap[scopeId])
+            "
+          >
+            Destination: {{ store.state.sideMap[targetSideId]?.name }}
+          </p>
+        </section>
+        <Alert
+          v-if="action === 'replace' && content !== 'state-only'"
+          variant="destructive"
+          class="mt-2"
+        >
+          <AlertTitle>Replace entire {{ mode === "side" ? "side" : "group" }}</AlertTitle>
+          <AlertDescription
+            >Units and groups missing from the file will be removed.
+            {{ summary.counts.removed }} units will be removed.</AlertDescription
+          >
+        </Alert>
+        <Alert v-if="plan.errors.length" variant="destructive" class="mt-2">
+          <AlertTitle>Cannot import this selection</AlertTitle>
+          <AlertDescription
+            ><ul>
+              <li v-for="error in plan.errors" :key="error">{{ error }}</li>
+            </ul></AlertDescription
+          >
+        </Alert>
+        <details class="mt-2">
+          <summary>Review changes</summary>
+          <section aria-label="Scenario import preview" class="flex flex-col gap-2">
+            <details
+              v-for="dependency in plan.dependencies"
+              :key="dependency.kind + dependency.name"
+            >
+              <summary>
+                Added {{ dependency.kind }} definition: {{ dependency.name }}
+              </summary>
+              <details>
+                <summary>Advanced details</summary>
+                <pre class="overflow-auto text-xs">{{
+                  JSON.stringify(dependency.definition, null, 2)
+                }}</pre>
+              </details>
+            </details>
+            <p v-for="message in plan.ignored" :key="message">{{ message }}</p>
+            <article
+              v-for="change in affectedChanges"
+              :key="change.id"
+              class="flex flex-col gap-1"
+            >
+              <h4>
+                {{ effectLabels[change.effect] }} {{ change.kind }}: {{ change.name }}
+              </h4>
+              <ul class="list-inside list-disc">
+                <li v-for="description in change.descriptions" :key="description">
+                  {{ description }}
+                </li>
+              </ul>
+              <details>
+                <summary>Advanced details</summary>
+                <p>ID: {{ change.id }}</p>
+                <div class="grid grid-cols-2 gap-4">
+                  <div>
+                    <p>Before</p>
+                    <pre class="overflow-auto text-xs">{{
+                      JSON.stringify(change.before, null, 2) ?? "Absent"
+                    }}</pre>
+                  </div>
+                  <div>
+                    <p>After</p>
+                    <pre class="overflow-auto text-xs">{{
+                      JSON.stringify(change.after, null, 2) ?? "Absent"
+                    }}</pre>
+                  </div>
+                </div>
+              </details>
+            </article>
+            <details v-if="unchangedChanges.length">
+              <summary>
+                Left unchanged ({{ unchangedChanges.length }} sides, groups and units)
+              </summary>
+              <ul class="list-inside list-disc">
+                <li v-for="change in unchangedChanges" :key="change.id">
+                  {{ change.name }} — {{ effectLabels[change.effect] }} ({{ change.id }})
+                </li>
+              </ul>
+            </details>
+            <p v-if="!plan.hasChanges && !plan.errors.length">No content changes.</p>
+          </section>
+          <details>
+            <summary>How this import works</summary>
+            <p v-if="content === 'state-only'">
+              Only history of existing selected units changes. Missing units are skipped.
+            </p>
+            <p v-else>
+              Included units and groups take the file's fields and hierarchy, including
+              cleared fields. Updates preserve units not included.
+            </p>
+            <p v-if="content !== 'units-only' && states === 'add_new'">
+              Only states after each unit's latest existing timestamp are appended.
+            </p>
+            <p>Use Undo to revert the import in one step.</p>
+          </details>
+        </details>
+      </div>
+    </template>
+    <Alert v-if="failure" variant="destructive"
+      ><AlertTitle>Import failed</AlertTitle
+      ><AlertDescription>{{ failure }}</AlertDescription></Alert
+    >
+
+    <Teleport :to="actionsTarget ?? 'body'" :disabled="!actionsTarget">
+      <div class="flex gap-2">
+        <Button
+          :disabled="!scopeId || plan.errors.length > 0 || !plan.hasChanges"
+          @click="apply"
+          >Import</Button
+        >
+      </div>
+    </Teleport>
+  </div>
+</template>

--- a/src/importexport/applyScenarioImport.ts
+++ b/src/importexport/applyScenarioImport.ts
@@ -1,0 +1,92 @@
+import { klona } from "klona";
+import { isEqual } from "es-toolkit";
+import {
+  prepareScenario,
+  type NewScenarioStore,
+  type ScenarioState,
+} from "@/scenariostore/newScenarioStore";
+import { refreshHierarchyTimelineMetadata } from "@/scenariostore/hierarchy";
+import type { planScenarioImport } from "./scenarioImportPlan";
+
+type Plan = ReturnType<typeof planScenarioImport>;
+const catalogs = [
+  "equipmentMap",
+  "personnelMap",
+  "supplyClassMap",
+  "supplyUomMap",
+  "supplyCategoryMap",
+  "rangeRingGroupMap",
+  "unitStatusMap",
+] as const;
+/** Reuse target catalog IDs; preparing a file normally creates fresh catalog IDs.
+ * Only known reference fields are remapped, never arbitrary authored strings. */
+function prepareImport(plan: Plan, current: ScenarioState) {
+  const prepared = prepareScenario(klona(plan.scenario));
+  const ids = new Map<string, string>();
+  for (const key of catalogs) {
+    const byName = new Map(Object.values(current[key]).map((e) => [e.name, e.id]));
+    for (const entry of Object.values(prepared[key]))
+      ids.set(entry.id, byName.get(entry.name) ?? entry.id);
+  }
+  function remap(value: unknown): void {
+    if (!value || typeof value !== "object") return;
+    for (const [key, v] of Object.entries(value)) {
+      if (
+        ["id", "status", "group", "supplyClass", "uom"].includes(key) &&
+        typeof v === "string" &&
+        ids.has(v)
+      )
+        (value as Record<string, unknown>)[key] = ids.get(v);
+      else remap(v);
+    }
+  }
+  remap(prepared.unitMap);
+  for (const key of catalogs) {
+    const entries = Object.values(prepared[key]);
+    entries.forEach(remap);
+    Object.assign(prepared, { [key]: Object.fromEntries(entries.map((e) => [e.id, e])) });
+  }
+  return prepared;
+}
+
+/** Commit the reviewed import atomically in one undo entry. */
+export function applyScenarioImport(store: NewScenarioStore, plan: Plan) {
+  if (plan.errors.length) throw new Error("Resolve import conflicts first.");
+  if (!plan.hasChanges) return;
+  const prepared = prepareImport(plan, store.state);
+  const modified = new Set(
+    plan.changes
+      .filter((c) => c.effect === "added" || c.effect === "changed")
+      .map((c) => c.id),
+  );
+  store.update((s) => {
+    for (const [id, symbol] of Object.entries(prepared.customSymbolMap))
+      if (!(id in s.customSymbolMap)) s.customSymbolMap[id] = symbol;
+    for (const key of catalogs)
+      for (const [id, entry] of Object.entries(prepared[key])) {
+        if (!(id in s[key])) Object.assign(s[key], { [id]: entry });
+      }
+    for (const key of ["unitMap", "sideGroupMap", "sideMap"] as const) {
+      for (const id of Object.keys(s[key])) if (!(id in prepared[key])) delete s[key][id];
+      for (const [id, entry] of Object.entries(prepared[key])) {
+        if (modified.has(id) || !s[key][id]) {
+          const old = s[key][id];
+          Object.assign(s[key], {
+            [id]: { ...entry, _isOpen: old?._isOpen ?? entry._isOpen },
+          });
+        } else {
+          const old = s[key][id];
+          // A new group may extend an existing side outside the copied scope.
+          if (!isEqual(old._baseSubUnits, entry._baseSubUnits))
+            old._baseSubUnits = entry._baseSubUnits;
+          if ("groups" in old && "groups" in entry && !isEqual(old.groups, entry.groups))
+            old.groups = entry.groups;
+        }
+      }
+    }
+    if (!isEqual(s.sides, prepared.sides)) s.sides = prepared.sides;
+    refreshHierarchyTimelineMetadata(s);
+    s.hierarchyProjectionVersion = -1;
+    s.unitStateCounter++;
+  });
+}

--- a/src/importexport/scenarioImportPlan.test.ts
+++ b/src/importexport/scenarioImportPlan.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect } from "vitest";
+import { klona } from "klona";
+import { planScenarioImport, type ImportOptions } from "./scenarioImportPlan";
+import { loadControlMeasureScenarioFixture } from "@/testdata/controlMeasureScenario";
+import type { Scenario, Unit } from "@/types/scenarioModels";
+
+const unit = (id: string, fields: Partial<Unit> = {}): Unit => ({
+  id,
+  name: id,
+  sidc: "10031000001211000000",
+  ...fields,
+});
+function scenario(): Scenario {
+  return {
+    ...loadControlMeasureScenarioFixture(),
+    sides: [
+      {
+        id: "blue",
+        name: "Blue",
+        standardIdentity: "3",
+        groups: [
+          {
+            id: "own",
+            name: "Own forces",
+            subUnits: [
+              unit("reserve"),
+              unit("omitted"),
+              unit("parent", { subUnits: [unit("child")] }),
+            ],
+          },
+          { id: "contacts", name: "White-cell contacts", subUnits: [unit("contact")] },
+        ],
+      },
+      {
+        id: "red",
+        name: "Red",
+        standardIdentity: "6",
+        groups: [{ id: "enemy", name: "Enemy", subUnits: [unit("enemy-unit")] }],
+      },
+    ],
+  };
+}
+const opts: ImportOptions = {
+  scopeId: "own",
+  action: "update",
+  content: "units-and-state",
+  states: "replace",
+  selectedIds: ["reserve"],
+};
+function contribution(units = [unit("reserve", { location: [10, 20] })]) {
+  const s = scenario();
+  s.sides[0].groups[0].subUnits = units;
+  return s;
+}
+function own(s: Scenario) {
+  return s.sides[0].groups[0].subUnits;
+}
+describe("scenario contribution import plan", () => {
+  it("previews without mutating either scenario, so cancellation is inert", () => {
+    const master = scenario(),
+      incoming = contribution();
+    const a = klona(master),
+      b = klona(incoming);
+    const plan = planScenarioImport(master, incoming, opts);
+    expect(plan.errors).toEqual([]);
+    expect(master).toEqual(a);
+    expect(incoming).toEqual(b);
+    expect(plan.changes.find((c) => c.id === "reserve")?.effect).toBe("changed");
+  });
+  it("deploys reserve by ID and preserves omitted units and excluded forces", () => {
+    const master = scenario();
+    const plan = planScenarioImport(master, contribution(), opts);
+    expect(own(plan.scenario).map((u) => u.id)).toEqual(["reserve", "omitted", "parent"]);
+    expect(own(plan.scenario)[0].location).toEqual([10, 20]);
+    expect(
+      plan.changes.filter((c) => c.effect === "preserved" && c.kind === "unit"),
+    ).toHaveLength(3);
+    expect(plan.scenario.sides[1]).toEqual(master.sides[1]);
+    expect(plan.scenario.sides[0].groups[1]).toEqual(master.sides[0].groups[1]);
+  });
+  it("previews additions and clears omitted authored fields of included units", () => {
+    const master = scenario();
+    own(master)[0].description = "old";
+    const plan = planScenarioImport(
+      master,
+      contribution([unit("reserve"), unit("new")]),
+      { ...opts, selectedIds: ["reserve", "new"] },
+    );
+    expect(plan.errors).toEqual([]);
+    expect(own(plan.scenario)[0].description).toBeUndefined();
+    expect(plan.changes.find((c) => c.id === "new")?.effect).toBe("added");
+  });
+  it("moves included units and retains omitted descendants", () => {
+    const plan = planScenarioImport(
+      scenario(),
+      contribution([unit("parent", { subUnits: [unit("reserve")] })]),
+      { ...opts, selectedIds: ["parent", "reserve"] },
+    );
+    expect(plan.errors).toEqual([]);
+    const parent = own(plan.scenario).find((u) => u.id === "parent")!;
+    expect(parent.subUnits?.map((u) => u.id)).toContain("reserve");
+    expect(parent.subUnits?.map((u) => u.id)).toContain("child");
+    expect(plan.changes.find((c) => c.id === "reserve")?.after).toMatchObject({
+      parent: "parent",
+    });
+  });
+  it("explicit replacement previews every removed unit", () => {
+    const plan = planScenarioImport(scenario(), contribution(), {
+      ...opts,
+      action: "replace",
+    });
+    expect(plan.errors).toEqual([]);
+    expect(
+      plan.changes
+        .filter((c) => c.effect === "removed")
+        .map((c) => c.id)
+        .sort(),
+    ).toEqual(["child", "omitted", "parent"]);
+    expect(own(plan.scenario)).toHaveLength(1);
+  });
+  it("side replacement also previews removed groups", () => {
+    const incoming = contribution();
+    incoming.sides[0].groups = [incoming.sides[0].groups[0]];
+    const plan = planScenarioImport(scenario(), incoming, {
+      ...opts,
+      scopeId: "blue",
+      action: "replace",
+    });
+    expect(plan.changes.find((c) => c.id === "contacts")?.effect).toBe("removed");
+    expect(plan.changes.find((c) => c.id === "contact")?.effect).toBe("removed");
+  });
+  it("blocks existing IDs outside scope even when names match", () => {
+    const incoming = contribution([unit("enemy-unit")]);
+    // Remove its original occurrence to isolate the scope collision.
+    incoming.sides[1].groups[0].subUnits = [];
+    const plan = planScenarioImport(scenario(), incoming, {
+      ...opts,
+      selectedIds: ["enemy-unit"],
+    });
+    expect(plan.errors.join(" ")).toContain("outside");
+  });
+  it("flags missing parents and unresolved / outside timed references", () => {
+    const incoming = contribution([unit("new-parent", { subUnits: [unit("reserve")] })]);
+    expect(planScenarioImport(scenario(), incoming, opts).errors.join(" ")).toContain(
+      "unresolved parent",
+    );
+    for (const targetId of ["enemy-unit", "missing"]) {
+      const p = planScenarioImport(
+        scenario(),
+        contribution([
+          unit("reserve", {
+            state: [{ id: "s", t: 10, hierarchy: { targetId, placement: "on" } }],
+          }),
+        ]),
+        opts,
+      );
+      expect(p.errors.join(" ")).toContain("hierarchy reference");
+    }
+  });
+  it("reports unchanged repeated submissions without duplication", () => {
+    const first = planScenarioImport(scenario(), contribution(), opts);
+    const second = planScenarioImport(first.scenario, contribution(), opts);
+    expect(second.hasChanges).toBe(false);
+    expect(second.changes.find((c) => c.id === "reserve")?.effect).toBe("unchanged");
+  });
+  it("preserves scope position during replacement and previews incoming sibling order", () => {
+    const master = scenario();
+    const incoming = contribution([unit("parent"), unit("reserve")]);
+    const group = planScenarioImport(master, incoming, { ...opts, action: "replace" });
+    expect(group.scenario.sides[0].groups.map((g) => g.id)).toEqual(["own", "contacts"]);
+    expect(own(group.scenario).map((u) => u.id)).toEqual(["parent", "reserve"]);
+    const side = planScenarioImport(master, incoming, {
+      ...opts,
+      scopeId: "blue",
+      action: "replace",
+    });
+    expect(side.scenario.sides.map((s) => s.id)).toEqual(["blue", "red"]);
+  });
+  it("state-only respects unit selection even with the replacement action", () => {
+    const incoming = contribution([
+      unit("reserve", { state: [{ id: "s", t: 1000 }] }),
+      unit("omitted", { name: "Changed", state: [{ id: "x", t: 2000 }] }),
+    ]);
+    const p = planScenarioImport(scenario(), incoming, {
+      ...opts,
+      action: "replace",
+      content: "state-only",
+    });
+    expect(p.changes.find((c) => c.id === "omitted")?.effect).toBe("preserved");
+    expect(own(p.scenario)[1].state).toBeUndefined();
+  });
+  it("state-only skips additions, preserves fields and structural hierarchy", () => {
+    const incoming = contribution([
+      unit("parent", {
+        subUnits: [
+          unit("reserve", {
+            name: "renamed",
+            state: [{ id: "s", t: 10, location: [1, 2] }],
+          }),
+        ],
+      }),
+      unit("new"),
+    ]);
+    const plan = planScenarioImport(scenario(), incoming, {
+      ...opts,
+      content: "state-only",
+      selectedIds: ["reserve", "new"],
+    });
+    expect(plan.errors).toEqual([]);
+    expect(own(plan.scenario)[0]).toMatchObject({
+      id: "reserve",
+      name: "reserve",
+      state: [{ id: "s", t: 10, location: [1, 2] }],
+    });
+    expect(plan.changes.some((c) => c.effect === "added")).toBe(false);
+    expect(plan.ignored.join(" ")).toContain("missing unit");
+  });
+  it("state replacement clears empty history while append ignores old/equal times", () => {
+    const master = scenario();
+    own(master)[0].state = [{ id: "old", t: 20, location: [0, 0] }];
+    const incoming = contribution([
+      unit("reserve", {
+        state: [
+          { id: "earlier", t: 10 },
+          { id: "equal", t: 20 },
+          { id: "later", t: 30 },
+        ],
+      }),
+    ]);
+    const plan = planScenarioImport(master, incoming, {
+      ...opts,
+      content: "state-only",
+      states: "add_new",
+    });
+    expect(own(plan.scenario)[0].state?.map((s) => s.id)).toEqual(["old", "later"]);
+    expect(plan.ignored[0]).toContain("2 states");
+    const clear = planScenarioImport(master, contribution(), {
+      ...opts,
+      content: "state-only",
+    });
+    expect(own(clear.scenario)[0].state).toEqual([]);
+  });
+  it("state-only replacement never deletes omitted units; units-only retains history", () => {
+    const master = scenario();
+    own(master)[0].state = [{ id: "old", t: 20 }];
+    const p = planScenarioImport(master, contribution(), {
+      ...opts,
+      content: "state-only",
+      action: "replace",
+    });
+    expect(own(p.scenario)).toHaveLength(3);
+    expect(p.changes.some((c) => c.effect === "removed")).toBe(false);
+    const q = planScenarioImport(master, contribution(), {
+      ...opts,
+      content: "units-only",
+    });
+    expect(own(q.scenario)[0].state).toEqual(own(master)[0].state);
+  });
+  it("copies intentionally with fresh IDs and remapped hierarchy references", () => {
+    const incoming = contribution([
+      unit("reserve", {
+        state: [{ id: "s", t: 10, hierarchy: { targetId: "own", placement: "on" } }],
+      }),
+    ]);
+    const p = planScenarioImport(scenario(), incoming, {
+      ...opts,
+      action: "copy",
+      targetSideId: "blue",
+    });
+    expect(p.errors).toEqual([]);
+    const group = p.scenario.sides[0].groups.at(-1)!;
+    expect(group.id).not.toBe("own");
+    expect(group.subUnits[0].id).not.toBe("reserve");
+    expect(group.subUnits[0].state![0].hierarchy?.targetId).toBe(group.id);
+    expect(p.scenario.sides[0].groups[0]).toEqual(scenario().sides[0].groups[0]);
+  });
+});
+
+import { vi } from "vitest";
+import { shallowRef } from "vue";
+import { useNewScenarioStore } from "@/scenariostore/newScenarioStore";
+import { useScenarioIO } from "@/scenariostore/io";
+import { useScenarioTime } from "@/scenariostore/time";
+import { applyScenarioImport } from "./applyScenarioImport";
+import "@/dayjs";
+vi.mock("@/stores/settingsStore", () => ({
+  useSymbolSettingsStore: () => ({ symbologyStandard: "2525d" }),
+}));
+
+describe("import application and recovery", () => {
+  function setup() {
+    const store = useNewScenarioStore(scenario());
+    const io = useScenarioIO(shallowRef(store));
+    return { store, io };
+  }
+  it("applies the preview through the codec and reports no changes on repeat", async () => {
+    const { store, io } = setup();
+    const original = io.serializeToObject();
+    const source = contribution([
+      unit("reserve", {
+        location: [10, 20],
+        state: [{ id: "s", t: 1000, location: [20, 30] }],
+      }),
+    ]);
+    const p = planScenarioImport(original, source, opts);
+    expect(p.errors).toEqual([]);
+    const layers = klona(store.state.layerStackMap),
+      enemy = klona(store.state.unitMap["enemy-unit"]);
+    applyScenarioImport(store, p);
+    expect(store.state.unitMap.reserve.location).toEqual([10, 20]);
+    expect(store.state.layerStackMap).toEqual(layers);
+    expect(store.state.unitMap["enemy-unit"]).toEqual(enemy);
+    const next = planScenarioImport(io.serializeToObject(), source, opts);
+    expect(next.changes.filter((c) => c.effect === "changed")).toEqual([]);
+    expect(next.hasChanges).toBe(false);
+  });
+  it("restores the entire import with one Undo and reapplies it with Redo", () => {
+    const { store, io } = setup();
+    const original = io.serializeToObject();
+    const p = planScenarioImport(original, contribution(), {
+      ...opts,
+      action: "replace",
+    });
+    applyScenarioImport(store, p);
+    const imported = io.serializeToObject();
+    expect(store.state.unitMap.omitted).toBeUndefined();
+    expect(store.undo()).toBe(true);
+    // Serialization stamps a fresh modification date on every export.
+    expect(io.serializeToObject()).toEqual({
+      ...original,
+      meta: { ...original.meta, lastModifiedDate: expect.any(String) },
+    });
+    expect(store.canUndo.value).toBe(false);
+    expect(store.redo()).toBe(true);
+    expect(io.serializeToObject()).toEqual({
+      ...imported,
+      meta: { ...imported.meta, lastModifiedDate: expect.any(String) },
+    });
+  });
+  it("never applies an invalid plan", () => {
+    const { store, io } = setup();
+    const original = klona(store.state);
+    const invalid = planScenarioImport(io.serializeToObject(), contribution(), {
+      ...opts,
+      scopeId: "missing",
+    });
+    expect(() => applyScenarioImport(store, invalid)).toThrow("conflicts");
+    expect(store.state).toEqual(original);
+    expect(store.canUndo.value).toBe(false);
+  });
+  it("keeps catalog IDs stable and resolves imported resource history", async () => {
+    const { store, io } = setup();
+    const catalog = klona(store.state.equipmentMap);
+    const source = contribution([
+      unit("reserve", {
+        equipment: [{ name: "New tank", count: 3 }],
+        state: [
+          { id: "s", t: 1000, update: { equipment: [{ name: "New tank", count: 4 }] } },
+        ],
+      }),
+    ]);
+    const p = planScenarioImport(io.serializeToObject(), source, opts);
+    applyScenarioImport(store, p);
+    for (const [id, entry] of Object.entries(catalog))
+      expect(store.state.equipmentMap[id]).toEqual(entry);
+    expect(own(io.serializeToObject())[0].equipment).toEqual([
+      { name: "New tank", count: 3 },
+    ]);
+    expect(planScenarioImport(io.serializeToObject(), source, opts).hasChanges).toBe(
+      false,
+    );
+  });
+  it("updates projected hierarchy at current time and preserves omitted descendants", async () => {
+    const { store, io } = setup();
+    const source = contribution([unit("parent", { subUnits: [unit("reserve")] })]);
+    const p = planScenarioImport(io.serializeToObject(), source, {
+      ...opts,
+      selectedIds: ["reserve", "parent"],
+    });
+    applyScenarioImport(store, p);
+    useScenarioTime(store).setCurrentTime(store.state.currentTime);
+    expect(store.state.unitMap.reserve._pid).toBe("parent");
+    expect(store.state.unitMap.parent.subUnits).toContain("child");
+    expect(store.state.unitMap.parent.subUnits).toContain("reserve");
+  });
+});

--- a/src/importexport/scenarioImportPlan.ts
+++ b/src/importexport/scenarioImportPlan.ts
@@ -1,0 +1,393 @@
+import { klona } from "klona";
+import { isEqual } from "es-toolkit";
+import { nanoid } from "@/utils";
+import { getCustomSymbolId } from "@/symbology/helpers";
+import type { Scenario, Side, SideGroup, Unit } from "@/types/scenarioModels";
+
+export interface ImportOptions {
+  scopeId: string;
+  action: "update" | "replace" | "copy";
+  content: "units-only" | "units-and-state" | "state-only";
+  states: "replace" | "add_new";
+  selectedIds: string[];
+  targetSideId?: string;
+}
+type Node = Side | SideGroup | Unit;
+interface Entry {
+  node: Node;
+  parent?: string;
+  side: string;
+  kind: "side" | "group" | "unit";
+}
+export interface ImportChange {
+  id: string;
+  name: string;
+  kind: Entry["kind"];
+  effect: "added" | "changed" | "removed" | "unchanged" | "preserved";
+  before?: object;
+  after?: object;
+}
+function index(scenario: Scenario, errors: string[] = []) {
+  const result = new Map<string, Entry>();
+  function visit(node: Node, side: string, kind: Entry["kind"], parent?: string) {
+    if (!node.id || result.has(node.id))
+      errors.push(`Missing or duplicate ID: ${node.name} (${node.id})`);
+    result.set(node.id, { node, parent, side, kind });
+    if ("groups" in node) node.groups.forEach((g) => visit(g, side, "group", node.id));
+    node.subUnits?.forEach((u) => visit(u, side, "unit", node.id));
+  }
+  scenario.sides.forEach((s) => visit(s, s.id, "side"));
+  return result;
+}
+function fields(entry: Entry) {
+  const { subUnits, ...rest } = entry.node;
+  const result = Object.fromEntries(
+    Object.entries(rest).filter(
+      ([k, v]) => k !== "groups" && !k.startsWith("_") && v !== undefined,
+    ),
+  );
+  return {
+    ...result,
+    subUnits: (subUnits ?? []).map((u) => u.id),
+    ...("groups" in entry.node ? { groups: entry.node.groups.map((g) => g.id) } : {}),
+    parent: entry.parent,
+  };
+}
+/** File timestamps may be ISO strings, while the store uses numbers. Empty optional
+ * lists and generated state-entry IDs do not constitute authored content changes.
+ * Shared with the summary so the diff and its description agree on what changed. */
+export function comparable(value: unknown, key = ""): unknown {
+  if (Array.isArray(value))
+    return value.length
+      ? value.map((v) => comparable(v, key === "state" ? "stateEntry" : ""))
+      : undefined;
+  if (value && typeof value === "object")
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([k]) => !(key === "stateEntry" && k === "id"))
+        .map(([k, v]) => [k, comparable(v, k)])
+        .filter(([, v]) => v !== undefined),
+    );
+  if ((key === "t" || key === "viaStartTime") && value != null)
+    return +new Date(value as string);
+  return value;
+}
+function within(entries: Map<string, Entry>, id: string, scope: string): boolean {
+  const seen = new Set<string>();
+  let current: string | undefined = id;
+  while (current && !seen.has(current)) {
+    if (current === scope) return true;
+    seen.add(current);
+    current = entries.get(current)?.parent;
+  }
+  return false;
+}
+/** Incoming authored fields replace included units' fields; omitted units retain their
+ * fields and parent. This is deliberately not field-level conflict resolution.
+ * The returned scenario is the sole source for both the diff and application. */
+export function planScenarioImport(
+  master: Scenario,
+  incoming: Scenario,
+  options: ImportOptions,
+) {
+  const errors: string[] = [];
+  const before = index(master, errors);
+  const source = index(klona(incoming), errors);
+  const next = klona(master);
+  const after = index(next);
+  const scope = source.get(options.scopeId);
+  const target = before.get(options.scopeId);
+  const changes: ImportChange[] = [];
+  const ignored: string[] = [];
+  if (!scope || scope.kind === "unit") errors.push("Select a side or group to import.");
+  if (options.action !== "copy" && target && target.kind !== scope?.kind)
+    errors.push("Target ID belongs to another entity type.");
+  const selected = new Set(options.selectedIds);
+  const included = [...source].filter(
+    ([id, e]) =>
+      within(source, id, options.scopeId) &&
+      (e.kind !== "unit" ||
+        (options.action === "replace" && options.content !== "state-only") ||
+        selected.has(id)),
+  );
+  if (options.action === "copy" && options.content === "state-only")
+    errors.push("State-only import cannot create a separate copy.");
+  const remap = new Map<string, string>();
+  if (options.action === "copy") included.forEach(([id]) => remap.set(id, nanoid()));
+  const mapped = (id: string) => remap.get(id) ?? id;
+  const touched = new Set<string>();
+  if (options.action === "replace" && options.content !== "state-only") {
+    for (const [id] of before)
+      if (within(before, id, options.scopeId)) {
+        after.delete(id);
+        touched.add(id);
+      }
+  }
+  for (const [id, entry] of included) {
+    const old = before.get(id);
+    if (options.action !== "copy" && old && !within(before, id, options.scopeId)) {
+      errors.push(
+        `${entry.node.name} (${id}) belongs outside the selected target scope.`,
+      );
+      continue;
+    }
+    if (options.content === "state-only" && (entry.kind !== "unit" || !old)) {
+      if (entry.kind === "unit")
+        ignored.push(`${entry.node.name}: missing unit; state-only does not add units.`);
+      continue;
+    }
+    if (old && options.action !== "copy" && old.kind !== entry.kind) {
+      errors.push(`${entry.node.name}: ID belongs to another entity type.`);
+      continue;
+    }
+    let node = klona(entry.node);
+    let parent =
+      id === options.scopeId && old && options.action !== "copy"
+        ? old.parent
+        : entry.parent;
+    if (entry.kind === "unit") {
+      const unit = node as Unit;
+      const existing =
+        options.action === "copy" ? undefined : (old?.node as Unit | undefined);
+      if (options.content === "state-only") {
+        node = klona(existing!);
+        parent = old!.parent;
+      }
+      const output = node as Unit;
+      if (options.content === "units-only") output.state = klona(existing?.state ?? []);
+      else if (options.states === "add_new") {
+        const latest = Math.max(
+          -Infinity,
+          ...(existing?.state ?? []).map((s) => +new Date(s.t)),
+        );
+        const additions = (unit.state ?? []).filter((s) => +new Date(s.t) > latest);
+        const skipped = (unit.state?.length ?? 0) - additions.length;
+        if (skipped)
+          ignored.push(
+            `${unit.name}: ${skipped} states at or before the latest timestamp ignored.`,
+          );
+        output.state = [...klona(existing?.state ?? []), ...additions];
+      } else output.state = klona(unit.state ?? []);
+      if (options.action === "copy")
+        output.state?.forEach((s) => {
+          s.id = nanoid();
+          if (s.hierarchy) {
+            s.hierarchy.targetId = mapped(s.hierarchy.targetId);
+            if (s.hierarchy.parentId) s.hierarchy.parentId = mapped(s.hierarchy.parentId);
+          }
+        });
+    }
+    node.id = mapped(id);
+    if (parent) parent = mapped(parent);
+    if (
+      id === options.scopeId &&
+      entry.kind === "group" &&
+      (options.action === "copy" || !target)
+    )
+      parent = options.targetSideId;
+    after.set(node.id, { ...entry, node, parent });
+    touched.add(node.id);
+  }
+  // Validate the final graph before rebuilding it. Also catches references from
+  // preserved units to nodes removed by an explicit replacement.
+  for (const [id, e] of after) {
+    if (e.parent && !after.has(e.parent))
+      errors.push(`${e.node.name}: unresolved parent ${e.parent}.`);
+    if (e.kind === "group" && e.parent && after.get(e.parent)?.kind !== "side")
+      errors.push(`${e.node.name}: a group must belong to a side.`);
+    if (e.kind !== "side" && !e.parent) errors.push(`${e.node.name}: missing parent.`);
+    if (
+      touched.has(id) &&
+      e.parent &&
+      id !== mapped(options.scopeId) &&
+      !within(after, e.parent, mapped(options.scopeId))
+    )
+      errors.push(`${e.node.name}: parent lies outside selected scope.`);
+    const seen = new Set([id]);
+    let parent = e.parent;
+    while (parent && after.has(parent)) {
+      if (seen.has(parent)) {
+        errors.push(`${e.node.name}: hierarchy cycle.`);
+        break;
+      }
+      seen.add(parent);
+      parent = after.get(parent)?.parent;
+    }
+    if (e.kind === "unit")
+      for (const state of (e.node as Unit).state ?? []) {
+        if (!state.hierarchy) continue;
+        for (const ref of [state.hierarchy.targetId, state.hierarchy.parentId].filter(
+          Boolean,
+        ) as string[]) {
+          if (
+            !after.has(ref) ||
+            (touched.has(id) && !within(after, ref, mapped(options.scopeId)))
+          )
+            errors.push(
+              `${e.node.name}: unresolved or out-of-scope hierarchy reference ${ref}.`,
+            );
+        }
+      }
+  }
+  if (!errors.length) {
+    next.sides = [];
+    for (const e of after.values()) {
+      if (e.node.subUnits) e.node.subUnits = [];
+      if ("groups" in e.node) e.node.groups = [];
+    }
+    for (const e of after.values()) {
+      if (e.kind === "side") next.sides.push(e.node as Side);
+      else {
+        const parent = after.get(e.parent!)!.node;
+        if (e.kind === "group" && "groups" in parent)
+          parent.groups.push(e.node as SideGroup);
+        else (parent.subUnits ??= []).push(e.node as Unit);
+      }
+    }
+  }
+  if (!errors.length) {
+    const sideOrder = master.sides.map((s) => s.id);
+    const rank = (ids: string[], id: string) =>
+      ids.includes(id) ? ids.indexOf(id) : ids.length;
+    next.sides.sort((a, b) => rank(sideOrder, a.id) - rank(sideOrder, b.id));
+    if (scope?.kind === "group" && target?.parent && options.action !== "copy") {
+      const oldParent = before.get(target.parent)?.node as Side;
+      const newParent = after.get(target.parent)?.node as Side;
+      const order = oldParent.groups.map((g) => g.id);
+      newParent.groups.sort((a, b) => rank(order, a.id) - rank(order, b.id));
+    }
+  }
+  if (!errors.length && options.content !== "state-only") {
+    for (const [sourceId, e] of included) {
+      const dest = after.get(mapped(sourceId));
+      if (!dest) continue;
+      const ordered = (e.node.subUnits ?? [])
+        .map((u) => mapped(u.id))
+        .filter((id) => touched.has(id));
+      dest.node.subUnits?.sort((a, b) => {
+        const rank = (id: string) =>
+          ordered.includes(id) ? ordered.indexOf(id) : ordered.length;
+        return rank(a.id) - rank(b.id);
+      });
+      if ("groups" in dest.node && "groups" in e.node) {
+        const order = e.node.groups.map((g) => mapped(g.id));
+        dest.node.groups.sort(
+          (a, b) =>
+            (order.includes(a.id) ? order.indexOf(a.id) : order.length) -
+            (order.includes(b.id) ? order.indexOf(b.id) : order.length),
+        );
+      }
+    }
+  }
+  for (const id of new Set([...before.keys(), ...after.keys()])) {
+    const a = before.get(id),
+      b = after.get(id);
+    const oldFields = a && fields(a),
+      newFields = b && fields(b);
+    if (
+      !touched.has(id) &&
+      !within(before, id, options.scopeId) &&
+      isEqual(comparable(oldFields), comparable(newFields))
+    )
+      continue;
+    const effect = !a
+      ? "added"
+      : !b
+        ? "removed"
+        : !isEqual(comparable(oldFields), comparable(newFields))
+          ? "changed"
+          : !touched.has(id)
+            ? "preserved"
+            : "unchanged";
+    changes.push({
+      id,
+      name: (b ?? a)!.node.name,
+      kind: (b ?? a)!.kind,
+      effect,
+      before: oldFields,
+      after: newFields,
+    });
+  }
+
+  // Bring definitions needed by additions without importing unrelated catalogs or
+  // overwriting the master's definitions. Unit resources use names in scenario files.
+  const dependencies: { kind: string; name: string; definition: object }[] = [];
+  const changedUnits = changes
+    .filter((c) => c.kind === "unit" && (c.effect === "added" || c.effect === "changed"))
+    .map((c) => after.get(c.id)!.node as Unit);
+  function addDefinitions<T extends { name: string }>(
+    kind: string,
+    existing: T[],
+    definitions: T[],
+    required: Set<string>,
+  ): T[] {
+    const names = new Set(existing.map((e) => e.name));
+    const added = definitions.filter((e) => required.has(e.name) && !names.has(e.name));
+    added.forEach((e) => dependencies.push({ kind, name: e.name, definition: e }));
+    return [...existing, ...klona(added)];
+  }
+  const resourceNames = (key: "equipment" | "personnel" | "supplies") =>
+    new Set(
+      changedUnits.flatMap((u) => [
+        ...(u[key] ?? []).map((e) => e.name),
+        ...(u.state ?? []).flatMap((s) =>
+          [...(s.update?.[key] ?? []), ...(s.diff?.[key] ?? [])].map((e) => e.name),
+        ),
+      ]),
+    );
+  next.equipment = addDefinitions(
+    "Equipment",
+    next.equipment ?? [],
+    incoming.equipment ?? [],
+    resourceNames("equipment"),
+  );
+  next.personnel = addDefinitions(
+    "Personnel",
+    next.personnel ?? [],
+    incoming.personnel ?? [],
+    resourceNames("personnel"),
+  );
+  next.supplyCategories = addDefinitions(
+    "Supply",
+    next.supplyCategories ?? [],
+    incoming.supplyCategories ?? [],
+    resourceNames("supplies"),
+  );
+  const symbols = new Set(
+    changedUnits.flatMap((u) =>
+      [u.sidc, ...(u.state ?? []).map((s) => s.sidc)]
+        .filter(Boolean)
+        .map((sidc) => getCustomSymbolId(sidc!))
+        .filter(Boolean),
+    ),
+  );
+  const addedSymbols = (incoming.settings?.customSymbols ?? []).filter(
+    (s) =>
+      symbols.has(s.id) &&
+      !(next.settings?.customSymbols ?? []).some((e) => e.id === s.id),
+  );
+  if (addedSymbols.length) {
+    next.settings ??= {
+      rangeRingGroups: [],
+      statuses: [],
+      supplyClasses: [],
+      supplyUoMs: [],
+    };
+    next.settings.customSymbols = [
+      ...(next.settings.customSymbols ?? []),
+      ...klona(addedSymbols),
+    ];
+    addedSymbols.forEach((s) =>
+      dependencies.push({ kind: "Symbol", name: s.name, definition: s }),
+    );
+  }
+  return {
+    scenario: next,
+    changes,
+    errors: [...new Set(errors)],
+    ignored,
+    dependencies,
+    options: klona(options),
+    hasChanges: changes.some((c) => ["added", "changed", "removed"].includes(c.effect)),
+  };
+}

--- a/src/importexport/scenarioImportSummary.test.ts
+++ b/src/importexport/scenarioImportSummary.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { describeImportChange } from "./scenarioImportSummary";
+import type { ImportChange } from "./scenarioImportPlan";
+const names = (id: string) =>
+  ({ hq: "HQ", infantry: "Infantry", child: "Platoon" })[id] ?? id;
+function summary(
+  before: object,
+  after: object,
+  effect: ImportChange["effect"] = "changed",
+) {
+  return describeImportChange(
+    { id: "u", name: "Unit", kind: "unit", effect, before, after },
+    names,
+  );
+}
+describe("readable import changes", () => {
+  it("uses names for hierarchy moves and describes location additions", () => {
+    expect(summary({ parent: "hq" }, { parent: "infantry", location: [1, 2] })).toEqual([
+      "Moved from HQ to Infantry.",
+      "Location added.",
+    ]);
+  });
+  it("counts appended history while accepting equivalent timestamp formats and generated IDs", () => {
+    expect(
+      summary(
+        { state: [{ id: "old", t: 1000, location: [0, 0] }] },
+        {
+          state: [
+            { id: "generated", t: "1970-01-01T00:00:01Z", location: [0, 0] },
+            { id: "new", t: 2000 },
+          ],
+        },
+      ),
+    ).toEqual(["History: 1 entry added."]);
+  });
+  it("distinguishes changed, added and removed history entries", () => {
+    expect(
+      summary(
+        {
+          state: [
+            { id: "a", t: 1000, location: [1, 1] },
+            { id: "b", t: 2000 },
+          ],
+        },
+        {
+          state: [
+            { id: "a", t: 1000, location: [2, 2] },
+            { id: "c", t: 3000 },
+          ],
+        },
+      ),
+    ).toEqual(["History: 1 entry added, 1 entry updated, 1 entry removed."]);
+    expect(
+      summary(
+        {
+          state: [
+            { id: "a", t: 1000 },
+            { id: "b", t: 2000 },
+          ],
+        },
+        { state: [] },
+      ),
+    ).toEqual(["History: 2 entries removed."]);
+  });
+  it("describes incoming unit details without showing raw symbol codes", () => {
+    expect(
+      summary(
+        {},
+        {
+          id: "u",
+          name: "Unit",
+          sidc: "10031000001211000000",
+          parent: "hq",
+          location: [1, 2],
+          state: [{ id: "s", t: 1000 }],
+        },
+        "added",
+      ),
+    ).toEqual([
+      "New unit will be added.",
+      "Symbol set.",
+      "Added under HQ.",
+      "Location added.",
+      "History: 1 entry added.",
+    ]);
+  });
+  it("describes reordered children and cleared fields", () => {
+    expect(
+      summary(
+        { subUnits: ["hq", "child"], description: "old" },
+        { subUnits: ["child", "hq"] },
+      ),
+    ).toEqual(["Child units reordered.", "Description cleared."]);
+    expect(summary({ subUnits: [] }, { subUnits: ["child"] })).toEqual([
+      "Child units added: Platoon.",
+    ]);
+  });
+  it("does not hide ID changes inside authored fields", () => {
+    expect(summary({ properties: { id: "old" } }, { properties: { id: "new" } })).toEqual(
+      ["Properties changed."],
+    );
+  });
+  it("keeps removals and unchanged items unambiguous", () => {
+    expect(summary({}, {}, "removed")).toEqual([
+      "This unit and its data will be removed.",
+    ]);
+    expect(summary({}, {}, "preserved")).toEqual([
+      "Not included in this update; kept as it is.",
+    ]);
+    expect(summary({}, {}, "unchanged")).toEqual(["Already matches; no changes needed."]);
+  });
+});

--- a/src/importexport/scenarioImportSummary.ts
+++ b/src/importexport/scenarioImportSummary.ts
@@ -1,0 +1,140 @@
+import { isEqual } from "es-toolkit";
+import { comparable, type ImportChange, type ImportOptions } from "./scenarioImportPlan";
+
+const equal = (a: unknown, b: unknown, key = "") =>
+  isEqual(comparable(a, key), comparable(b, key));
+const label = (key: string) =>
+  ({
+    sidc: "Symbol",
+    subUnits: "Child units",
+    symbolOptions: "Symbol appearance",
+    state: "History",
+  })[key] ??
+  key[0].toUpperCase() + key.slice(1).replace(/[A-Z]/g, (c) => ` ${c.toLowerCase()}`);
+const count = (n: number) => `${n} ${n === 1 ? "entry" : "entries"}`;
+
+/** Short user-facing descriptions; the original plan remains available for inspection. */
+export function describeImportChange(
+  change: ImportChange,
+  nameForId: (id: string) => string,
+): string[] {
+  if (change.effect === "removed")
+    return [`This ${change.kind} and its data will be removed.`];
+  if (change.effect === "preserved")
+    return ["Not included in this update; kept as it is."];
+  if (change.effect === "unchanged") return ["Already matches; no changes needed."];
+  const before = (change.before ?? {}) as Record<string, unknown>;
+  const after = (change.after ?? {}) as Record<string, unknown>;
+  const messages: string[] =
+    change.effect === "added" ? [`New ${change.kind} will be added.`] : [];
+  for (const key of new Set([...Object.keys(before), ...Object.keys(after)])) {
+    if (
+      key === "id" ||
+      (key === "name" && change.effect === "added") ||
+      equal(before[key], after[key], key)
+    )
+      continue;
+    const a = before[key],
+      b = after[key];
+    if (key === "parent") {
+      messages.push(
+        a == null
+          ? `Added under ${nameForId(String(b))}.`
+          : `Moved from ${nameForId(String(a))} to ${nameForId(String(b))}.`,
+      );
+    } else if (key === "state") {
+      const old = [...((a ?? []) as Record<string, unknown>[])];
+      const incoming = (b ?? []) as Record<string, unknown>[];
+      // Match identical entries first so a repeated entry cannot conceal a removal.
+      const unmatched = incoming.filter((entry) => {
+        const i = old.findIndex((s) => equal(s, entry, "stateEntry"));
+        if (i < 0) return true;
+        old.splice(i, 1);
+        return false;
+      });
+      let updated = 0;
+      for (const entry of unmatched) {
+        const i = old.findIndex(
+          (s) =>
+            (s.id && s.id === entry.id) ||
+            +new Date(s.t as string) === +new Date(entry.t as string),
+        );
+        if (i >= 0) {
+          updated++;
+          old.splice(i, 1);
+        }
+      }
+      const added = unmatched.length - updated;
+      const parts = [
+        added && `${count(added)} added`,
+        updated && `${count(updated)} updated`,
+        old.length && `${count(old.length)} removed`,
+      ].filter(Boolean);
+      messages.push(
+        parts.length ? `History: ${parts.join(", ")}.` : "History entries reordered.",
+      );
+    } else if (key === "subUnits" || key === "groups") {
+      const old = (a ?? []) as string[],
+        next = (b ?? []) as string[];
+      const added = next.filter((id) => !old.includes(id));
+      const removed = old.filter((id) => !next.includes(id));
+      if (added.length)
+        messages.push(`${label(key)} added: ${added.map(nameForId).join(", ")}.`);
+      if (removed.length)
+        messages.push(
+          `${label(key)} moved or removed: ${removed.map(nameForId).join(", ")}.`,
+        );
+      if (!added.length && !removed.length) messages.push(`${label(key)} reordered.`);
+    } else if (key === "sidc") {
+      messages.push(a == null ? "Symbol set." : "Symbol changed.");
+    } else if (key === "location") {
+      messages.push(
+        b == null
+          ? "Location removed."
+          : a == null
+            ? "Location added."
+            : "Location changed.",
+      );
+    } else if (b == null || (Array.isArray(b) && !b.length))
+      messages.push(`${label(key)} cleared.`);
+    else if (["string", "number", "boolean"].includes(typeof b))
+      messages.push(
+        `${label(key)}: ${a == null ? "not set" : String(a)} → ${String(b)}.`,
+      );
+    else messages.push(`${label(key)} ${a == null ? "added" : "changed"}.`);
+  }
+  return messages;
+}
+
+/** Headline for the whole plan: the verb describing the action and the unit tally. */
+export function summarizeImportPlan(
+  changes: ImportChange[],
+  options: Pick<ImportOptions, "action" | "content">,
+) {
+  const counts: Record<ImportChange["effect"], number> = {
+    added: 0,
+    changed: 0,
+    removed: 0,
+    unchanged: 0,
+    preserved: 0,
+  };
+  for (const change of changes) if (change.kind === "unit") counts[change.effect]++;
+  const parts = [
+    `${counts.changed} ${counts.changed === 1 ? "unit" : "units"} updated`,
+    `${counts.added} added`,
+  ];
+  if (counts.removed) parts.push(`${counts.removed} removed`);
+  parts.push(`${counts.unchanged + counts.preserved} left unchanged`);
+  return {
+    counts,
+    action:
+      options.content === "state-only"
+        ? "Update history for"
+        : options.action === "replace"
+          ? "Replace"
+          : options.action === "copy"
+            ? "Create a separate copy of"
+            : "Update",
+    sentence: parts.join(", ") + ".",
+  };
+}

--- a/src/modules/grid/DataGrid.test.ts
+++ b/src/modules/grid/DataGrid.test.ts
@@ -1,0 +1,103 @@
+import { mount, flushPromises } from "@vue/test-utils";
+import { describe, expect, it, vi } from "vitest";
+import DataGrid from "./DataGrid.vue";
+
+// jsdom has no layout. Render every virtual row while exercising the real table model.
+vi.mock("@tanstack/vue-virtual", async () => {
+  const { computed } = await import("vue");
+  return {
+    useVirtualizer: (options: { value: { count: number } }) =>
+      computed(() => ({
+        getVirtualItems: () =>
+          Array.from({ length: options.value.count }, (_, index) => ({
+            key: index,
+            index,
+            start: index * 40,
+          })),
+        getTotalSize: () => options.value.count * 40,
+      })),
+  };
+});
+const data = [
+  {
+    id: "parent",
+    name: "Parent",
+    subUnits: [
+      { id: "changed", name: "Changed" },
+      { id: "same", name: "Unchanged child" },
+    ],
+  },
+  { id: "other", name: "Other" },
+];
+function setup() {
+  return mount(DataGrid, {
+    props: {
+      data,
+      columns: [{ id: "name", accessorKey: "name", header: "Name" }],
+      select: true,
+      selectAll: true,
+      initialState: { expanded: true },
+      getSubRows: (row: { subUnits?: unknown[] }) => row.subUnits ?? [],
+    },
+  });
+}
+describe("DataGrid display filtering", () => {
+  it("keeps ancestors and selection when filtering and unfiltering", async () => {
+    const wrapper = setup();
+    await flushPromises();
+    expect(wrapper.findAll("tbody tr")).toHaveLength(4);
+    const events = wrapper.emitted("update:selected")!.length;
+    await wrapper.setProps({ rowFilter: (row) => row.id === "changed" });
+    expect(wrapper.findAll("tbody tr").map((r) => r.text())).toEqual([
+      "Parent",
+      "Changed",
+    ]);
+    expect(wrapper.emitted("update:selected")).toHaveLength(events);
+    await wrapper.setProps({ rowFilter: undefined });
+    expect(wrapper.findAll("tbody tr")).toHaveLength(4);
+    expect(
+      wrapper
+        .findAll<HTMLInputElement>('tbody input[type="checkbox"]')
+        .every((c) => c.element.checked),
+    ).toBe(true);
+    expect(wrapper.emitted("update:selected")).toHaveLength(events);
+  });
+  it("preserves hidden selections when a visible row is deselected", async () => {
+    const wrapper = setup();
+    await flushPromises();
+    await wrapper.setProps({ rowFilter: (row) => row.id === "changed" });
+    await wrapper.findAll("tbody tr")[1].get('input[type="checkbox"]').setValue(false);
+    const selected = wrapper.emitted("update:selected")!.at(-1)![0] as { id: string }[];
+    expect(selected.map((r) => r.id)).toEqual(expect.arrayContaining(["same", "other"]));
+    expect(selected.map((r) => r.id)).not.toContain("changed");
+    await wrapper.setProps({ rowFilter: undefined });
+    const boxes = wrapper.findAll<HTMLInputElement>('tbody input[type="checkbox"]');
+    expect(boxes[1].element.checked).toBe(false);
+    expect(boxes[2].element.checked).toBe(true);
+  });
+  it("keeps existing column visibility settings", async () => {
+    const wrapper = mount(DataGrid, {
+      props: {
+        data: [{ id: "id-1", name: "Visible" }],
+        columns: [
+          { id: "name", accessorKey: "name", header: "Name" },
+          { id: "id", accessorKey: "id", header: "ID" },
+        ],
+        initialState: { columnVisibility: { id: false } },
+      },
+    });
+    await flushPromises();
+    expect(wrapper.findAll("th").map((h) => h.text())).toEqual(["Name"]);
+    await wrapper.setProps({ rowFilter: () => true });
+    expect(wrapper.findAll("th").map((h) => h.text())).toEqual(["Name"]);
+  });
+  it("shows an empty result without clearing selection", async () => {
+    const wrapper = setup();
+    await flushPromises();
+    const events = wrapper.emitted("update:selected")!.length;
+    await wrapper.setProps({ rowFilter: () => false });
+    expect(wrapper.text()).toContain("No matching entries.");
+    expect(wrapper.findAll("tbody tr")).toHaveLength(0);
+    expect(wrapper.emitted("update:selected")).toHaveLength(events);
+  });
+});

--- a/src/modules/grid/DataGrid.vue
+++ b/src/modules/grid/DataGrid.vue
@@ -15,6 +15,9 @@ import {
   getSortedRowModel,
   type InitialTableState,
   type RowSelectionState,
+  type Row,
+  type ColumnFiltersState,
+  type VisibilityState,
   useVueTable,
 } from "@tanstack/vue-table";
 import { useVirtualizer } from "@tanstack/vue-virtual";
@@ -34,6 +37,8 @@ interface Props {
   initialState?: InitialTableState;
   getSubRows?: (row: any) => any[];
   noIndeterminate?: boolean;
+  /** Filters displayed rows while retaining hidden selections and ancestor context. */
+  rowFilter?: (row: Props["data"][number]) => boolean;
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -92,10 +97,32 @@ watch(
 );
 
 const computedColumns = computed((): ColumnDef<any, any>[] => {
-  return [props.select && { ...selectColumn }, ...props.columns].filter(
-    (e) => e,
-  ) as ColumnDef<any, any>[];
+  return [
+    props.select && { ...selectColumn },
+    props.rowFilter && {
+      id: "__rowFilter",
+      enableGlobalFilter: false,
+      accessorFn: (row: Props["data"][number]) => row,
+      filterFn: (
+        row: Row<Props["data"][number]>,
+        _columnId: string,
+        predicate: NonNullable<Props["rowFilter"]>,
+      ) => predicate(row.original),
+    },
+    ...props.columns,
+  ].filter((e) => e) as ColumnDef<any, any>[];
 });
+
+const columnFilters = ref<ColumnFiltersState>(props.initialState?.columnFilters ?? []);
+const columnVisibility = ref<VisibilityState>({
+  ...props.initialState?.columnVisibility,
+  __rowFilter: false,
+});
+const rowFilters = computed(() =>
+  props.rowFilter
+    ? [...columnFilters.value, { id: "__rowFilter", value: props.rowFilter }]
+    : columnFilters.value,
+);
 
 const table = useVueTable({
   get data() {
@@ -103,6 +130,12 @@ const table = useVueTable({
   },
   initialState: props.initialState,
   state: {
+    get columnFilters() {
+      return rowFilters.value;
+    },
+    get columnVisibility() {
+      return columnVisibility.value;
+    },
     get rowSelection() {
       return rowSelection.value;
     },
@@ -121,6 +154,8 @@ const table = useVueTable({
   getExpandedRowModel: getExpandedRowModel(),
   getFilteredRowModel: getFilteredRowModel(),
   autoResetExpanded: false,
+  onColumnFiltersChange: (value) => valueUpdater(value, columnFilters),
+  onColumnVisibilityChange: (value) => valueUpdater(value, columnVisibility),
   onRowSelectionChange: (updateOrValue) => valueUpdater(updateOrValue, rowSelection),
   // onGroupingChange: (updateOrValue) => valueUpdater(updateOrValue, grouping),
   onGlobalFilterChange: (updateOrValue) => valueUpdater(updateOrValue, query),
@@ -146,7 +181,11 @@ const virtualRows = computed(() => rowVirtualizer.value.getVirtualItems());
 
 watch([rowSelection, debouncedQuery], () => {
   const sel: any[] = [];
-  table.getFilteredSelectedRowModel().flatRows.forEach((row) => {
+  // A display filter must not turn hidden selections into deselections.
+  const selectedModel = props.rowFilter
+    ? table.getSelectedRowModel()
+    : table.getFilteredSelectedRowModel();
+  selectedModel.flatRows.forEach((row) => {
     sel.push(row.original);
   });
   emit("update:selected", sel);
@@ -288,6 +327,12 @@ const filteredRowCount = computed(() => {
           </tr>
         </tbody>
       </table>
+      <p
+        v-if="rowFilter && !table.getFilteredRowModel().rows.length"
+        class="text-muted-foreground p-4"
+      >
+        No matching entries.
+      </p>
     </section>
   </div>
 </template>

--- a/user-docs/guide/import-data.md
+++ b/user-docs/guide/import-data.md
@@ -2,6 +2,7 @@
 
 ORBAT Mapper can import units and features from these sources and formats:
 
+- [ORBAT Mapper scenarios](#orbat-mapper-scenarios)
 - [GeoJSON](#geojson)
 - [MilX](#milx)
 - [Spatial Illusions ORBAT Builder](#spatial-illusions-orbat-builder)
@@ -22,6 +23,57 @@ start the import. Select the file for the import and click _Load_. Usually ORBAT
 automatically. If it does not, select the correct format from the _Select import format_ dropdown list.
 
 ![An image](images/import.png)
+
+## ORBAT Mapper scenarios
+
+Use **Side** or **Group** import to add or update data in your current scenario
+from another scenario file. Choose the side or group you want to import.
+To update only part of a side, use **Group** import and import each group separately.
+Other sides and groups are left unchanged.
+
+- **Update included units** is the default. Select the units to update. Existing
+  sides, groups and units are matched by ID, not name. For example, adding a location
+  to an existing unit updates that unit without creating a duplicate. Units missing
+  from the file retain their fields and parent.
+- **Replace entire side/group** treats the incoming scope as complete, including all
+  its units. Existing units and groups missing from the file are removed. Inspect the removal list.
+- **Import as a separate copy** creates fresh IDs for intentional duplication and
+  remaps hierarchy references within the copy.
+
+For included units and groups, incoming authored fields replace existing fields,
+including clearing fields absent from the incoming object. Incoming parentage and
+sibling order apply to included units; omitted siblings follow them in their existing
+order. This is not field-level conflict resolution. References to missing parents or
+units outside the selected scope block the import.
+
+**Units only** preserves existing history. **Units with state** also imports history.
+**State only** updates matching selected units' history without creating missing units
+or changing unit fields or structural parentage. It does not remove omitted units,
+even with the replacement action. History can be replaced (an empty history clears it)
+or appended. Append ignores states at or before the latest existing timestamp.
+Timed hierarchy references in imported history must remain within the selected scope.
+
+Choose import options in the sidebar. The first available side or group is selected
+automatically; use the selector above the unit table to choose another.
+Use the table's checkboxes to select units; expand rows to see their hierarchy.
+The **Changes** column describes each entry's planned changes. Hover over a shortened
+description to read it in full.
+Turn on **Show changed entries only** to hide unchanged entries. Added entries and
+parent rows remain visible, including entries you have unchecked. The filter compares
+all incoming entries; the preview and Import button still use your selection.
+Filtering does not change your selection; removals are
+listed under **Review changes**.
+The summary below the table shows the selected action and target, with counts of units
+updated, added, removed and left unchanged. Units omitted from an update are identified separately.
+Expand **Review changes** for descriptions such as “Location added,” parent changes using
+unit names, and counts of history entries added, updated or removed. Expand **Advanced
+details** to inspect IDs and the full before-and-after data. Unchanged items are listed
+separately in a collapsible section.
+
+Previewing and canceling leave the active scenario untouched. **Import**
+uses that same plan.
+
+Use **Undo** immediately after import to revert the entire import in one step.
 
 ## GeoJSON
 


### PR DESCRIPTION
Partial scenario imports can currently remove omitted units or duplicate existing ones without showing the consequences. This adds a shared import plan so users can review exactly what will change before applying it.

- Default to updating included units by ID while preserving omitted units; retain explicit whole-side/group replacement and separate-copy actions.
- Restrict changes to the selected scope and flag conflicting IDs or unresolved hierarchy references.
- Preview additions, changes, removals, preserved units, hierarchy changes, and state history according to the selected content mode.
- Keep the unit table with a Changes column, automatically select the first side/group, and support filtering to changed entries without hiding changes because of row selection.
- Apply each import as one Undo/Redo action. Recovery uses Undo; automatic checkpoints are intentionally omitted.

Validation: 42 focused import, summary, component, and grid tests pass; TypeScript checking and lint for the changed import files pass. The full suite has a previously reproduced baseline failure in ControlMeasureAmplifiers.

Closes #710
