### PR TITLE
Add export presets and recipient data preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 - Replaced the previous experimental MGRS overlay with the reusable reference-grid implementation and moved its controls into the main map toolbar.
 - Reference-grid rendering is now loaded on demand the first time a grid is shown, reducing the initial MapLibre editor download.
 
+### Fixed
+
+- Fixed side duplication omitting units attached directly to a side, including sides without groups. Both duplicate actions now copy these units and their descendants, retaining unit state when requested.
+
 ## August 2026
 
 ### Added

--- a/src/components/ExportSettingsOrbatMapper.test.ts
+++ b/src/components/ExportSettingsOrbatMapper.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { defineComponent } from "vue";
 import { mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import ExportSettingsOrbatMapper from "@/components/ExportSettingsOrbatMapper.vue";
 import { activeScenarioKey } from "@/components/injects";
 import type { OrbatMapperExportSettings } from "@/types/importExport";
@@ -12,8 +12,9 @@ const InputCheckboxStub = defineComponent({
   template: "<div />",
 });
 
-function mountSettings(form: OrbatMapperExportSettings) {
+function mountSettings(form: OrbatMapperExportSettings, scenarioId = "scenario-a") {
   const state = {
+    id: scenarioId,
     info: { name: "Source scenario" },
     sides: [],
     sideMap: {},
@@ -32,13 +33,35 @@ function mountSettings(form: OrbatMapperExportSettings) {
   };
 
   return mount(ExportSettingsOrbatMapper, {
-    props: { modelValue: form },
+    props: {
+      modelValue: form,
+      "onUpdate:modelValue": (value) => Object.assign(form, value),
+    },
     global: {
       provide: {
-        [activeScenarioKey as symbol]: { store: { state } },
+        [activeScenarioKey as symbol]: {
+          store: { state },
+          io: {
+            toObject: () => ({
+              id: scenarioId,
+              name: "Source scenario",
+              sides: [],
+              layerStack: Object.values(state.layerStackMap),
+              description: "Controller briefing",
+              events: [],
+            }),
+          },
+        },
       },
       stubs: {
         InputCheckbox: InputCheckboxStub,
+        FieldSelect: defineComponent({
+          props: ["items", "modelValue"],
+          emits: ["update:modelValue"],
+          template: `<select :value="modelValue" @change="$emit('update:modelValue', $event.target.value || null)">
+            <option v-for="item in items" :key="item.value" :value="item.value ?? ''">{{ item.label }}</option>
+          </select>`,
+        }),
         InputGroupTemplate: { template: "<section><slot /></section>" },
         InputGroup: true,
       },
@@ -56,6 +79,68 @@ function form(layerIds?: string[]): OrbatMapperExportSettings {
 }
 
 describe("ExportSettingsOrbatMapper", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("saves explicit selections and reloads them only for the same scenario", async () => {
+    const settings = form(["features"]);
+    const wrapper = mountSettings(settings);
+    wrapper
+      .findComponent({ name: "InputGroup" })
+      .vm.$emit("update:modelValue", "Blue contacts");
+    await wrapper.vm.$nextTick();
+    const button = (text: string) =>
+      wrapper.findAll("button").find((b) => b.text() === text)!;
+    await button("Save as new preset").trigger("click");
+    expect(wrapper.findAll("option").map((o) => o.text())).toContain("Blue contacts");
+    wrapper.unmount();
+
+    const reopened = mountSettings(form([]));
+    const id = reopened.findAll("option")[1]!.attributes("value");
+    await reopened.find("select").setValue(id);
+    expect(reopened.props("modelValue").layerIds).toEqual(["features"]);
+    // The other existing layer remains excluded, as will any newly added layer.
+    expect(mountSettings(form([]), "scenario-b").findAll("option")).toHaveLength(1);
+    await reopened
+      .findAll("button")
+      .find((b) => b.text() === "Delete preset")!
+      .trigger("click");
+    expect(reopened.findAll("option")).toHaveLength(1);
+    reopened.unmount();
+  });
+
+  it("shows selected content and retained scenario information in the preview", async () => {
+    const wrapper = mountSettings(form(["features"]));
+    await wrapper
+      .findAll("button")
+      .find((b) => b.text() === "Preview recipient data")!
+      .trigger("click");
+    const preview = wrapper.find('[aria-label="Recipient preview"]');
+    expect(preview.text()).toContain("Controller briefing");
+    expect(preview.text()).toContain("Features");
+    expect(preview.text()).not.toContain("Control measures");
+  });
+
+  it("warns about missing preset content without selecting other layers", async () => {
+    localStorage.setItem(
+      "orbatmapper:export-presets:scenario-a",
+      JSON.stringify([
+        {
+          id: "blue",
+          name: "Blue",
+          sideGroups: ["deleted"],
+          layerIds: ["removed"],
+          fileName: "blue.json",
+        },
+      ]),
+    );
+    const settings = form();
+    const wrapper = mountSettings(settings);
+    await wrapper.find("select").setValue("blue");
+    expect(settings.sideGroups).toEqual([]);
+    expect(settings.layerIds).toEqual([]);
+    expect(wrapper.find('[role="status"]').text()).toContain("no longer exist");
+  });
+
   it("selects every layer for settings saved before layer selection existed", () => {
     const settings = form();
     const wrapper = mountSettings(settings);

--- a/src/components/ExportSettingsOrbatMapper.test.ts
+++ b/src/components/ExportSettingsOrbatMapper.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { defineComponent } from "vue";
+import { defineComponent, reactive } from "vue";
 import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it } from "vitest";
 import ExportSettingsOrbatMapper from "@/components/ExportSettingsOrbatMapper.vue";
@@ -16,8 +16,8 @@ function mountSettings(form: OrbatMapperExportSettings, scenarioId = "scenario-a
   const state = {
     id: scenarioId,
     info: { name: "Source scenario" },
-    sides: [],
-    sideMap: {},
+    sides: ["empty"],
+    sideMap: { empty: { id: "empty", name: "Empty side", groups: [] } },
     sideGroupMap: {},
     layerStack: ["features", "control-measures"],
     layerStackMap: {
@@ -45,7 +45,7 @@ function mountSettings(form: OrbatMapperExportSettings, scenarioId = "scenario-a
             toObject: () => ({
               id: scenarioId,
               name: "Source scenario",
-              sides: [],
+              sides: Object.values(state.sideMap),
               layerStack: Object.values(state.layerStackMap),
               description: "Controller briefing",
               events: [],
@@ -70,16 +70,95 @@ function mountSettings(form: OrbatMapperExportSettings, scenarioId = "scenario-a
 }
 
 function form(layerIds?: string[]): OrbatMapperExportSettings {
-  return {
+  return reactive({
     sideGroups: [],
     layerIds,
     customColors: true,
     fileName: "scenario.json",
-  };
+  });
 }
 
 describe("ExportSettingsOrbatMapper", () => {
   beforeEach(() => localStorage.clear());
+
+  it("updates suggested names until each field is edited", async () => {
+    const settings = form(["features"]);
+    const wrapper = mountSettings(settings);
+    expect(settings.scenarioName).toBe("Source scenario — Layers");
+    expect(settings.fileName).toBe("source-scenario-layers.json");
+    const input = (label: string) =>
+      wrapper
+        .findAllComponents({ name: "InputGroup" })
+        .find((c) => c.attributes("label") === label)!;
+    input("Scenario name").vm.$emit("update:modelValue", "Custom briefing");
+    settings.emptySideIds = ["empty"];
+    await wrapper.vm.$nextTick();
+    expect(settings.scenarioName).toBe("Custom briefing");
+    expect(settings.fileName).toBe("source-scenario-empty-side.json");
+    input("Name of downloaded file").vm.$emit("update:modelValue", "briefing.json");
+    settings.emptySideIds = [];
+    await wrapper.vm.$nextTick();
+    expect(settings.fileName).toBe("briefing.json");
+  });
+
+  it("preserves preset names after selections change", async () => {
+    localStorage.setItem(
+      "orbatmapper:export-presets:scenario-a",
+      JSON.stringify([
+        {
+          id: "blue",
+          name: "Blue",
+          sideGroups: [],
+          layerIds: ["features"],
+          scenarioName: "Turn 3",
+          fileName: "turn-3.json",
+        },
+      ]),
+    );
+    const settings = form([]);
+    const wrapper = mountSettings(settings);
+    await wrapper.find("select").setValue("blue");
+    settings.emptySideIds = ["empty"];
+    await wrapper.vm.$nextTick();
+    expect(settings.scenarioName).toBe("Turn 3");
+    expect(settings.fileName).toBe("turn-3.json");
+  });
+
+  it("selects an empty side, previews it, and restores it from a preset", async () => {
+    const settings = form([]);
+    const wrapper = mountSettings(settings);
+    const checkbox = wrapper
+      .findAllComponents(InputCheckboxStub)
+      .find((c) => c.props("value") === "empty")!;
+    expect(checkbox.props("label")).toBe("Include side");
+    checkbox.vm.$emit("update:modelValue", ["empty"]);
+    await wrapper.vm.$nextTick();
+    expect(settings.emptySideIds).toEqual(["empty"]);
+    const button = (text: string) =>
+      wrapper.findAll("button").find((b) => b.text() === text)!;
+    await button("Preview recipient data").trigger("click");
+    expect(wrapper.find('[aria-label="Recipient preview"]').text()).toContain(
+      "Empty side — no groups",
+    );
+    wrapper
+      .findComponent({ name: "InputGroup" })
+      .vm.$emit("update:modelValue", "Empty side preset");
+    await wrapper.vm.$nextTick();
+    await button("Save as new preset").trigger("click");
+    wrapper.unmount();
+    const restored = form([]);
+    const reopened = mountSettings(restored);
+    await reopened
+      .find("select")
+      .setValue(reopened.findAll("option")[1]!.attributes("value"));
+    expect(restored.emptySideIds).toEqual(["empty"]);
+    await reopened
+      .findAll("button")
+      .find((b) => b.text() === "Empty side")!
+      .trigger("click");
+    expect(restored.emptySideIds).toEqual([]);
+    reopened.unmount();
+  });
 
   it("saves explicit selections and reloads them only for the same scenario", async () => {
     const settings = form(["features"]);

--- a/src/components/ExportSettingsOrbatMapper.vue
+++ b/src/components/ExportSettingsOrbatMapper.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { type OrbatMapperExportSettings } from "@/types/importExport.ts";
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useLocalStorage } from "@vueuse/core";
 import { Button } from "@/components/ui/button";
 import { nanoid } from "@/utils";
 import { buildRecipientScenario } from "@/importexport/export/recipientScenario";
+import { suggestExportNames } from "@/importexport/export/exportNames";
 import type { Unit } from "@/types/scenarioModels";
 import { injectStrict } from "@/utils";
 import { activeScenarioKey } from "@/components/injects";
@@ -20,10 +21,11 @@ const {
   store: { state },
 } = injectStrict(activeScenarioKey);
 
-form.value.scenarioName = state.info.name;
 // Existing persisted export settings predate layer selection. Start those users with
 // every layer selected, preserving the export behavior they had before this option.
 if (form.value.layerIds === undefined) form.value.layerIds = [...state.layerStack];
+
+if (form.value.emptySideIds === undefined) form.value.emptySideIds = [];
 
 const sides = computed(() => {
   return state.sides.map((id) => state.sideMap[id]);
@@ -33,10 +35,29 @@ const layers = computed(() => {
   return state.layerStack.map((id) => state.layerStackMap[id]).filter(Boolean);
 });
 
+const automaticScenarioName = ref(
+  !form.value.scenarioName || form.value.scenarioName === state.info.name,
+);
+const automaticFileName = ref(
+  !form.value.fileName || form.value.fileName === "scenario.json",
+);
+const suggestedNames = computed(() =>
+  suggestExportNames(state.info.name, sides.value, state.layerStack, form.value),
+);
+watch(
+  suggestedNames,
+  (names) => {
+    if (automaticScenarioName.value) form.value.scenarioName = names.scenarioName;
+    if (automaticFileName.value) form.value.fileName = names.fileName;
+  },
+  { immediate: true },
+);
+
 interface ExportPreset {
   id: string;
   name: string;
   sideGroups: string[];
+  emptySideIds?: string[];
   layerIds: NonNullable<OrbatMapperExportSettings["layerIds"]>;
   scenarioName?: string;
   fileName: string;
@@ -61,6 +82,7 @@ function savePreset(replace = false) {
     id: replace ? selectedPreset.value : nanoid(),
     name: presetName.value.trim(),
     sideGroups: [...form.value.sideGroups],
+    emptySideIds: [...(form.value.emptySideIds ?? [])],
     layerIds: [...(form.value.layerIds ?? state.layerStack)],
     scenarioName: form.value.scenarioName,
     fileName: form.value.fileName,
@@ -72,19 +94,27 @@ function savePreset(replace = false) {
 function loadPreset() {
   const preset = presets.value.find((p) => p.id === selectedPreset.value);
   if (!preset) return;
+  automaticScenarioName.value = false;
+  automaticFileName.value = false;
   const groups = preset.sideGroups.filter((id) => state.sideGroupMap[id]);
+  const emptySides = (preset.emptySideIds ?? []).filter(
+    (id) => state.sideMap[id]?.groups.length === 0,
+  );
   const layers = preset.layerIds.filter((id) => state.layerStackMap[id]);
   form.value = {
     ...form.value,
     sideGroups: groups,
+    emptySideIds: emptySides,
     layerIds: layers,
     scenarioName: preset.scenarioName,
     fileName: preset.fileName,
   };
   presetName.value = preset.name;
   notice.value =
-    groups.length !== preset.sideGroups.length || layers.length !== preset.layerIds.length
-      ? "Some saved groups or layers no longer exist and were omitted. Review the selection."
+    groups.length !== preset.sideGroups.length ||
+    emptySides.length !== (preset.emptySideIds ?? []).length ||
+    layers.length !== preset.layerIds.length
+      ? "Some saved selections no longer exist or are no longer empty and were omitted. Review the selection."
       : `Loaded ${preset.name}.`;
 }
 function deletePreset() {
@@ -110,6 +140,13 @@ function countUnits(units: Unit[]): number {
 
 function toggleSide(sideId: string) {
   const groups = state.sideMap[sideId].groups;
+  if (!groups.length) {
+    const selected = form.value.emptySideIds ?? [];
+    form.value.emptySideIds = selected.includes(sideId)
+      ? selected.filter((id) => id !== sideId)
+      : [...selected, sideId];
+    return;
+  }
   if (form.value.sideGroups.some((g) => groups.includes(g))) {
     form.value.sideGroups = form.value.sideGroups.filter((g) => !groups.includes(g));
   } else {
@@ -174,7 +211,7 @@ function toggleSide(sideId: string) {
         <p role="status" class="text-sm">{{ notice }}</p>
       </div>
     </details>
-    <InputGroupTemplate label="Select which side groups you want to export">
+    <InputGroupTemplate label="Select which sides and groups you want to export">
       <div class="divide-y">
         <div v-for="v in sides" :key="v.id" class="grid grid-cols-4 gap-4 py-3">
           <button
@@ -185,6 +222,12 @@ function toggleSide(sideId: string) {
             {{ v.name }}
           </button>
 
+          <InputCheckbox
+            v-if="!v.groups.length"
+            label="Include side"
+            :value="v.id"
+            v-model="form.emptySideIds"
+          />
           <InputCheckbox
             v-for="g in v.groups"
             :label="state.sideGroupMap[g].name"
@@ -214,8 +257,16 @@ function toggleSide(sideId: string) {
         This scenario has no layers.
       </p>
     </InputGroupTemplate>
-    <InputGroup label="Scenario name" v-model="form.scenarioName" />
-    <InputGroup label="Name of downloaded file" v-model="form.fileName" />
+    <InputGroup
+      label="Scenario name"
+      v-model="form.scenarioName"
+      @update:model-value="automaticScenarioName = false"
+    />
+    <InputGroup
+      label="Name of downloaded file"
+      v-model="form.fileName"
+      @update:model-value="automaticFileName = false"
+    />
     <section class="space-y-3 rounded-md border p-4" aria-label="Recipient preview">
       <Button
         type="button"
@@ -236,9 +287,10 @@ function toggleSide(sideId: string) {
             JSON.stringify(preview, null, 2)
           }}</pre>
         </details>
-        <h4 class="font-medium">Included groups</h4>
-        <p v-if="!preview.sides.length" class="text-sm">No groups included.</p>
+        <h4 class="font-medium">Included sides and groups</h4>
+        <p v-if="!preview.sides.length" class="text-sm">No sides or groups included.</p>
         <template v-for="side in preview.sides" :key="side.id">
+          <p v-if="!side.groups.length" class="text-sm">{{ side.name }} — no groups</p>
           <details v-for="group in side.groups" :key="group.id">
             <summary class="cursor-pointer">
               {{ side.name }} / {{ group.name }} — {{ countUnits(group.subUnits) }} units

--- a/src/components/ExportSettingsOrbatMapper.vue
+++ b/src/components/ExportSettingsOrbatMapper.vue
@@ -1,15 +1,22 @@
 <script setup lang="ts">
 import { type OrbatMapperExportSettings } from "@/types/importExport.ts";
-import { computed } from "vue";
+import { computed, ref } from "vue";
+import { useLocalStorage } from "@vueuse/core";
+import { Button } from "@/components/ui/button";
+import { nanoid } from "@/utils";
+import { buildRecipientScenario } from "@/importexport/export/recipientScenario";
+import type { Unit } from "@/types/scenarioModels";
 import { injectStrict } from "@/utils";
 import { activeScenarioKey } from "@/components/injects";
 import InputCheckbox from "@/components/InputCheckbox.vue";
 import InputGroupTemplate from "@/components/InputGroupTemplate.vue";
+import FieldSelect from "@/components/FieldSelect.vue";
 import InputGroup from "@/components/InputGroup.vue";
 
 const form = defineModel<OrbatMapperExportSettings>({ required: true });
 
 const {
+  io,
   store: { state },
 } = injectStrict(activeScenarioKey);
 
@@ -26,6 +33,81 @@ const layers = computed(() => {
   return state.layerStack.map((id) => state.layerStackMap[id]).filter(Boolean);
 });
 
+interface ExportPreset {
+  id: string;
+  name: string;
+  sideGroups: string[];
+  layerIds: NonNullable<OrbatMapperExportSettings["layerIds"]>;
+  scenarioName?: string;
+  fileName: string;
+}
+const presets = useLocalStorage<ExportPreset[]>(
+  computed(() => `orbatmapper:export-presets:${state.id}`),
+  [],
+);
+const presetItems = computed(() => [
+  { label: "Custom selection", value: "custom" },
+  ...presets.value.map((preset) => ({ label: preset.name, value: preset.id })),
+]);
+const selectedPreset = ref("custom");
+const hasSelectedPreset = computed(() =>
+  presets.value.some((preset) => preset.id === selectedPreset.value),
+);
+const presetName = ref("");
+const notice = ref("");
+function savePreset(replace = false) {
+  if (!presetName.value.trim()) return;
+  const preset: ExportPreset = {
+    id: replace ? selectedPreset.value : nanoid(),
+    name: presetName.value.trim(),
+    sideGroups: [...form.value.sideGroups],
+    layerIds: [...(form.value.layerIds ?? state.layerStack)],
+    scenarioName: form.value.scenarioName,
+    fileName: form.value.fileName,
+  };
+  presets.value = [...presets.value.filter((p) => p.id !== preset.id), preset];
+  selectedPreset.value = preset.id;
+  notice.value = `Saved ${preset.name}.`;
+}
+function loadPreset() {
+  const preset = presets.value.find((p) => p.id === selectedPreset.value);
+  if (!preset) return;
+  const groups = preset.sideGroups.filter((id) => state.sideGroupMap[id]);
+  const layers = preset.layerIds.filter((id) => state.layerStackMap[id]);
+  form.value = {
+    ...form.value,
+    sideGroups: groups,
+    layerIds: layers,
+    scenarioName: preset.scenarioName,
+    fileName: preset.fileName,
+  };
+  presetName.value = preset.name;
+  notice.value =
+    groups.length !== preset.sideGroups.length || layers.length !== preset.layerIds.length
+      ? "Some saved groups or layers no longer exist and were omitted. Review the selection."
+      : `Loaded ${preset.name}.`;
+}
+function deletePreset() {
+  presets.value = presets.value.filter((p) => p.id !== selectedPreset.value);
+  selectedPreset.value = "custom";
+  notice.value = "Preset deleted. Current export selections are unchanged.";
+}
+const showPreview = ref(false);
+const preview = computed(() =>
+  showPreview.value ? buildRecipientScenario(io.toObject(), form.value) : undefined,
+);
+const scenarioData = computed(() => {
+  if (!preview.value) return {};
+  return Object.fromEntries(
+    Object.entries(preview.value).filter(
+      ([key]) => !["sides", "layerStack"].includes(key),
+    ),
+  );
+});
+function countUnits(units: Unit[]): number {
+  return units.reduce((total, unit) => total + 1 + countUnits(unit.subUnits ?? []), 0);
+}
+
 function toggleSide(sideId: string) {
   const groups = state.sideMap[sideId].groups;
   if (form.value.sideGroups.some((g) => groups.includes(g))) {
@@ -41,6 +123,57 @@ function toggleSide(sideId: string) {
     <p>Export partial scenario</p>
   </section>
   <fieldset class="flex flex-col gap-4">
+    <details aria-label="Export presets">
+      <summary class="text-muted-foreground cursor-pointer text-sm">
+        Export presets<span v-if="hasSelectedPreset">
+          · {{ presets.find((preset) => preset.id === selectedPreset)?.name }}</span
+        >
+      </summary>
+      <div class="mt-3 flex max-w-lg flex-col gap-3">
+        <FieldSelect
+          label="Saved preset"
+          v-model="selectedPreset"
+          :items="presetItems"
+          @update:model-value="loadPreset"
+        />
+        <InputGroup
+          label="Preset name"
+          v-model="presetName"
+          placeholder="Blue contacts update"
+        />
+        <div class="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            :disabled="!presetName.trim()"
+            @click="savePreset()"
+            >Save as new preset</Button
+          >
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            :disabled="!hasSelectedPreset || !presetName.trim()"
+            @click="savePreset(true)"
+            >Update preset</Button
+          >
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            :disabled="!hasSelectedPreset"
+            @click="deletePreset"
+            >Delete preset</Button
+          >
+        </div>
+        <p class="text-muted-foreground text-sm">
+          Presets are saved in this browser for this scenario. New groups and layers must
+          be selected explicitly.
+        </p>
+        <p role="status" class="text-sm">{{ notice }}</p>
+      </div>
+    </details>
     <InputGroupTemplate label="Select which side groups you want to export">
       <div class="divide-y">
         <div v-for="v in sides" :key="v.id" class="grid grid-cols-4 gap-4 py-3">
@@ -83,5 +216,62 @@ function toggleSide(sideId: string) {
     </InputGroupTemplate>
     <InputGroup label="Scenario name" v-model="form.scenarioName" />
     <InputGroup label="Name of downloaded file" v-model="form.fileName" />
+    <section class="space-y-3 rounded-md border p-4" aria-label="Recipient preview">
+      <Button
+        type="button"
+        variant="outline"
+        :aria-expanded="showPreview"
+        @click="showPreview = !showPreview"
+        >{{ showPreview ? "Hide recipient preview" : "Preview recipient data" }}</Button
+      >
+      <template v-if="preview">
+        <h3 class="font-semibold">{{ preview.name }}</h3>
+        <p class="text-sm">
+          This is the data included in the downloaded file, including hidden items and
+          stored histories. Map visibility does not remove data from the export.
+        </p>
+        <details>
+          <summary class="cursor-pointer">Inspect complete recipient data</summary>
+          <pre class="max-h-96 overflow-auto text-xs break-all whitespace-pre-wrap">{{
+            JSON.stringify(preview, null, 2)
+          }}</pre>
+        </details>
+        <h4 class="font-medium">Included groups</h4>
+        <p v-if="!preview.sides.length" class="text-sm">No groups included.</p>
+        <template v-for="side in preview.sides" :key="side.id">
+          <details v-for="group in side.groups" :key="group.id">
+            <summary class="cursor-pointer">
+              {{ side.name }} / {{ group.name }} — {{ countUnits(group.subUnits) }} units
+            </summary>
+            <pre class="max-h-72 overflow-auto text-xs break-all whitespace-pre-wrap">{{
+              JSON.stringify(group, null, 2)
+            }}</pre>
+          </details>
+        </template>
+        <h4 class="font-medium">Included layers</h4>
+        <p v-if="!preview.layerStack.length" class="text-sm">No layers included.</p>
+        <details v-for="layer in preview.layerStack" :key="layer.id">
+          <summary class="cursor-pointer">{{ layer.name }} ({{ layer.kind }})</summary>
+          <pre class="max-h-72 overflow-auto text-xs break-all whitespace-pre-wrap">{{
+            JSON.stringify(layer, null, 2)
+          }}</pre>
+        </details>
+        <h4 class="font-medium">Scenario-wide data</h4>
+        <p class="text-sm">
+          Descriptions, events, templates, catalogs and settings are retained regardless
+          of group and layer selection. Inspect these for information the recipient should
+          not receive.
+        </p>
+        <details v-for="(value, key) in scenarioData" :key="key">
+          <summary class="cursor-pointer">{{ key }}</summary>
+          <pre class="max-h-72 overflow-auto text-xs break-all whitespace-pre-wrap">{{
+            JSON.stringify(value, null, 2)
+          }}</pre>
+        </details>
+        <p class="text-muted-foreground text-sm">
+          The download receives a new scenario ID and export timestamp.
+        </p>
+      </template>
+    </section>
   </fieldset>
 </template>

--- a/src/importexport/export/exportNames.test.ts
+++ b/src/importexport/export/exportNames.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { suggestExportNames } from "./exportNames";
+
+const sides = [
+  { id: "blue", name: "Blue", groups: ["b1", "b2"] },
+  { id: "red", name: "Red", groups: ["r1"] },
+];
+
+describe("export name suggestions", () => {
+  it.each([
+    [["b1"], ["map"], "Northern Exercise — Blue", "northern-exercise-blue.json"],
+    [["r1"], [], "Northern Exercise — Red", "northern-exercise-red.json"],
+    [
+      ["b1", "r1"],
+      [],
+      "Northern Exercise — Blue + Red",
+      "northern-exercise-blue-red.json",
+    ],
+    [[], ["map"], "Northern Exercise — Layers", "northern-exercise-layers.json"],
+    [["b1", "b2", "r1"], ["map"], "Northern Exercise", "northern-exercise.json"],
+    [[], [], "Northern Exercise — Export", "northern-exercise-export.json"],
+  ])("names selection %j / %j", (sideGroups, layerIds, scenarioName, fileName) => {
+    expect(
+      suggestExportNames("Northern Exercise", sides, ["map"], {
+        sideGroups,
+        layerIds,
+        fileName: "",
+        customColors: true,
+      }),
+    ).toEqual({ scenarioName, fileName });
+  });
+
+  it("includes selected sides without groups and keeps Unicode filenames", () => {
+    expect(
+      suggestExportNames(
+        "Øvelse / 2026",
+        [{ id: "blue", name: "Blue", groups: [] }],
+        ["map"],
+        {
+          sideGroups: [],
+          emptySideIds: ["blue"],
+          layerIds: [],
+          fileName: "",
+          customColors: true,
+        },
+      ).fileName,
+    ).toBe("øvelse-2026-blue.json");
+  });
+});

--- a/src/importexport/export/exportNames.ts
+++ b/src/importexport/export/exportNames.ts
@@ -1,0 +1,40 @@
+import type { OrbatMapperExportSettings } from "@/types/importExport";
+
+/** Derive recipient names from the selected content, in scenario side order. */
+export function suggestExportNames(
+  sourceName: string,
+  sides: { id: string; name: string; groups: string[] }[],
+  layerIds: NonNullable<OrbatMapperExportSettings["layerIds"]>,
+  settings: OrbatMapperExportSettings,
+) {
+  const selectedSides = sides.filter((side) =>
+    side.groups.length
+      ? side.groups.some((id) => settings.sideGroups.includes(id))
+      : settings.emptySideIds?.includes(side.id),
+  );
+  const allContent =
+    sides.every((side) =>
+      side.groups.length
+        ? side.groups.every((id) => settings.sideGroups.includes(id))
+        : settings.emptySideIds?.includes(side.id),
+    ) &&
+    layerIds.every(
+      (id) => settings.layerIds === undefined || settings.layerIds.includes(id),
+    );
+  const suffix = allContent
+    ? ""
+    : selectedSides.length
+      ? selectedSides.map((side) => side.name).join(" + ")
+      : layerIds.some(
+            (id) => settings.layerIds === undefined || settings.layerIds.includes(id),
+          )
+        ? "Layers"
+        : "Export";
+  const scenarioName = suffix ? `${sourceName} — ${suffix}` : sourceName;
+  const slug = scenarioName
+    .normalize("NFKC")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, "-")
+    .replace(/^-+|-+$/g, "");
+  return { scenarioName, fileName: `${slug || "scenario"}.json` };
+}

--- a/src/importexport/export/partialScenarioControlMeasures.test.ts
+++ b/src/importexport/export/partialScenarioControlMeasures.test.ts
@@ -13,8 +13,7 @@ vi.mock("@/importexport/export/kmlExport", () => ({
 }));
 
 describe("partial ORBAT Mapper export", () => {
-  function exporter() {
-    const source = loadControlMeasureScenarioFixture();
+  function exporter(source = loadControlMeasureScenarioFixture()) {
     const activeScenario = {
       io: { toObject: () => source },
       store: { state: { sideMap: {} } },
@@ -24,6 +23,33 @@ describe("partial ORBAT Mapper export", () => {
     } as unknown as TScenario;
     return useScenarioExport({ activeScenario });
   }
+
+  it("exports explicitly selected empty sides without including unselected sides", () => {
+    const source = loadControlMeasureScenarioFixture();
+    const emptySide = {
+      standardIdentity: "3" as const,
+      id: "empty",
+      name: "Empty side",
+      groups: [],
+    };
+    source.sides.push(emptySide);
+    const settings = {
+      sideGroups: [],
+      emptySideIds: ["empty"],
+      layerIds: [],
+      customColors: true,
+      fileName: "empty.json",
+    };
+    expect(buildRecipientScenario(source, settings).sides).toEqual([emptySide]);
+    expect(JSON.parse(exporter(source).generateOrbatMapper(settings)).sides).toEqual([
+      emptySide,
+    ]);
+    source.sides.push({ ...emptySide, id: "unselected" });
+    expect(buildRecipientScenario(source, settings).sides).toEqual([emptySide]);
+    expect(
+      buildRecipientScenario(source, { ...settings, emptySideIds: [] }).sides,
+    ).toEqual([]);
+  });
 
   it("previews the downloaded content, including scenario-wide data", () => {
     const settings = {

--- a/src/importexport/export/partialScenarioControlMeasures.test.ts
+++ b/src/importexport/export/partialScenarioControlMeasures.test.ts
@@ -1,3 +1,4 @@
+import { buildRecipientScenario } from "./recipientScenario";
 import { describe, expect, it, vi } from "vitest";
 import { useScenarioExport } from "@/importexport/export/scenarioExport";
 import { loadControlMeasureScenarioFixture } from "@/testdata/controlMeasureScenario";
@@ -23,6 +24,26 @@ describe("partial ORBAT Mapper export", () => {
     } as unknown as TScenario;
     return useScenarioExport({ activeScenario });
   }
+
+  it("previews the downloaded content, including scenario-wide data", () => {
+    const settings = {
+      sideGroups: [],
+      layerIds: ["layer-control-measures"],
+      scenarioName: "Blue update",
+      customColors: true,
+      fileName: "blue.json",
+    };
+    const source = loadControlMeasureScenarioFixture();
+    const preview = buildRecipientScenario(source, settings);
+    const downloaded = JSON.parse(exporter().generateOrbatMapper(settings));
+    const { id: previewId, meta: previewMeta, ...previewContent } = preview;
+    const { id: downloadId, meta: downloadMeta, ...downloadContent } = downloaded;
+    expect(downloadContent).toEqual(JSON.parse(JSON.stringify(previewContent)));
+    expect(downloadId).not.toBe(previewId);
+    expect(downloadMeta).toMatchObject({ ...previewMeta, exportedFrom: previewId });
+    expect(preview.events).toEqual(source.events);
+    expect(source.layerStack.length).toBeGreaterThan(preview.layerStack.length);
+  });
 
   it("retains control-measure layers and their complete parameter bags", () => {
     const exported = JSON.parse(

--- a/src/importexport/export/recipientScenario.ts
+++ b/src/importexport/export/recipientScenario.ts
@@ -4,17 +4,24 @@ import type { OrbatMapperExportSettings } from "@/types/importExport";
 /** Shared by the preview and download so both include exactly the same content. */
 export function buildRecipientScenario(
   scenario: Scenario,
-  settings: Pick<OrbatMapperExportSettings, "sideGroups" | "layerIds" | "scenarioName">,
+  settings: Pick<
+    OrbatMapperExportSettings,
+    "sideGroups" | "emptySideIds" | "layerIds" | "scenarioName"
+  >,
 ): Scenario {
   return {
     ...scenario,
     name: settings.scenarioName || scenario.name,
     sides: scenario.sides
+      .filter((side) =>
+        side.groups.length
+          ? side.groups.some((group) => settings.sideGroups.includes(group.id))
+          : settings.emptySideIds?.includes(side.id),
+      )
       .map((side) => ({
         ...side,
         groups: side.groups.filter((group) => settings.sideGroups.includes(group.id)),
-      }))
-      .filter((side) => side.groups.length),
+      })),
     layerStack:
       settings.layerIds === undefined
         ? scenario.layerStack

--- a/src/importexport/export/recipientScenario.ts
+++ b/src/importexport/export/recipientScenario.ts
@@ -1,0 +1,23 @@
+import type { Scenario } from "@/types/scenarioModels";
+import type { OrbatMapperExportSettings } from "@/types/importExport";
+
+/** Shared by the preview and download so both include exactly the same content. */
+export function buildRecipientScenario(
+  scenario: Scenario,
+  settings: Pick<OrbatMapperExportSettings, "sideGroups" | "layerIds" | "scenarioName">,
+): Scenario {
+  return {
+    ...scenario,
+    name: settings.scenarioName || scenario.name,
+    sides: scenario.sides
+      .map((side) => ({
+        ...side,
+        groups: side.groups.filter((group) => settings.sideGroups.includes(group.id)),
+      }))
+      .filter((side) => side.groups.length),
+    layerStack:
+      settings.layerIds === undefined
+        ? scenario.layerStack
+        : scenario.layerStack.filter((layer) => settings.layerIds!.includes(layer.id)),
+  };
+}

--- a/src/importexport/export/scenarioExport.ts
+++ b/src/importexport/export/scenarioExport.ts
@@ -1,3 +1,4 @@
+import { buildRecipientScenario } from "./recipientScenario";
 import { featureCollection } from "@turf/helpers";
 import { injectStrict, nanoid } from "@/utils";
 import { activeScenarioKey } from "@/components/injects";
@@ -265,20 +266,11 @@ export function useScenarioExport(options: Partial<UseScenarioExportOptions> = {
     layerIds,
   }: OrbatMapperExportSettings): string {
     const scn = io.toObject();
-    const sidesWithFilteredGroups = scn.sides.map((side) => ({
-      ...side,
-      groups: side.groups.filter((g) => sideGroups.includes(g.id)),
-    }));
-    const newScenario = {
-      ...scn,
-      sides: sidesWithFilteredGroups.filter((e) => e.groups.length),
-      // Undefined is intentional backward compatibility for callers and saved form
-      // settings created before layer selection existed. An explicit [] exports none.
-      layerStack:
-        layerIds === undefined
-          ? scn.layerStack
-          : scn.layerStack.filter((layer) => layerIds.includes(layer.id)),
-    };
+    const newScenario = buildRecipientScenario(scn, {
+      scenarioName,
+      sideGroups,
+      layerIds,
+    });
     newScenario.id = nanoid();
     newScenario.meta = {
       ...scn.meta!,

--- a/src/importexport/export/scenarioExport.ts
+++ b/src/importexport/export/scenarioExport.ts
@@ -260,24 +260,15 @@ export function useScenarioExport(options: Partial<UseScenarioExportOptions> = {
     );
   }
 
-  function generateOrbatMapper({
-    scenarioName,
-    sideGroups,
-    layerIds,
-  }: OrbatMapperExportSettings): string {
+  function generateOrbatMapper(settings: OrbatMapperExportSettings): string {
     const scn = io.toObject();
-    const newScenario = buildRecipientScenario(scn, {
-      scenarioName,
-      sideGroups,
-      layerIds,
-    });
+    const newScenario = buildRecipientScenario(scn, settings);
     newScenario.id = nanoid();
     newScenario.meta = {
       ...scn.meta!,
       exportedFrom: scn.id,
       exportedDate: new Date().toISOString(),
     };
-    if (scenarioName) newScenario.name = scenarioName;
     return JSON.stringify(newScenario, undefined, 2);
   }
 

--- a/src/scenariostore/unitManipulations.test.ts
+++ b/src/scenariostore/unitManipulations.test.ts
@@ -930,3 +930,59 @@ describe("expandUnitWithSymbolOptions", () => {
     ]);
   });
 });
+
+describe("cloneSide without groups", () => {
+  it.each([false, true])(
+    "duplicates a completely empty side with includeState=%s",
+    (includeState) => {
+      const scenario = createScenario();
+      scenario.sides[0].groups = [];
+      const store = useNewScenarioStore(scenario);
+      const id = useUnitManipulations(store).cloneSide("side-1", { includeState })!;
+      expect(store.state.sideMap[id]).toMatchObject({
+        name: "Blue (copy)",
+        groups: [],
+        subUnits: [],
+      });
+      expect(store.state.sides).toContain(id);
+    },
+  );
+
+  it.each([false, true])(
+    "duplicates direct units with includeState=%s",
+    (includeState) => {
+      const scenario = createScenario();
+      const side = scenario.sides[0];
+      const unit = side.groups[0].subUnits[0];
+      unit.state = [{ id: "move", t: "2025-01-01T01:00:00Z", location: [11, 61] }];
+      unit.subUnits = [
+        { id: "child", name: "Child", sidc: unit.sidc, subUnits: [], state: unit.state },
+      ];
+      side.subUnits = [unit];
+      side.groups = [];
+      const store = useNewScenarioStore(scenario);
+      const actions = useUnitManipulations(store);
+      const id = actions.cloneSide(side.id, { includeState })!;
+      const copy = store.state.sideMap[id];
+      expect(copy.name).toBe("Blue (copy)");
+      expect(copy.groups).toEqual([]);
+      expect(copy.subUnits).toHaveLength(1);
+      const root = store.state.unitMap[copy.subUnits[0]!];
+      expect(root.id).not.toBe(unit.id);
+      expect(root._pid).toBe(id);
+      expect(root.name).toBe(unit.name);
+      expect(root.state).toHaveLength(includeState ? 1 : 0);
+      const child = store.state.unitMap[root.subUnits[0]!];
+      expect(child.id).not.toBe("child");
+      expect(child._pid).toBe(root.id);
+      expect(child._sid).toBe(id);
+      expect(child.state).toHaveLength(includeState ? 1 : 0);
+      expect(store.state.sideMap[side.id].subUnits).toEqual([unit.id]);
+      store.undo();
+      expect(store.state.sideMap[id]).toBeUndefined();
+      expect(Object.keys(store.state.unitMap)).toHaveLength(2);
+      store.redo();
+      expect(store.state.sideMap[id].subUnits).toHaveLength(1);
+    },
+  );
+});

--- a/src/scenariostore/unitManipulations.ts
+++ b/src/scenariostore/unitManipulations.ts
@@ -1020,6 +1020,15 @@ export function useUnitManipulations(store: NewScenarioStore) {
     let newSideId: EntityId | undefined;
     groupUpdate(() => {
       newSideId = addSide(newSide, { markAsNew: false, addDefaultGroup: false });
+      [...getBaseSubUnits(side)].forEach((unitId) => {
+        const newUnitId = cloneUnit(unitId, {
+          target: "end",
+          includeSubordinates: true,
+          includeState,
+          modifyName: false,
+        });
+        newUnitId && newSideId && changeUnitParent(newUnitId, newSideId);
+      });
       side.groups.forEach((groupId) => {
         const newGroupId = cloneSideGroup(groupId, { includeState, modifyName: false });
         newGroupId && newSideId && changeSideGroupParent(newGroupId, newSideId, "on");

--- a/src/types/importExport.ts
+++ b/src/types/importExport.ts
@@ -74,6 +74,8 @@ export interface GeoJsonSettings extends BaseExportSettings {
 
 export interface OrbatMapperExportSettings extends BaseExportSettings {
   sideGroups: EntityId[];
+  /** Explicitly selected sides that have no groups. */
+  emptySideIds?: EntityId[];
   /** Undefined preserves the legacy behavior of exporting every layer. */
   layerIds?: FeatureId[];
   scenarioName?: string;

--- a/user-docs/guide/export-data.md
+++ b/user-docs/guide/export-data.md
@@ -18,13 +18,18 @@ To start the export, select _Export scenario_ from the _File_ menu.
 ## ORBAT Mapper
 
 Choose **ORBAT Mapper** to export selected side groups and layers as a scenario file.
-Set the scenario name and downloaded filename before exporting.
+For a side without groups, select **Include side** to include it in the file.
+The scenario name and filename are suggested from the source name and selected sides
+(for example, **Northern Exercise — Blue** and `northern-exercise-blue.json`).
+Layers-only exports use a **Layers** suffix; exporting all content keeps the source name.
+Suggestions update with your selections until you edit the corresponding field.
+Names loaded from a preset are preserved. You can add a turn label manually, such as **Turn 3**.
 
 ### Reuse an export preset
 
 Select the groups and layers for a recipient, expand **Export presets**, and enter a **Preset name** (for example,
 “Blue contacts update”), and click **Save as new preset**. A preset remembers the
-selected groups and layers, scenario name, and filename.
+selected groups, empty sides and layers, scenario name, and filename.
 
 Choose a **Saved preset** to restore its settings. After making changes, click
 **Update preset** to save them, or **Save as new preset** to keep another variation.

--- a/user-docs/guide/export-data.md
+++ b/user-docs/guide/export-data.md
@@ -2,6 +2,7 @@
 
 ORBAT Mapper can export units and features to these data formats:
 
+- [ORBAT Mapper](#orbat-mapper)
 - [GeoJSON](#geojson)
 - [KML/KMZ](#kml)
 - [MilX](#milx)
@@ -13,6 +14,39 @@ ORBAT Mapper can export units and features to these data formats:
 To start the export, select _Export scenario_ from the _File_ menu.
 
 ![Export menu](images/export.png)
+
+## ORBAT Mapper
+
+Choose **ORBAT Mapper** to export selected side groups and layers as a scenario file.
+Set the scenario name and downloaded filename before exporting.
+
+### Reuse an export preset
+
+Select the groups and layers for a recipient, expand **Export presets**, and enter a **Preset name** (for example,
+“Blue contacts update”), and click **Save as new preset**. A preset remembers the
+selected groups and layers, scenario name, and filename.
+
+Choose a **Saved preset** to restore its settings. After making changes, click
+**Update preset** to save them, or **Save as new preset** to keep another variation.
+**Delete preset** removes the saved preset without changing the current selection.
+
+Presets are stored in this browser for the current scenario; they are not included
+in downloaded scenario files. New groups and layers are not automatically added.
+If a saved group or layer has been deleted, loading the preset omits it and displays
+a notice. Review the selection before exporting.
+
+### Preview recipient data
+
+Click **Preview recipient data** to inspect included groups, unit counts, layers,
+and scenario-wide data. Expand entries to inspect their stored contents, or expand
+**Inspect complete recipient data** to see everything together. The preview updates
+when you change your selections.
+
+Hidden units and layers are still included when their group or layer is selected.
+Descriptions, events, templates, catalogs, settings, and stored unit histories may
+also contain information you do not intend to share. Group and layer selection does
+not remove scenario-wide data. Review these contents before distributing a file.
+The downloaded file receives a new scenario ID and export timestamp.
 
 ## GeoJSON
 


### PR DESCRIPTION
## Summary

- Add browser-local export presets scoped to each scenario.
- Support saving, updating, loading, and deleting selected groups, layers, and export metadata.
- Add a recipient preview showing included groups, layers, unit counts, and scenario-wide data.
- Share recipient filtering logic between preview and ORBAT Mapper downloads.
- Document preset usage and export data-sharing considerations.
- Add coverage for preset lifecycle, missing content, preview output, and download parity.

## Testing

- Added and updated Vitest component and export tests covering presets, preview behavior, missing selections, and generated download content.